### PR TITLE
Add RUSTC as env_var to buildscripts

### DIFF
--- a/src/templates/partials/build_script.template
+++ b/src/templates/partials/build_script.template
@@ -32,6 +32,7 @@ genrule(
     local = 1,
     cmd = "mkdir {{ crate_name_sanitized}}_out_dir_outputs/;"
         + " (export CARGO_MANIFEST_DIR=\"$$PWD/{{ workspace.workspace_path | replace(from="//", to="") }}/vendor/{{ crate.pkg_name }}-{{ crate.pkg_version }}\";"
+        + " export RUSTC=\"$$PWD/$(location @rust_linux_x86_64//:rustc)\";"
         + " export TARGET='{{ crate.platform_triple }}';"
         + " export RUST_BACKTRACE=1;"
         {%- for feature in crate.features %}

--- a/src/templates/partials/remote_build_script.template
+++ b/src/templates/partials/remote_build_script.template
@@ -32,6 +32,7 @@ genrule(
     local = 1,
     cmd = "mkdir {{ crate_name_sanitized}}_out_dir_outputs/;"
         + " (export CARGO_MANIFEST_DIR=\"$$PWD/$$(dirname $(location :Cargo.toml))\";"
+        + " export RUSTC=\"$$PWD/$(location @rust_linux_x86_64//:rustc)\";"
         + " export TARGET='{{ crate.platform_triple }}';"
         + " export RUST_BACKTRACE=1;"
         {%- for feature in crate.features %}


### PR DESCRIPTION
Fixes https://github.com/google/cargo-raze/issues/32

Probably will be broken in CI. Will fix.