### PR TITLE
Remove rust_library.rustc_flag.target setting per rules_rust changes

### DIFF
--- a/impl/src/templates/partials/build_script.template
+++ b/impl/src/templates/partials/build_script.template
@@ -13,7 +13,6 @@ rust_binary(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target={{workspace.platform_triple}}",
     ],
     crate_features = [
       {%- for feature in crate.features %}
@@ -35,6 +34,8 @@ genrule(
     local = 1,
     cmd = "mkdir -p {{ crate_name_sanitized}}_out_dir_outputs/;"
         + " (export CARGO_MANIFEST_DIR=\"$$PWD/$$(dirname $(location :Cargo.toml))\";"
+        # TODO(acmcarther): This needs to be revisited as part of the cross compilation story.
+        #                   See also: https://github.com/google/cargo-raze/pull/54
         + " export TARGET='{{ workspace.platform_triple }}';"
         + " export RUST_BACKTRACE=1;"
         {%- for feature in crate.features %}

--- a/impl/src/templates/partials/rust_binary.template
+++ b/impl/src/templates/partials/rust_binary.template
@@ -17,7 +17,6 @@ rust_binary(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target={{workspace.platform_triple}}",
         {%- for flag in crate.raze_settings.additional_flags %}
         "{{flag}}",
         {%- endfor %}

--- a/impl/src/templates/partials/rust_library.template
+++ b/impl/src/templates/partials/rust_library.template
@@ -21,7 +21,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target={{workspace.platform_triple}}",
         {%- for flag in crate.raze_settings.additional_flags %}
         "{{flag}}",
         {%- endfor %}


### PR DESCRIPTION
Fixes https://github.com/google/cargo-raze/issues/69


The target setting is now being set (since https://github.com/bazelbuild/rules_rust/pull/136) by rules_rust internals and it is no longer appropriate for us to be setting it here. Per the current path we're taking for cross compilation, the toolchain itself is the only entity that knows the proper target setting. It has not yet been determined how the complation target will be set. Work and supplemental discussion is ongoing in https://github.com/google/cargo-raze/pull/54

The builds for this PR will be broken until https://github.com/google/cargo-raze/pull/67 is submitted (or a build containing the fix to the non_cratesio_library example.