### PR TITLE
Clean up the planner code

### DIFF
--- a/impl/src/bazel.rs
+++ b/impl/src/bazel.rs
@@ -155,7 +155,7 @@ impl BuildRenderer for BazelRenderer {
           .map_err(|e| CargoError::from(e.to_string()))
       );
       file_outputs.push(FileOutputs {
-        path: package.path.clone(),
+        path: format!("{}/{}", path_prefix, package.expected_build_path),
         contents: rendered_crate_build_file,
       })
     }
@@ -201,7 +201,7 @@ impl BuildRenderer for BazelRenderer {
           .map_err(|e| CargoError::from(e.to_string()))
       );
       file_outputs.push(FileOutputs {
-        path: package.path.clone(),
+        path: format!("{}/{}", path_prefix, package.expected_build_path),
         contents: rendered_crate_build_file,
       })
     }
@@ -265,14 +265,14 @@ mod tests {
       pkg_name: "test-binary".to_owned(),
       pkg_version: "1.1.1".to_owned(),
       features: vec!["feature1".to_owned(), "feature2".to_owned()].to_owned(),
-      path: "vendor/test-binary-1.1.1/".to_owned(),
+      expected_build_path: "vendor/test-binary-1.1.1/BUILD".to_owned(),
       licenses: Vec::new(),
       raze_settings: CrateSettings::default(),
       dependencies: Vec::new(),
       build_dependencies: Vec::new(),
       dev_dependencies: Vec::new(),
       is_root_dependency: true,
-      build_path: "@raze__test_binary__1_1_1//".to_owned(),
+      workspace_path_to_crate: "@raze__test_binary__1_1_1//".to_owned(),
       targets: vec![
         BuildableTarget {
           name: "some_binary".to_owned(),
@@ -293,12 +293,12 @@ mod tests {
       licenses: Vec::new(),
       raze_settings: CrateSettings::default(),
       features: vec!["feature1".to_owned(), "feature2".to_owned()].to_owned(),
-      path: "vendor/test-library-1.1.1/".to_owned(),
+      expected_build_path: "vendor/test-library-1.1.1/BUILD".to_owned(),
       dependencies: Vec::new(),
       build_dependencies: Vec::new(),
       dev_dependencies: Vec::new(),
       is_root_dependency: true,
-      build_path: "@raze__test_library__1_1_1//".to_owned(),
+      workspace_path_to_crate: "@raze__test_library__1_1_1//".to_owned(),
       targets: vec![
         BuildableTarget {
           name: "some_library".to_owned(),

--- a/impl/src/bazel.rs
+++ b/impl/src/bazel.rs
@@ -20,9 +20,9 @@ use planning::PlannedBuild;
 use rendering::BuildRenderer;
 use rendering::FileOutputs;
 use rendering::RenderDetails;
-use tera;
 use tera::Context;
 use tera::Tera;
+use tera;
 
 pub struct BazelRenderer {
   internal_renderer: Tera,
@@ -279,7 +279,7 @@ mod tests {
       is_root_dependency: true,
       build_path: "@raze__test_binary__1_1_1//".to_owned(),
       targets: vec![
-        BuildTarget {
+        BuildableTarget {
           name: "some_binary".to_owned(),
           kind: "bin".to_owned(),
           path: "bin/main.rs".to_owned(),
@@ -305,7 +305,7 @@ mod tests {
       is_root_dependency: true,
       build_path: "@raze__test_library__1_1_1//".to_owned(),
       targets: vec![
-        BuildTarget {
+        BuildableTarget {
           name: "some_library".to_owned(),
           kind: "lib".to_owned(),
           path: "path/lib.rs".to_owned(),

--- a/impl/src/bazel.rs
+++ b/impl/src/bazel.rs
@@ -149,14 +149,13 @@ impl BuildRenderer for BazelRenderer {
     let mut file_outputs = Vec::new();
 
     for package in crate_contexts {
-      let build_file_path = format!("{}/{}BUILD", &path_prefix, &package.path);
       let rendered_crate_build_file = try!(
         self
           .render_crate(&workspace_context, &package)
           .map_err(|e| CargoError::from(e.to_string()))
       );
       file_outputs.push(FileOutputs {
-        path: build_file_path,
+        path: package.path.clone(),
         contents: rendered_crate_build_file,
       })
     }
@@ -196,17 +195,13 @@ impl BuildRenderer for BazelRenderer {
     });
 
     for package in crate_contexts {
-      let build_file_path = format!(
-        "remote/{}-{}.BUILD",
-        &package.pkg_name, &package.pkg_version
-      );
       let rendered_crate_build_file = try!(
         self
           .render_remote_crate(&workspace_context, &package)
           .map_err(|e| CargoError::from(e.to_string()))
       );
       file_outputs.push(FileOutputs {
-        path: build_file_path,
+        path: package.path.clone(),
         contents: rendered_crate_build_file,
       })
     }

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use settings::CrateSettings;
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct BuildDependency {
   pub name: String,
@@ -45,26 +47,26 @@ pub struct GitRepo {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct SourceDetails {
+  pub git_data: Option<GitRepo>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct CrateContext {
   pub pkg_name: String,
   pub pkg_version: String,
+  pub raze_settings: CrateSettings,
   pub licenses: Vec<LicenseData>,
   pub features: Vec<String>,
-  pub path: String,
   pub build_path: String,
   pub dependencies: Vec<BuildDependency>,
   pub build_dependencies: Vec<BuildDependency>,
   pub dev_dependencies: Vec<BuildDependency>,
   pub is_root_dependency: bool,
-  pub metadeps: Vec<Metadep>,
-  pub platform_triple: String,
   pub targets: Vec<BuildTarget>,
   pub build_script_target: Option<BuildTarget>,
-  pub additional_deps: Vec<String>,
-  pub additional_flags: Vec<String>,
-  pub extra_aliased_targets: Vec<String>,
-  pub data_attr: Option<String>,
-  pub git_data: Option<GitRepo>,
+  pub source_details: SourceDetails,
+  pub path: String,
   pub sha256: Option<String>,
 }
 

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -58,7 +58,7 @@ pub struct CrateContext {
   pub raze_settings: CrateSettings,
   pub licenses: Vec<LicenseData>,
   pub features: Vec<String>,
-  pub build_path: String,
+  pub workspace_path_to_crate: String,
   pub dependencies: Vec<BuildableDependency>,
   pub build_dependencies: Vec<BuildableDependency>,
   pub dev_dependencies: Vec<BuildableDependency>,
@@ -72,7 +72,7 @@ pub struct CrateContext {
   // somewhere more explicit.
   //
   // I'm punting on this now because this requires a more serious look at the renderer code.
-  pub path: String,
+  pub expected_build_path: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -15,14 +15,14 @@
 use settings::CrateSettings;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-pub struct BuildDependency {
+pub struct BuildableDependency {
   pub name: String,
   pub version: String,
-  pub build_target: String,
+  pub buildable_target: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-pub struct BuildTarget {
+pub struct BuildableTarget {
   pub name: String,
   pub kind: String,
   pub path: String,
@@ -59,33 +59,32 @@ pub struct CrateContext {
   pub licenses: Vec<LicenseData>,
   pub features: Vec<String>,
   pub build_path: String,
-  pub dependencies: Vec<BuildDependency>,
-  pub build_dependencies: Vec<BuildDependency>,
-  pub dev_dependencies: Vec<BuildDependency>,
+  pub dependencies: Vec<BuildableDependency>,
+  pub build_dependencies: Vec<BuildableDependency>,
+  pub dev_dependencies: Vec<BuildableDependency>,
   pub is_root_dependency: bool,
-  pub targets: Vec<BuildTarget>,
-  pub build_script_target: Option<BuildTarget>,
+  pub targets: Vec<BuildableTarget>,
+  pub build_script_target: Option<BuildableTarget>,
   pub source_details: SourceDetails,
-  pub path: String,
   pub sha256: Option<String>,
+  // TODO(acmcarther): This is used internally by renderer to know where to put the build file. It
+  // probably should live somewhere else. Renderer params (separate from context) should live
+  // somewhere more explicit.
+  //
+  // I'm punting on this now because this requires a more serious look at the renderer code.
+  pub path: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct WorkspaceContext {
-  /**
-   * The bazel path prefix to the vendor directory
-   */
+  // The bazel path prefix to the vendor directory
   pub workspace_path: String,
 
-  /**
-   * The compilation target triple.
-   */
+  // The compilation target triple.
   pub platform_triple: String,
 
-  /**
-   * The generated new_http_library Bazel workspace prefix.
-   *
-   * This has no effect unless the GenMode setting is Remote.
-   */
+  // The generated new_http_library Bazel workspace prefix.
+  //
+  // This has no effect unless the GenMode setting is Remote.
   pub gen_workspace_prefix: String,
 }

--- a/impl/src/main.rs
+++ b/impl/src/main.rs
@@ -51,14 +51,14 @@ use rendering::FileOutputs;
 use rendering::RenderDetails;
 use settings::GenMode;
 use settings::RazeSettings;
-use util::PlatformDetails;
 use std::env;
-use std::fs;
 use std::fs::File;
+use std::fs;
 use std::io::Read;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
+use util::PlatformDetails;
 
 #[derive(Debug, RustcDecodable)]
 struct Options {

--- a/impl/src/main.rs
+++ b/impl/src/main.rs
@@ -121,9 +121,8 @@ fn real_main(options: Options, cargo_config: &Config) -> CliResult {
     lock_path_opt: lock_path_opt,
   };
   let platform_details = try!(PlatformDetails::new_using_rustc(&settings.target));
-  let planned_build = planner
-    .plan_build(&settings, files, platform_details)
-    .unwrap();
+  let planned_build = try!(planner
+    .plan_build(&settings, files, platform_details));
   let mut bazel_renderer = BazelRenderer::new();
   let render_details = RenderDetails {
     path_prefix: "./".to_owned(),

--- a/impl/src/metadata.rs
+++ b/impl/src/metadata.rs
@@ -82,8 +82,7 @@ pub struct Dependency {
   pub source: String,
   pub req: String,
   pub kind: Option<Kind>,
-  #[serde(default = "default_dependency_field_optional")]
-  pub optional: bool,
+  #[serde(default = "default_dependency_field_optional")] pub optional: bool,
   #[serde(default = "default_dependency_field_use_default_features")]
   pub use_default_features: bool,
   pub features: Vec<FeatureOrDependency>,
@@ -131,7 +130,13 @@ pub struct CargoInternalsMetadataFetcher<'config> {
 impl MetadataFetcher for CargoSubcommandMetadataFetcher {
   fn fetch_metadata(&mut self, files: CargoWorkspaceFiles) -> CargoResult<Metadata> {
     assert!(files.toml_path.is_file());
-    assert!(files.lock_path_opt.as_ref().map(|p| p.is_file()).unwrap_or(true));
+    assert!(
+      files
+        .lock_path_opt
+        .as_ref()
+        .map(|p| p.is_file())
+        .unwrap_or(true)
+    );
 
     // Copy files into a temp directory
     // UNWRAP: Guarded by function assertion
@@ -213,7 +218,11 @@ impl<'config> MetadataFetcher for CargoInternalsMetadataFetcher<'config> {
 
     for id in cargo_resolve.iter() {
       let dependencies = cargo_resolve.deps(id).map(|p| p.to_string()).collect();
-      let features = cargo_resolve.features_sorted(id).iter().map(|s| s.to_string()).collect();
+      let features = cargo_resolve
+        .features_sorted(id)
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
       resolve.nodes.push(ResolveNode {
         id: id.to_string(),
         dependencies: dependencies,
@@ -247,7 +256,11 @@ impl<'config> MetadataFetcher for CargoInternalsMetadataFetcher<'config> {
 
       let mut targets = Vec::new();
       for target in package.targets().iter() {
-        let crate_types = target.rustc_crate_types().iter().map(|t| t.to_string()).collect();
+        let crate_types = target
+          .rustc_crate_types()
+          .iter()
+          .map(|t| t.to_string())
+          .collect();
         targets.push(Target {
           name: target.name().to_owned(),
           kind: util::kind_to_kinds(target.kind()),
@@ -265,7 +278,11 @@ impl<'config> MetadataFetcher for CargoInternalsMetadataFetcher<'config> {
       let pkg_source = serde_json::to_string(package_id.source_id()).unwrap();
 
       // Cargo use SHA256 for checksum so we can use them directly
-      let sha256 = package.manifest().summary().checksum().map(ToString::to_string);
+      let sha256 = package
+        .manifest()
+        .summary()
+        .checksum()
+        .map(ToString::to_string);
 
       packages.push(Package {
         name: package.name().to_string(),
@@ -283,7 +300,9 @@ impl<'config> MetadataFetcher for CargoInternalsMetadataFetcher<'config> {
       });
     }
 
-    let workspace_members = ws.members().map(|pkg| pkg.package_id().to_string()).collect();
+    let workspace_members = ws.members()
+      .map(|pkg| pkg.package_id().to_string())
+      .collect();
 
     Ok(Metadata {
       packages: packages,
@@ -331,9 +350,7 @@ pub mod testing {
 
   impl StubMetadataFetcher {
     pub fn with_metadata(metadata: Metadata) -> StubMetadataFetcher {
-      StubMetadataFetcher {
-        metadata: metadata,
-      }
+      StubMetadataFetcher { metadata: metadata }
     }
   }
 

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -181,6 +181,20 @@ impl CrateCatalogEntry {
     format!("./{}{}", VENDOR_DIR, &self.package_ident)
   }
 
+  /** Yields the expected location of the build file (relative to execution path). */
+  pub fn local_build_path(&self, settings: &RazeSettings) -> String {
+    match settings.genmode {
+      GenMode::Remote => format!(
+        "remote/{}.BUILD",
+        &self.package_ident
+      ),
+      GenMode::Vendored => format!(
+        "vendor/{}/BUILD",
+        &self.package_ident
+      ),
+    }
+  }
+
   /** Yields the precise path to this dependency for the provided settings. */
   #[allow(dead_code)]
   pub fn workspace_path(&self, settings: &RazeSettings) -> String {
@@ -405,7 +419,9 @@ impl<'planner> CrateSubplanner<'planner> {
       targets: targets,
       raze_settings: self.crate_settings.clone(),
       source_details: self.produce_source_details(),
-      path: format!("./vendor/{}-{}", package.name, package.version),
+      path: self
+        .crate_catalog_entry
+        .local_build_path(&self.settings),
       sha256: package.sha256.clone(),
     })
   }

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -213,9 +213,8 @@ impl CrateCatalog {
     let mut package_id_to_entries_idx = HashMap::new();
 
     for (idx, crate_catalog_entry) in crate_catalog_entries.iter().enumerate() {
-      debug_assert!(
-        None == package_id_to_entries_idx.insert(crate_catalog_entry.package.id.clone(), idx)
-      );
+      let existing_value = package_id_to_entries_idx.insert(crate_catalog_entry.package.id.clone(), idx);
+      assert!(None == existing_value);
     }
 
     CrateCatalog {

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -412,14 +412,14 @@ impl<'planner> CrateSubplanner<'planner> {
       dependencies: normal_deps,
       build_dependencies: build_deps,
       dev_dependencies: dev_deps,
-      build_path: self
+      workspace_path_to_crate: self
         .crate_catalog_entry
         .workspace_path(&self.settings),
       build_script_target: build_script_target_opt,
       targets: targets,
       raze_settings: self.crate_settings.clone(),
       source_details: self.produce_source_details(),
-      path: self
+      expected_build_path: self
         .crate_catalog_entry
         .local_build_path(&self.settings),
       sha256: package.sha256.clone(),
@@ -932,7 +932,7 @@ mod tests {
   fn test_plan_build_missing_resolve_panics() {
     let mut fetcher = StubMetadataFetcher::with_metadata(metadata_testing::dummy_metadata());
     let mut planner = BuildPlannerImpl::new(&mut fetcher);
-    let planned_build_res = planner.plan_build(
+    let _ = planner.plan_build(
       &settings_testing::dummy_raze_settings(),
       dummy_workspace_files(),
       PlatformDetails::new("some_target_triple".to_owned(), Vec::new() /* attrs */),

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -400,7 +400,7 @@ impl<'planner> CrateSubplanner<'planner> {
       dev_dependencies: dev_deps,
       build_path: self
         .crate_catalog_entry
-        .workspace_path_and_default_target(&self.settings),
+        .workspace_path(&self.settings),
       build_script_target: build_script_target_opt,
       targets: targets,
       raze_settings: self.crate_settings.clone(),
@@ -912,7 +912,8 @@ mod tests {
   }
 
   #[test]
-  fn test_plan_build_missing_resolve_fails() {
+  #[should_panic]
+  fn test_plan_build_missing_resolve_panics() {
     let mut fetcher = StubMetadataFetcher::with_metadata(metadata_testing::dummy_metadata());
     let mut planner = BuildPlannerImpl::new(&mut fetcher);
     let planned_build_res = planner.plan_build(
@@ -920,9 +921,6 @@ mod tests {
       dummy_workspace_files(),
       PlatformDetails::new("some_target_triple".to_owned(), Vec::new() /* attrs */),
     );
-
-    println!("{:#?}", planned_build_res);
-    assert!(planned_build_res.is_err());
   }
 
   #[test]

--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -64,7 +64,7 @@ pub struct RazeSettings {
 }
 
 /** Override settings for individual crates (as part of RazeSettings). */
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CrateSettings {
   /**
    * Dependencies to be added to a crate.
@@ -133,6 +133,19 @@ pub struct CrateSettings {
 pub enum GenMode {
   Vendored,
   Remote,
+}
+
+impl Default for CrateSettings {
+  fn default() -> CrateSettings {
+    CrateSettings {
+      additional_deps: Vec::new(),
+      skipped_deps: Vec::new(),
+      extra_aliased_targets: Vec::new(),
+      additional_flags: Vec::new(),
+      gen_buildrs: default_crate_settings_field_gen_buildrs(),
+      data_attr: default_crate_settings_field_data_attr(),
+    }
+  }
 }
 
 #[cfg(test)]

--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -14,6 +14,8 @@
 
 use std::collections::HashMap;
 
+pub type CrateSettingsPerVersion = HashMap<String, CrateSettings>;
+
 /**
  * A "deserializable struct" for the whole Cargo.toml
  *
@@ -42,7 +44,7 @@ pub struct RazeSettings {
 
   /** Any crate-specific configuration. See CrateSetings for details. */
   #[serde(default)]
-  pub crates: HashMap<String, HashMap<String, CrateSettings>>,
+  pub crates: HashMap<String, CrateSettingsPerVersion>,
 
   /**
    * Prefix for generated Bazel workspaces (from workspace_rules)

--- a/impl/src/templates/partials/build_script.template
+++ b/impl/src/templates/partials/build_script.template
@@ -13,7 +13,7 @@ rust_binary(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target={{crate.platform_triple}}",
+        "--target={{workspace.platform_triple}}",
     ],
     crate_features = [
       {%- for feature in crate.features %}
@@ -35,7 +35,7 @@ genrule(
     local = 1,
     cmd = "mkdir -p {{ crate_name_sanitized}}_out_dir_outputs/;"
         + " (export CARGO_MANIFEST_DIR=\"$$PWD/$$(dirname $(location :Cargo.toml))\";"
-        + " export TARGET='{{ crate.platform_triple }}';"
+        + " export TARGET='{{ workspace.platform_triple }}';"
         + " export RUST_BACKTRACE=1;"
         {%- for feature in crate.features %}
         + " export CARGO_FEATURE_{{ feature | upper | replace(from="-", to="_") }}=1;"

--- a/impl/src/templates/partials/build_script.template
+++ b/impl/src/templates/partials/build_script.template
@@ -8,7 +8,7 @@ rust_binary(
     {%- endif %}
     deps = [
       {%- for dependency in crate.build_dependencies %}
-        "{{dependency.build_target}}",
+        "{{dependency.buildable_target}}",
       {%- endfor %}
     ],
     rustc_flags = [

--- a/impl/src/templates/partials/rust_binary.template
+++ b/impl/src/templates/partials/rust_binary.template
@@ -11,14 +11,14 @@ rust_binary(
         {%- for dependency in crate.dependencies %}
         "{{dependency.build_target}}",
         {%- endfor %}
-        {%- for dependency in crate.additional_deps %}
+        {%- for dependency in crate.raze_settings.additional_deps %}
         "{{dependency}}",
         {%- endfor %}
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target={{crate.platform_triple}}",
-        {%- for flag in crate.additional_flags %}
+        "--target={{workspace.platform_triple}}",
+        {%- for flag in crate.raze_settings.additional_flags %}
         "{{flag}}",
         {%- endfor %}
     ],

--- a/impl/src/templates/partials/rust_binary.template
+++ b/impl/src/templates/partials/rust_binary.template
@@ -9,7 +9,7 @@ rust_binary(
         # Binaries get an implicit dependency on their lib
         ":{{crate.pkg_name | replace(from="-", to="_") }}",
         {%- for dependency in crate.dependencies %}
-        "{{dependency.build_target}}",
+        "{{dependency.buildable_target}}",
         {%- endfor %}
         {%- for dependency in crate.raze_settings.additional_deps %}
         "{{dependency}}",
@@ -25,8 +25,8 @@ rust_binary(
     {%- if crate.build_script_target %}
     out_dir_tar = ":{{ crate.pkg_name | replace(from="-", to="_")}}_build_script_executor",
     {%- endif %}
-    {%- if crate.data_attr %}
-    data = {{crate.data_attr}},
+    {%- if crate.raze_settings.data_attr %}
+    data = {{crate.raze_settings.data_attr}},
     {%- endif %}
     version = "{{ crate.pkg_version }}",
     crate_features = [

--- a/impl/src/templates/partials/rust_library.template
+++ b/impl/src/templates/partials/rust_library.template
@@ -15,14 +15,14 @@ rust_library(
         {%- for dependency in crate.dependencies %}
         "{{dependency.build_target}}",
         {%- endfor %}
-        {%- for dependency in crate.additional_deps %}
+        {%- for dependency in crate.raze_settings.additional_deps %}
         "{{dependency}}",
         {%- endfor %}
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target={{crate.platform_triple}}",
-        {%- for flag in crate.additional_flags %}
+        "--target={{workspace.platform_triple}}",
+        {%- for flag in crate.raze_settings.additional_flags %}
         "{{flag}}",
         {%- endfor %}
     ],

--- a/impl/src/templates/partials/rust_library.template
+++ b/impl/src/templates/partials/rust_library.template
@@ -13,7 +13,7 @@ rust_library(
     srcs = glob(["**/*.rs"]),
     deps = [
         {%- for dependency in crate.dependencies %}
-        "{{dependency.build_target}}",
+        "{{dependency.buildable_target}}",
         {%- endfor %}
         {%- for dependency in crate.raze_settings.additional_deps %}
         "{{dependency}}",
@@ -29,8 +29,8 @@ rust_library(
     {%- if crate.build_script_target %}
     out_dir_tar = ":{{ crate.pkg_name | replace(from="-", to="_")}}_build_script_executor",
     {%- endif %}
-    {%- if crate.data_attr %}
-    data = {{crate.data_attr}},
+    {%- if crate.raze_settings.data_attr %}
+    data = {{crate.raze_settings.data_attr}},
     {%- endif %}
     version = "{{ crate.pkg_version }}",
     crate_features = [

--- a/impl/src/templates/remote_crates.bzl.template
+++ b/impl/src/templates/remote_crates.bzl.template
@@ -14,11 +14,11 @@ def _new_git_repository(name, **kwargs):
 
 def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
 {% for crate in crates %}
-    {%- if crate.git_data %}
+    {%- if crate.source_details.git_data %}
     _new_git_repository(
         name = "{{workspace.gen_workspace_prefix}}__{{crate.pkg_name | slugify | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}}",
-        remote = "{{crate.git_data.remote}}",
-        commit = "{{crate.git_data.commit}}",
+        remote = "{{crate.source_details.git_data.remote}}",
+        commit = "{{crate.source_details.git_data.commit}}",
         build_file = "{{workspace.workspace_path}}/remote:{{crate.pkg_name}}-{{crate.pkg_version}}.BUILD",
         init_submodules = True
     )

--- a/impl/src/templates/workspace.BUILD.template
+++ b/impl/src/templates/workspace.BUILD.template
@@ -17,7 +17,7 @@ alias(
     actual = "{{crate.build_path}}:{{crate_name_sanitized}}",
 )
 {%- endif %}
-{%- for aliased_target in crate.extra_aliased_targets %}
+{%- for aliased_target in crate.raze_settings.extra_aliased_targets %}
 alias(
     # Extra aliased target, from raze configuration
     # N.B.: The exact form of this is subject to change.

--- a/impl/src/templates/workspace.BUILD.template
+++ b/impl/src/templates/workspace.BUILD.template
@@ -14,7 +14,7 @@ licenses([
 {%- set crate_name_sanitized = crate.pkg_name | replace(from="-", to="_") %}
 alias(
     name = "{{crate_name_sanitized}}",
-    actual = "{{crate.build_path}}:{{crate_name_sanitized}}",
+    actual = "{{crate.workspace_path_to_crate}}:{{crate_name_sanitized}}",
 )
 {%- endif %}
 {%- for aliased_target in crate.raze_settings.extra_aliased_targets %}
@@ -22,7 +22,7 @@ alias(
     # Extra aliased target, from raze configuration
     # N.B.: The exact form of this is subject to change.
     name = "{{aliased_target}}",
-    actual = "{{crate.build_path}}:{{aliased_target}}",
+    actual = "{{crate.workspace_path_to_crate}}:{{aliased_target}}",
 )
 {%- endfor %}
 {%- endfor %}

--- a/impl/src/util.rs
+++ b/impl/src/util.rs
@@ -17,11 +17,11 @@ use cargo::core::TargetKind;
 use cargo::util::CargoResult;
 use cargo::util::Cfg;
 use slug;
-use std::process::Command;
-use std::str;
-use std::str::FromStr;
-use std::iter::Iterator;
 use std::fmt;
+use std::iter::Iterator;
+use std::process::Command;
+use std::str::FromStr;
+use std::str;
 
 pub struct PlatformDetails {
   target_triple: String,


### PR DESCRIPTION
Breaks out the BuildPlannerImpl classes' responsibilities into a bunch of smaller planners which have reasonable scope. Removes weird hash maps. Adds CargoCrateCatalog and uses it to look up things.

This gives me a reasonable place from which to continue https://github.com/google/cargo-raze/pull/54 without having to keep a billion hashmaps and random blobs in my head.

EDIT:
This also renames and gently restructures some code I nitted but allowed through during review. Gotta have those incredibly long variable names or I let my Java heritage down. I hope nobody is offended.