### PR TITLE
Remove rust_bench_test from generated imports

### DIFF
--- a/impl/src/templates/crate.BUILD.template
+++ b/impl/src/templates/crate.BUILD.template
@@ -22,7 +22,6 @@ load(
     "rust_library",
     "rust_binary",
     "rust_test",
-    "rust_bench_test",
 )
 
 {% set crate_name_sanitized = crate.pkg_name | replace(from="-", to="_") %}


### PR DESCRIPTION
This rule is never used and was renamed in recent rust rules into
rust_bechmark.