### PR TITLE
Fix whitespace for vendored targets

### DIFF
--- a/src/templates/crate.BUILD.template
+++ b/src/templates/crate.BUILD.template
@@ -13,7 +13,7 @@ load(
     "rust_bench_test",
 )
 
-{%- set crate_name_sanitized = crate.pkg_name | replace(from="-", to="_") %}
+{% set crate_name_sanitized = crate.pkg_name | replace(from="-", to="_") %}
 {%- if crate.build_script_target %}
 {%- include "templates/partials/build_script.template" %}
 {%- endif %}


### PR DESCRIPTION
Fixes https://github.com/acmcarther/cargo-raze/issues/30#issuecomment-365379349

Demoed in https://github.com/acmcarther/cargo-raze-examples/compare/demo-acm-fix-whitespace , which I'll push after pushing this change to Cargo.