### PR TITLE
Take two on remote Git targets

### DIFF
--- a/impl/src/bazel.rs
+++ b/impl/src/bazel.rs
@@ -309,6 +309,7 @@ mod tests {
       additional_flags: Vec::new(),
       extra_aliased_targets: Vec::new(),
       data_attr: None,
+      git_data: None,
     }
   }
 
@@ -337,6 +338,7 @@ mod tests {
       additional_flags: Vec::new(),
       extra_aliased_targets: Vec::new(),
       data_attr: None,
+      git_data: None,
     }
   }
 

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -37,6 +37,12 @@ pub struct LicenseData {
   pub rating: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub struct GitData {
+  pub remote: String,
+  pub commit: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct CrateContext {
   pub pkg_name: String,
@@ -56,6 +62,7 @@ pub struct CrateContext {
   pub additional_flags: Vec<String>,
   pub extra_aliased_targets: Vec<String>,
   pub data_attr: Option<String>,
+  pub git_data: Option<GitData>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -38,7 +38,7 @@ pub struct LicenseData {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-pub struct GitData {
+pub struct GitRepo {
   pub remote: String,
   pub commit: String,
 }
@@ -62,7 +62,7 @@ pub struct CrateContext {
   pub additional_flags: Vec<String>,
   pub extra_aliased_targets: Vec<String>,
   pub data_attr: Option<String>,
-  pub git_data: Option<GitData>,
+  pub git_data: Option<GitRepo>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]

--- a/impl/src/metadata.rs
+++ b/impl/src/metadata.rs
@@ -224,7 +224,8 @@ impl<'config> MetadataFetcher for CargoInternalsMetadataFetcher<'config> {
       for dependency in package.dependencies().iter() {
         dependencies.push(Dependency {
           name: dependency.name().to_string(),
-          source: dependency.source_id().to_string(),
+          // UNWRAP: It's cargo's responsibility to ensure a serializable source_id
+          source: serde_json::to_string(dependency.source_id()).unwrap(),
           req: dependency.version_req().to_string(),
           kind: match dependency.kind() {
             CargoKind::Normal => None,
@@ -258,6 +259,8 @@ impl<'config> MetadataFetcher for CargoInternalsMetadataFetcher<'config> {
         features.insert(feature.clone(), features_or_dependencies.clone());
       }
 
+      // UNWRAP: It's cargo's responsibility to ensure a serializable source_id
+      let pkg_source = serde_json::to_string(package_id.source_id()).unwrap();
       packages.push(Package {
         name: package.name().to_string(),
         version: package.version().to_string(),
@@ -265,7 +268,7 @@ impl<'config> MetadataFetcher for CargoInternalsMetadataFetcher<'config> {
         license: manifest_metadata.license.clone(),
         license_file: manifest_metadata.license_file.clone(),
         description: manifest_metadata.description.clone(),
-        source: Some(package_id.source_id().to_string()),
+        source: Some(pkg_source),
         dependencies: dependencies,
         targets: targets,
         features: features,

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -14,11 +14,13 @@
 
 use cargo::CargoError;
 use cargo::core::dependency::Platform;
+use cargo::core::SourceId;
 use cargo::util::CargoResult;
 use context::BuildDependency;
 use context::BuildTarget;
 use context::CrateContext;
 use context::LicenseData;
+use context::GitData;
 use context::WorkspaceContext;
 use license;
 use metadata::CargoWorkspaceFiles;
@@ -30,6 +32,7 @@ use metadata::ResolveNode;
 use settings::CrateSettings;
 use settings::GenMode;
 use settings::RazeSettings;
+use serde_json;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs;
@@ -202,6 +205,11 @@ impl<'fetcher> BuildPlannerImpl<'fetcher> {
         continue;
       }
 
+      // UNWRAP: Safe given unwrap during serialize step of metadata
+      let own_source_id = own_package.source.as_ref()
+        .map(|s| serde_json::from_str::<SourceId>(&s).unwrap());
+
+
       // Resolve dependencies into types
       let mut build_dep_names = Vec::new();
       let mut dev_dep_names = Vec::new();
@@ -255,7 +263,19 @@ impl<'fetcher> BuildPlannerImpl<'fetcher> {
       dev_deps.sort();
       normal_deps.sort();
 
-      let mut targets = try!(self.produce_targets(&own_package));
+      let is_git = own_source_id.as_ref().map_or(false, SourceId::is_git);
+      let git_data = if is_git {
+        // UNWRAP: is_git true implies own_source_id exists
+        let s = own_source_id.as_ref().unwrap();
+        Some(GitData {
+          remote: s.url().to_string(),
+          commit: s.precise().unwrap().to_owned(),
+        })
+      } else {
+        None
+      };
+
+      let mut targets = try!(self.produce_targets(&own_package, &own_source_id, settings));
       targets.sort();
 
       let possible_crate_settings = settings
@@ -328,28 +348,31 @@ impl<'fetcher> BuildPlannerImpl<'fetcher> {
         additional_flags: additional_flags,
         extra_aliased_targets: extra_aliased_targets,
         data_attr: data_attr,
+        git_data: git_data,
       })
     }
 
     Ok(crate_contexts)
   }
 
-  fn produce_targets(&self, package: &Package) -> CargoResult<Vec<BuildTarget>> {
-    let full_name = format!("{}-{}", package.name, package.version);
-    let partial_path = format!("{}/", full_name);
-    let partial_path_byte_length = partial_path.as_bytes().len();
+  fn produce_targets(&self, package: &Package, source_id: &Option<SourceId>, settings: &RazeSettings) -> CargoResult<Vec<BuildTarget>> {
     let mut targets = Vec::new();
     for target in package.targets.iter() {
       let manifest_pathbuf = PathBuf::from(&package.manifest_path);
       assert!(manifest_pathbuf.is_absolute());
 
-      let crate_path_prefix = manifest_pathbuf.parent().unwrap().display().to_string();
+      let is_git = source_id.as_ref().map_or(false, SourceId::is_git);
+      let local_root = match (settings.genmode.clone(), is_git) {
+        // UNWRAP: We know from source_id that this is a git package, so it must have a repo root
+        (GenMode::Remote, true) => package_git_root(&manifest_pathbuf).unwrap().to_str().unwrap().to_owned(),
+        _ => manifest_pathbuf.parent().unwrap().display().to_string(),
+      };
 
       // Trim the manifest_path parent dir from the target path (to give us the crate-local path)
       let mut local_path_str = target
         .src_path
         .clone()
-        .split_off(crate_path_prefix.len() + 1);
+        .split_off(local_root.len() + 1);
 
       // Some crates have a weird prefix, trim that.
       if local_path_str.starts_with("./") {
@@ -412,18 +435,29 @@ fn load_and_dedup_licenses(licenses: &str) -> Vec<LicenseData> {
   license_data_list
 }
 
+fn package_git_root(manifest: &PathBuf) -> CargoResult<PathBuf> {
+  let cloned = manifest.clone();
+  let mut check_path = cloned.as_path();
+  while let Some(c) = check_path.parent() {
+    let joined = c.join(".git");
+    if joined.is_dir() {
+      return Ok(c.to_path_buf());
+    } else {
+      check_path = c;
+    }
+  }
+
+  Err(CargoError::from(format!("Unable to locate git repository root for manifest {:?}", manifest)))
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
   use metadata::Metadata;
-  use metadata::MetadataFetcher;
   use metadata::ResolveNode;
   use metadata::testing::StubMetadataFetcher;
   use metadata::testing as metadata_testing;
   use settings::testing as settings_testing;
-  use hamcrest::core::expect;
-  use hamcrest::prelude::*;
-  use settings::RazeSettings;
 
   const ROOT_NODE_IDX: usize = 0;
 

--- a/impl/src/templates/remote_crates.bzl.template
+++ b/impl/src/templates/remote_crates.bzl.template
@@ -6,6 +6,15 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 
 def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
 {% for crate in crates %}
+    {%- if crate.git_data %}
+    native.new_git_repository(
+        name = "{{workspace.gen_workspace_prefix}}__{{crate.pkg_name | slugify | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}}",
+        remote = "{{crate.git_data.remote}}",
+        commit = "{{crate.git_data.commit}}",
+        build_file = "{{workspace.workspace_path}}/remote:{{crate.pkg_name}}-{{crate.pkg_version}}.BUILD",
+        init_submodules = True
+    )
+    {%- else %}
     native.new_http_archive(
         name = "{{workspace.gen_workspace_prefix}}__{{crate.pkg_name | slugify | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}}",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/{{crate.pkg_name}}/{{crate.pkg_name}}-{{crate.pkg_version}}.crate",
@@ -13,4 +22,5 @@ def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
         strip_prefix = "{{crate.pkg_name}}-{{crate.pkg_version}}",
         build_file = "{{workspace.workspace_path}}/remote:{{crate.pkg_name}}-{{crate.pkg_version}}.BUILD"
     )
+    {%- endif %}
 {% endfor %}


### PR DESCRIPTION
Previously the remote non-cratesio example worked because it accidentally resolved to crates.io even for "git" packages. The example was included before it was ready, and only because it relied exclusively on things already on `crates.io` did it compile in the first place.

Also takes a much lighter touch with metadata.rs - we know that we're checking out a git repository, so can guarantee that there's a `.git` folder somewhere when we walk back up the path, rather than relying on Cargo to tell us where the repo root is actually at.

---

Continues on from #31 