### PR TITLE
Remove --target flag

### DIFF
--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "io_bazel_rules_rust")
 
 git_repository(
     name = "io_bazel_rules_rust",
-    commit = "af9821bf3378b525ec3db0af3b1ca388920a8fb0",
+    commit = "4a9d0e0b6c66f1e98d15cbd3cccc8100a0454fc9",
     remote = "https://github.com/bazelbuild/rules_rust.git",
 )
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/aho-corasick-0.6.4/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/aho-corasick-0.6.4/BUILD
@@ -37,7 +37,6 @@ rust_binary(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.6.4",
     crate_features = [
@@ -55,7 +54,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.6.4",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/arrayvec-0.3.25/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/arrayvec-0.3.25/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.25",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/arrayvec-0.4.7/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/arrayvec-0.4.7/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.7",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/atom-0.3.4/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/atom-0.3.4/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.4",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/bitflags-1.0.1/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/bitflags-1.0.1/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.1",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/cfg-if-0.1.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/cfg-if-0.1.2/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/conduit-mime-types-0.7.3/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/conduit-mime-types-0.7.3/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     data = glob(["data/**"]),
     version = "0.7.3",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-0.3.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-0.3.2/BUILD
@@ -35,7 +35,6 @@ rust_binary(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.2",
     crate_features = [
@@ -52,7 +51,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.2",
     crate_features = [
@@ -71,7 +69,6 @@ rust_binary(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-deque-0.2.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-deque-0.2.0/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-epoch-0.3.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-epoch-0.3.0/BUILD
@@ -40,7 +40,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-utils-0.2.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-utils-0.2.2/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/derivative-1.0.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/derivative-1.0.0/BUILD
@@ -37,7 +37,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/either-1.4.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/either-1.4.0/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.4.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/fnv-1.0.6/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/fnv-1.0.6/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.6",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/fuchsia-zircon-0.3.3/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/fuchsia-zircon-0.3.3/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.3",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/fuchsia-zircon-sys-0.3.3/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/fuchsia-zircon-sys-0.3.3/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.3",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/hibitset-0.3.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/hibitset-0.3.2/BUILD
@@ -36,7 +36,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/itertools-0.5.10/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/itertools-0.5.10/BUILD
@@ -36,7 +36,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.5.10",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/lazy_static-0.2.11/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/lazy_static-0.2.11/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.11",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/lazy_static-1.0.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/lazy_static-1.0.0/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/libc-0.2.36/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/libc-0.2.36/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.36",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/memchr-2.0.1/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/memchr-2.0.1/BUILD
@@ -36,7 +36,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "2.0.1",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/memoffset-0.2.1/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/memoffset-0.2.1/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.1",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/mopa-0.2.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/mopa-0.2.2/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/nodrop-0.1.12/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/nodrop-0.1.12/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.12",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/num_cpus-1.8.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/num_cpus-1.8.0/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.8.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/odds-0.2.26/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/odds-0.2.26/BUILD
@@ -36,7 +36,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.26",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/pulse-0.5.3/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/pulse-0.5.3/BUILD
@@ -37,7 +37,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.5.3",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/quote-0.3.15/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/quote-0.3.15/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.15",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/rand-0.4.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/rand-0.4.2/BUILD
@@ -37,7 +37,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-0.8.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-0.8.2/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.8.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-core-1.4.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-core-1.4.0/BUILD
@@ -39,7 +39,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.4.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/redox_syscall-0.1.37/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/redox_syscall-0.1.37/BUILD
@@ -37,7 +37,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.37",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/regex-0.2.6/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/regex-0.2.6/BUILD
@@ -46,7 +46,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.6",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/regex-syntax-0.4.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/regex-syntax-0.4.2/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/rustc-serialize-0.3.24/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/rustc-serialize-0.3.24/BUILD
@@ -36,7 +36,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.24",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/scopeguard-0.3.3/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/scopeguard-0.3.3/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.3",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/shred-0.5.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/shred-0.5.2/BUILD
@@ -49,7 +49,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.5.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/shred-derive-0.3.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/shred-derive-0.3.0/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/smallvec-0.4.4/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/smallvec-0.4.4/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.4",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/specs-0.10.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/specs-0.10.0/BUILD
@@ -50,7 +50,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.10.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.10.8/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.10.8/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.10.8",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.11.11/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.11.11/BUILD
@@ -36,7 +36,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.11.11",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/synom-0.11.3/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/synom-0.11.3/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.11.3",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/thread_local-0.3.5/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/thread_local-0.3.5/BUILD
@@ -36,7 +36,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.5",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/time-0.1.39/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/time-0.1.39/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.39",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/tuple_utils-0.2.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/tuple_utils-0.2.0/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.0.4/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.0.4/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.0.4",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/unreachable-1.0.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/unreachable-1.0.0/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/utf8-ranges-1.0.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/utf8-ranges-1.0.0/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/void-1.0.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/void-1.0.2/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-0.3.4/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-0.3.4/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.4",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.0",
     crate_features = [

--- a/examples/vendored/hello_cargo_library/cargo/vendor/cfg-if-0.1.2/BUILD
+++ b/examples/vendored/hello_cargo_library/cargo/vendor/cfg-if-0.1.2/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.2",
     crate_features = [

--- a/examples/vendored/hello_cargo_library/cargo/vendor/fern-0.3.5/BUILD
+++ b/examples/vendored/hello_cargo_library/cargo/vendor/fern-0.3.5/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.5",
     crate_features = [

--- a/examples/vendored/hello_cargo_library/cargo/vendor/log-0.3.9/BUILD
+++ b/examples/vendored/hello_cargo_library/cargo/vendor/log-0.3.9/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.9",
     crate_features = [

--- a/examples/vendored/hello_cargo_library/cargo/vendor/log-0.4.1/BUILD
+++ b/examples/vendored/hello_cargo_library/cargo/vendor/log-0.4.1/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.1",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/aho-corasick-0.6.4/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/aho-corasick-0.6.4/BUILD
@@ -37,7 +37,6 @@ rust_binary(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.6.4",
     crate_features = [
@@ -55,7 +54,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.6.4",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/atty-0.2.8/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/atty-0.2.8/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.8",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/cfg-if-0.1.2/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/cfg-if-0.1.2/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.2",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/either-1.4.0/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/either-1.4.0/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.4.0",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/env_logger-0.5.5/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/env_logger-0.5.5/BUILD
@@ -43,7 +43,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.5.5",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-0.2.0-alpha/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-0.2.0-alpha/BUILD
@@ -40,7 +40,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.0-alpha",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-channel-0.2.0-alpha/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-channel-0.2.0-alpha/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.0-alpha",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-core-0.2.0-alpha/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-core-0.2.0-alpha/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.0-alpha",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-executor-0.2.0-alpha/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-executor-0.2.0-alpha/BUILD
@@ -37,7 +37,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.0-alpha",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-io-0.2.0-alpha/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-io-0.2.0-alpha/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.0-alpha",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-sink-0.2.0-alpha/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-sink-0.2.0-alpha/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.0-alpha",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-stable-0.2.0-alpha/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-stable-0.2.0-alpha/BUILD
@@ -36,7 +36,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.0-alpha",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-util-0.2.0-alpha/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-util-0.2.0-alpha/BUILD
@@ -39,7 +39,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.0-alpha",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/humantime-1.1.1/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/humantime-1.1.1/BUILD
@@ -36,7 +36,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.1.1",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/iovec-0.1.2/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/iovec-0.1.2/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.2",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/lazy_static-1.0.0/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/lazy_static-1.0.0/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.0",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/libc-0.2.39/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/libc-0.2.39/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.39",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.0/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.0/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.0",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.1/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.1/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.1",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/memchr-2.0.1/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/memchr-2.0.1/BUILD
@@ -36,7 +36,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "2.0.1",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/num_cpus-1.8.0/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/num_cpus-1.8.0/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.8.0",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/pin-api-0.1.3/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/pin-api-0.1.3/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.3",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/quick-error-1.2.1/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/quick-error-1.2.1/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.2.1",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/redox_syscall-0.1.37/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/redox_syscall-0.1.37/BUILD
@@ -37,7 +37,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.37",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/redox_termios-0.1.1/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/redox_termios-0.1.1/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.1",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/regex-0.2.9/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/regex-0.2.9/BUILD
@@ -47,7 +47,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.9",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/regex-syntax-0.5.3/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/regex-syntax-0.5.3/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.5.3",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/termcolor-0.3.5/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/termcolor-0.3.5/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.5",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/termion-1.5.1/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/termion-1.5.1/BUILD
@@ -49,7 +49,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.5.1",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/thread_local-0.3.5/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/thread_local-0.3.5/BUILD
@@ -36,7 +36,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.5",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/ucd-util-0.1.1/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/ucd-util-0.1.1/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.1",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/unreachable-1.0.0/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/unreachable-1.0.0/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.0",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/utf8-ranges-1.0.0/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/utf8-ranges-1.0.0/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.0",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/void-1.0.2/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/void-1.0.2/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.2",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/winapi-0.2.8/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/winapi-0.2.8/BUILD
@@ -33,7 +33,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.8",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/winapi-0.3.4/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/winapi-0.3.4/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.4",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.0",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD
@@ -34,7 +34,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.0",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/wincolor-0.1.6/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/wincolor-0.1.6/BUILD
@@ -35,7 +35,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.6",
     crate_features = [

--- a/impl/src/templates/partials/build_script.template
+++ b/impl/src/templates/partials/build_script.template
@@ -13,7 +13,6 @@ rust_binary(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target={{workspace.platform_triple}}",
     ],
     crate_features = [
       {%- for feature in crate.features %}

--- a/impl/src/templates/partials/rust_binary.template
+++ b/impl/src/templates/partials/rust_binary.template
@@ -17,7 +17,6 @@ rust_binary(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target={{workspace.platform_triple}}",
         {%- for flag in crate.raze_settings.additional_flags %}
         "{{flag}}",
         {%- endfor %}

--- a/impl/src/templates/partials/rust_library.template
+++ b/impl/src/templates/partials/rust_library.template
@@ -21,7 +21,6 @@ rust_library(
     ],
     rustc_flags = [
         "--cap-lints allow",
-        "--target={{workspace.platform_triple}}",
         {%- for flag in crate.raze_settings.additional_flags %}
         "{{flag}}",
         {%- endfor %}


### PR DESCRIPTION
It is now automatically set by rules_rust. It should always be correct
even for the build script with Bazel handling the configuration.