### PR TITLE
Add version number to imported crates

### DIFF
--- a/impl/src/templates/partials/build_script.template
+++ b/impl/src/templates/partials/build_script.template
@@ -21,6 +21,7 @@ rust_binary(
       {%- endfor %}
     ],
     data = glob(["*"]),
+    version = "{{ crate.pkg_version }}",
     visibility = ["//visibility:private"],
 )
 

--- a/impl/src/templates/partials/remote_build_script.template
+++ b/impl/src/templates/partials/remote_build_script.template
@@ -20,6 +20,7 @@ rust_binary(
       "{{feature}}",
       {%- endfor %}
     ],
+    version = "{{ crate.pkg_version }}",
     data = glob(["*"]),
     visibility = ["//visibility:private"],
 )

--- a/impl/src/templates/partials/remote_rust_binary.template
+++ b/impl/src/templates/partials/remote_rust_binary.template
@@ -28,6 +28,7 @@ rust_binary(
     {%- if crate.data_attr %}
     data = {{crate.data_attr}},
     {%- endif %}
+    version = "{{ crate.pkg_version }}",
     crate_features = [
         {%- for feature in crate.features %}
         "{{feature}}",

--- a/impl/src/templates/partials/remote_rust_library.template
+++ b/impl/src/templates/partials/remote_rust_library.template
@@ -32,6 +32,7 @@ rust_library(
     {%- if crate.data_attr %}
     data = {{crate.data_attr}},
     {%- endif %}
+    version = "{{ crate.pkg_version }}",
     crate_features = [
         {%- for feature in crate.features %}
         "{{feature}}",

--- a/impl/src/templates/partials/rust_binary.template
+++ b/impl/src/templates/partials/rust_binary.template
@@ -28,6 +28,7 @@ rust_binary(
     {%- if crate.data_attr %}
     data = {{crate.data_attr}},
     {%- endif %}
+    version = "{{ crate.pkg_version }}",
     crate_features = [
         {%- for feature in crate.features %}
         "{{feature}}",

--- a/impl/src/templates/partials/rust_library.template
+++ b/impl/src/templates/partials/rust_library.template
@@ -32,6 +32,7 @@ rust_library(
     {%- if crate.data_attr %}
     data = {{crate.data_attr}},
     {%- endif %}
+    version = "{{ crate.pkg_version }}",
     crate_features = [
         {%- for feature in crate.features %}
         "{{feature}}",

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -29,7 +29,7 @@ workspace(name = "io_bazel_rules_rust")
 
 git_repository(
     name = "io_bazel_rules_rust",
-    commit = "ee61ddff0b97cfc36278902e5210d1929ba5b119",           
+    commit = "af9821bf3378b525ec3db0af3b1ca388920a8fb0",
     remote = "https://github.com/bazelbuild/rules_rust.git",
 )
 


### PR DESCRIPTION
Now that rust_library/rust_binary supports it.