### PR TITLE
Remote: do not create http repository if it already exists.

### DIFF
--- a/impl/src/templates/remote_crates.bzl.template
+++ b/impl/src/templates/remote_crates.bzl.template
@@ -4,9 +4,13 @@ cargo-raze crate workspace functions
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+def _new_http_archive(name, **kwargs):
+    if not native.existing_rule(name):
+        native.new_http_archive(name=name, **kwargs)
+
 def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
 {% for crate in crates %}
-    native.new_http_archive(
+    _new_http_archive(
         name = "{{workspace.gen_workspace_prefix}}__{{crate.pkg_name | slugify | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}}",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/{{crate.pkg_name}}/{{crate.pkg_name}}-{{crate.pkg_version}}.crate",
         type = "tar.gz",


### PR DESCRIPTION
Using native.existing_rules allow to use several crates.bzl file that
would import the same crates without failing with duplicate rules.