### PR TITLE
Minor code cleanup

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -28,11 +28,7 @@ impl BazelLicenseType {
   }
 }
 
-/**
- * Breaks apart a cargo license string and yields the available license types.
- *
- * User should
- */
+/** Breaks apart a cargo license string and yields the available license types. */
 pub fn get_available_licenses(cargo_license_str: &str) -> Vec<(String, BazelLicenseType)> {
   let mut available_licenses = Vec::new();
   for license_name in cargo_license_str.split('/') {

--- a/src/rendering.rs
+++ b/src/rendering.rs
@@ -15,17 +15,10 @@
 use cargo::util::CargoResult;
 use planning::PlannedBuild;
 
-#[derive(Debug, Clone)]
-pub struct FileOutputs {
-  pub path: String,
-  pub contents: String,
-}
-
-#[derive(Debug, Clone)]
-pub struct RenderDetails {
-  pub path_prefix: String,
-}
-
+/**
+ * An object that can convert a prepared build plan into a series of files for a Bazel-like build
+ * system.
+ */
 pub trait BuildRenderer {
   fn render_planned_build(
     &mut self,
@@ -37,4 +30,15 @@ pub trait BuildRenderer {
     render_details: &RenderDetails,
     planned_build: &PlannedBuild,
   ) -> CargoResult<Vec<FileOutputs>>;
+}
+
+#[derive(Debug, Clone)]
+pub struct FileOutputs {
+  pub path: String,
+  pub contents: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RenderDetails {
+  pub path_prefix: String,
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -25,11 +25,7 @@ use std::str::FromStr;
 
 /** Extracts the dependencies that are of the provided kind. */
 pub fn take_kinded_dep_names(platform_deps: &Vec<Dependency>, kind: Kind) -> HashSet<String> {
-  platform_deps
-    .iter()
-    .filter(|d| d.kind() == kind)
-    .map(|dep| dep.name().to_owned())
-    .collect()
+  platform_deps.iter().filter(|d| d.kind() == kind).map(|dep| dep.name().to_owned()).collect()
 }
 
 /**
@@ -48,18 +44,13 @@ pub fn kind_to_kinds(kind: &TargetKind) -> Vec<String> {
   }
 }
 
-/**
- * Gets the proper system attributes for the provided platform triple using rustc.
- */
+/** Gets the proper system attributes for the provided platform triple using rustc. */
 pub fn fetch_attrs(target: &str) -> CargoResult<Vec<Cfg>> {
   let args = vec![format!("--target={}", target), "--print=cfg".to_owned()];
 
-  let output = try!(Command::new("rustc").args(&args).output().map_err(|_| {
-    CargoError::from(format!(
-      "could not run rustc to fetch attrs for target {}",
-      target
-    ))
-  }));
+  let output = try!(Command::new("rustc").args(&args).output().map_err(|_| CargoError::from(
+    format!("could not run rustc to fetch attrs for target {}", target)
+  )));
 
   if !output.status.success() {
     panic!(format!(
@@ -78,9 +69,7 @@ pub fn fetch_attrs(target: &str) -> CargoResult<Vec<Cfg>> {
     attr_str
       .lines()
       .map(Cfg::from_str)
-      .map(|cfg| {
-        cfg.expect("attrs from rustc should be parsable into Cargo Cfg")
-      })
+      .map(|cfg| cfg.expect("attrs from rustc should be parsable into Cargo Cfg"))
       .collect(),
   )
 }


### PR DESCRIPTION
Somehow since the time I first wrote some of this code I've accreted more dogmatic opinions.

Some of those fixed here include:

1) Serde defaults should be of the form `default_{type}_field_{field_name}`
2) Files should be organized in the following manner:
```
// traits
// structs / enums
// impls
// bare fns
```
(I've judged that struct-struct proximity is more important than struct-impl or trait-impl proximity, since impls can live anywhere anyway).

Also it seems rustfmt found more things to fix...