### PR TITLE
Update genfile location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-raze"
-version = "0.0.14"
+version = "0.0.16"
 dependencies = [
  "cargo 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hamcrest 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ $ cargo raze
 ```
 
 You can now depend on any *explicit* dependencies in any Rust rule by depending on
-`//cargo/vendor:your_dependency_name`.
+`//cargo:your_dependency_name`.
 
 ### Remote Dependency Mode
 
@@ -153,7 +153,7 @@ This tells Bazel where to get the dependencies from, and how to build them:
 using the files generated into //cargo.
 
 You can depend on any *explicit* dependencies in any Rust rule by depending on
-`//cargo:your_dependency_name`. Mind the lack of "vendor/" directory.
+`//cargo:your_dependency_name`.
 
 ### Handling Unconventional Crates
 
@@ -328,9 +328,9 @@ https://github.com/acmcarther/cargo-raze-crater
 
 See these examples of providing crate configuration:
 
-- [basic-example](https://github.com/acmcarther/cargo-raze-examples/blob/master/bazel/hello_cargo_library/Cargo.toml)
-- [complicated-example](https://github.com/acmcarther/cargo-raze-examples/blob/master/bazel/complicated_cargo_library/Cargo.toml)
-- [complicated-example-remote](https://github.com/acmcarther/cargo-raze-examples/blob/master/bazel/complicated_cargo_library_remote/Cargo.toml)
+- [basic-example](https://github.com/acmcarther/cargo-raze-examples/blob/master/bazel/hello_cargo_library/cargo/Cargo.toml)
+- [complicated-example](https://github.com/acmcarther/cargo-raze-examples/blob/master/bazel/complicated_cargo_library/cargo/Cargo.toml)
+- [complicated-example-remote](https://github.com/acmcarther/cargo-raze-examples/blob/master/bazel/complicated_cargo_library_remote/cargo/Cargo.toml)
 - [openssl-example](https://github.com/acmcarther/compile_openssl/blob/master/cargo/Cargo.toml)
 
 The [raze] section is derived from a struct declared in [src/settings.rs](./src/settings.rs).

--- a/src/bazel.rs
+++ b/src/bazel.rs
@@ -321,10 +321,11 @@ mod tests {
     }
   }
 
-  fn extract_contents_matching_path(file_outputs: &Vec<FileOutputs>, crate_name: &str) -> String {
+  fn extract_contents_matching_path(file_outputs: &Vec<FileOutputs>, file_name: &str) -> String {
+    println!("Known files :{:?}", file_outputs);
     let mut matching_files_contents = file_outputs
       .iter()
-      .filter(|output| output.path.contains(crate_name))
+      .filter(|output| output.path.starts_with(file_name))
       .map(|output| output.contents.to_owned())
       .collect::<Vec<String>>();
 
@@ -343,7 +344,7 @@ mod tests {
     let file_outputs = render_crates_for_test(Vec::new());
     let file_names = file_outputs.iter().map(|output| output.path.as_ref()).collect::<Vec<&str>>();
 
-    assert_that!(&file_names, contains(vec!["./some_render_prefix/vendor/BUILD"]).exactly());
+    assert_that!(&file_names, contains(vec!["./some_render_prefix/BUILD"]).exactly());
   }
 
   #[test]
@@ -354,8 +355,8 @@ mod tests {
     assert_that!(
       &file_names,
       contains(vec![
-        "./some_render_prefix/vendor/BUILD",
         "./some_render_prefix/vendor/test-library-1.1.1/BUILD",
+        "./some_render_prefix/BUILD",
       ]).exactly()
     );
   }
@@ -363,7 +364,8 @@ mod tests {
   #[test]
   fn root_crates_get_build_aliases() {
     let file_outputs = render_crates_for_test(vec![dummy_library_crate()]);
-    let root_build_contents = extract_contents_matching_path(&file_outputs, "vendor/BUILD");
+    let root_build_contents =
+      extract_contents_matching_path(&file_outputs, "./some_render_prefix/BUILD");
 
     expect(
       root_build_contents.contains("alias"),
@@ -381,7 +383,8 @@ mod tests {
     non_root_crate.is_root_dependency = false;
 
     let file_outputs = render_crates_for_test(vec![non_root_crate]);
-    let root_build_contents = extract_contents_matching_path(&file_outputs, "vendor/BUILD");
+    let root_build_contents =
+      extract_contents_matching_path(&file_outputs, "./some_render_prefix/BUILD");
 
     expect(
       !root_build_contents.contains("alias"),
@@ -396,8 +399,10 @@ mod tests {
   #[test]
   fn binaries_get_rust_binary_rules() {
     let file_outputs = render_crates_for_test(vec![dummy_binary_crate()]);
-    let crate_build_contents =
-      extract_contents_matching_path(&file_outputs, "vendor/test-binary-1.1.1/BUILD");
+    let crate_build_contents = extract_contents_matching_path(
+      &file_outputs,
+      "./some_render_prefix/vendor/test-binary-1.1.1/BUILD",
+    );
 
     expect(
       crate_build_contents.contains("rust_binary("),
@@ -411,8 +416,10 @@ mod tests {
   #[test]
   fn libraries_get_rust_library_rules() {
     let file_outputs = render_crates_for_test(vec![dummy_library_crate()]);
-    let crate_build_contents =
-      extract_contents_matching_path(&file_outputs, "vendor/test-library-1.1.1/BUILD");
+    let crate_build_contents = extract_contents_matching_path(
+      &file_outputs,
+      "./some_render_prefix/vendor/test-library-1.1.1/BUILD",
+    );
 
     expect(
       crate_build_contents.contains("rust_library("),

--- a/src/bazel.rs
+++ b/src/bazel.rs
@@ -20,7 +20,6 @@ use planning::PlannedBuild;
 use rendering::BuildRenderer;
 use rendering::FileOutputs;
 use rendering::RenderDetails;
-use std::fs;
 use tera;
 use tera::Context;
 use tera::Tera;
@@ -196,10 +195,11 @@ impl BuildRenderer for BazelRenderer {
     } = planned_build;
     let mut file_outputs = Vec::new();
 
-    // Create "remote/" if it doesn't exist
-    if fs::metadata("remote/").is_err() {
-      try!(fs::create_dir("remote/").map_err(|e| CargoError::from(e.to_string())));
-    }
+    // N.B. File needs to exist so that contained xyz-1.2.3.BUILD can be referenced
+    file_outputs.push(FileOutputs {
+      path: "remote/BUILD".to_owned(),
+      contents: String::new(),
+    });
 
     for package in crate_contexts {
       let build_file_path = format!("remote/{}-{}.BUILD", &package.pkg_name, &package.pkg_version);

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ use rendering::RenderDetails;
 use settings::GenMode;
 use settings::RazeSettings;
 use std::env;
+use std::fs;
 use std::fs::File;
 use std::io::Read;
 use std::io::Write;
@@ -114,6 +115,11 @@ fn real_main(options: Options, cargo_config: &Config) -> CliResult {
   let bazel_file_outputs = match settings.genmode {
     GenMode::Vendored => try!(bazel_renderer.render_planned_build(&render_details, &planned_build)),
     GenMode::Remote => {
+      // Create "remote/" if it doesn't exist
+      if fs::metadata("remote/").is_err() {
+        try!(fs::create_dir("remote/").map_err(|e| CargoError::from(e.to_string())));
+      }
+
       try!(bazel_renderer.render_remote_planned_build(&render_details, &planned_build))
     },
     /* exhaustive, we control the definition */

--- a/src/templates/remote_crates.bzl.template
+++ b/src/templates/remote_crates.bzl.template
@@ -11,6 +11,6 @@ def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/{{crate.pkg_name}}/{{crate.pkg_name}}-{{crate.pkg_version}}.crate",
         type = "tar.gz",
         strip_prefix = "{{crate.pkg_name}}-{{crate.pkg_version}}",
-        build_file = "{{workspace.workspace_path}}:{{crate.pkg_name}}-{{crate.pkg_version}}.BUILD"
+        build_file = "{{workspace.workspace_path}}/remote:{{crate.pkg_name}}-{{crate.pkg_version}}.BUILD"
     )
 {% endfor %}


### PR DESCRIPTION
Two changes:

- Moved {workspace_path}/vendor/BUILD into {workspace_path}/BUILD
- Moved generated remote deps from {workspace_path}/... into {workspace_path}/remote/...

No logic changes were required for vendored deps, but I needed to change a bit for remote deps.

Generated Example: https://github.com/acmcarther/cargo-raze-examples/tree/acm-update-genfile-location-example/bazel. I'll update the repository "officially" to catch all the latest changes once this PR is submitted
