### PR TITLE
Use --flag=value syntax for cap-lints

### DIFF
--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "io_bazel_rules_rust")
 
 git_repository(
     name = "io_bazel_rules_rust",
-    commit = "4a9d0e0b6c66f1e98d15cbd3cccc8100a0454fc9",
+    commit = "9a3de26b92e8f4e050d21bc126fc6c373e0acc35",
     remote = "https://github.com/bazelbuild/rules_rust.git",
 )
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/aho-corasick-0.6.4.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/aho-corasick-0.6.4.BUILD
@@ -36,7 +36,7 @@ rust_binary(
         "@complicated_cargo_library__memchr__2_0_1//:memchr",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.6.4",
@@ -54,7 +54,7 @@ rust_library(
         "@complicated_cargo_library__memchr__2_0_1//:memchr",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.6.4",

--- a/examples/remote/complicated_cargo_library/cargo/remote/arrayvec-0.3.25.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/arrayvec-0.3.25.BUILD
@@ -34,7 +34,7 @@ rust_library(
         "@complicated_cargo_library__odds__0_2_26//:odds",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.25",

--- a/examples/remote/complicated_cargo_library/cargo/remote/arrayvec-0.4.7.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/arrayvec-0.4.7.BUILD
@@ -34,7 +34,7 @@ rust_library(
         "@complicated_cargo_library__nodrop__0_1_12//:nodrop",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.7",

--- a/examples/remote/complicated_cargo_library/cargo/remote/atom-0.3.4.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/atom-0.3.4.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.4",

--- a/examples/remote/complicated_cargo_library/cargo/remote/bitflags-1.0.1.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/bitflags-1.0.1.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.1",

--- a/examples/remote/complicated_cargo_library/cargo/remote/cfg-if-0.1.2.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/cfg-if-0.1.2.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.2",

--- a/examples/remote/complicated_cargo_library/cargo/remote/crossbeam-0.3.2.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/crossbeam-0.3.2.BUILD
@@ -34,7 +34,7 @@ rust_binary(
         ":crossbeam",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.2",
@@ -51,7 +51,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.2",
@@ -70,7 +70,7 @@ rust_binary(
         ":crossbeam",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.2",

--- a/examples/remote/complicated_cargo_library/cargo/remote/crossbeam-deque-0.2.0.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/crossbeam-deque-0.2.0.BUILD
@@ -34,7 +34,7 @@ rust_library(
         "@complicated_cargo_library__crossbeam_utils__0_2_2//:crossbeam_utils",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.0",

--- a/examples/remote/complicated_cargo_library/cargo/remote/crossbeam-epoch-0.3.0.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/crossbeam-epoch-0.3.0.BUILD
@@ -39,7 +39,7 @@ rust_library(
         "@complicated_cargo_library__scopeguard__0_3_3//:scopeguard",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.0",

--- a/examples/remote/complicated_cargo_library/cargo/remote/crossbeam-utils-0.2.2.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/crossbeam-utils-0.2.2.BUILD
@@ -33,7 +33,7 @@ rust_library(
         "@complicated_cargo_library__cfg_if__0_1_2//:cfg_if",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.2",

--- a/examples/remote/complicated_cargo_library/cargo/remote/derivative-1.0.0.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/derivative-1.0.0.BUILD
@@ -36,7 +36,7 @@ rust_library(
         "@complicated_cargo_library__syn__0_10_8//:syn",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.0",

--- a/examples/remote/complicated_cargo_library/cargo/remote/either-1.4.0.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/either-1.4.0.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.4.0",

--- a/examples/remote/complicated_cargo_library/cargo/remote/fnv-1.0.6.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/fnv-1.0.6.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.6",

--- a/examples/remote/complicated_cargo_library/cargo/remote/fuchsia-zircon-0.3.3.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/fuchsia-zircon-0.3.3.BUILD
@@ -34,7 +34,7 @@ rust_library(
         "@complicated_cargo_library__fuchsia_zircon_sys__0_3_3//:fuchsia_zircon_sys",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.3",

--- a/examples/remote/complicated_cargo_library/cargo/remote/fuchsia-zircon-sys-0.3.3.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/fuchsia-zircon-sys-0.3.3.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.3",

--- a/examples/remote/complicated_cargo_library/cargo/remote/hibitset-0.3.2.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/hibitset-0.3.2.BUILD
@@ -35,7 +35,7 @@ rust_library(
         "@complicated_cargo_library__rayon__0_8_2//:rayon",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.2",

--- a/examples/remote/complicated_cargo_library/cargo/remote/itertools-0.5.10.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/itertools-0.5.10.BUILD
@@ -35,7 +35,7 @@ rust_library(
         "@complicated_cargo_library__either__1_4_0//:either",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.5.10",

--- a/examples/remote/complicated_cargo_library/cargo/remote/lazy_static-0.2.11.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/lazy_static-0.2.11.BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.11",

--- a/examples/remote/complicated_cargo_library/cargo/remote/lazy_static-1.0.0.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/lazy_static-1.0.0.BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.0",

--- a/examples/remote/complicated_cargo_library/cargo/remote/libc-0.2.36.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/libc-0.2.36.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.36",

--- a/examples/remote/complicated_cargo_library/cargo/remote/memchr-2.0.1.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/memchr-2.0.1.BUILD
@@ -35,7 +35,7 @@ rust_library(
         "@complicated_cargo_library__libc__0_2_36//:libc",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "2.0.1",

--- a/examples/remote/complicated_cargo_library/cargo/remote/memoffset-0.2.1.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/memoffset-0.2.1.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.1",

--- a/examples/remote/complicated_cargo_library/cargo/remote/mopa-0.2.2.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/mopa-0.2.2.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.2",

--- a/examples/remote/complicated_cargo_library/cargo/remote/nodrop-0.1.12.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/nodrop-0.1.12.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.12",

--- a/examples/remote/complicated_cargo_library/cargo/remote/num_cpus-1.8.0.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/num_cpus-1.8.0.BUILD
@@ -33,7 +33,7 @@ rust_library(
         "@complicated_cargo_library__libc__0_2_36//:libc",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.8.0",

--- a/examples/remote/complicated_cargo_library/cargo/remote/odds-0.2.26.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/odds-0.2.26.BUILD
@@ -35,7 +35,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.26",

--- a/examples/remote/complicated_cargo_library/cargo/remote/pulse-0.5.3.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/pulse-0.5.3.BUILD
@@ -36,7 +36,7 @@ rust_library(
         "@complicated_cargo_library__time__0_1_39//:time",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.5.3",

--- a/examples/remote/complicated_cargo_library/cargo/remote/quote-0.3.15.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/quote-0.3.15.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.15",

--- a/examples/remote/complicated_cargo_library/cargo/remote/rand-0.4.2.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/rand-0.4.2.BUILD
@@ -36,7 +36,7 @@ rust_library(
         "@complicated_cargo_library__libc__0_2_36//:libc",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.2",

--- a/examples/remote/complicated_cargo_library/cargo/remote/rayon-0.8.2.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/rayon-0.8.2.BUILD
@@ -34,7 +34,7 @@ rust_library(
         "@complicated_cargo_library__rayon_core__1_4_0//:rayon_core",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.8.2",

--- a/examples/remote/complicated_cargo_library/cargo/remote/rayon-core-1.4.0.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/rayon-core-1.4.0.BUILD
@@ -38,7 +38,7 @@ rust_library(
         "@complicated_cargo_library__rand__0_4_2//:rand",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.4.0",

--- a/examples/remote/complicated_cargo_library/cargo/remote/redox_syscall-0.1.37.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/redox_syscall-0.1.37.BUILD
@@ -36,7 +36,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.37",

--- a/examples/remote/complicated_cargo_library/cargo/remote/regex-0.2.6.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/regex-0.2.6.BUILD
@@ -45,7 +45,7 @@ rust_library(
         "@complicated_cargo_library__utf8_ranges__1_0_0//:utf8_ranges",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.6",

--- a/examples/remote/complicated_cargo_library/cargo/remote/regex-syntax-0.4.2.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/regex-syntax-0.4.2.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.2",

--- a/examples/remote/complicated_cargo_library/cargo/remote/scopeguard-0.3.3.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/scopeguard-0.3.3.BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.3",

--- a/examples/remote/complicated_cargo_library/cargo/remote/shred-0.5.2.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/shred-0.5.2.BUILD
@@ -48,7 +48,7 @@ rust_library(
         "@complicated_cargo_library__smallvec__0_4_4//:smallvec",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.5.2",

--- a/examples/remote/complicated_cargo_library/cargo/remote/shred-derive-0.3.0.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/shred-derive-0.3.0.BUILD
@@ -34,7 +34,7 @@ rust_library(
         "@complicated_cargo_library__syn__0_11_11//:syn",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.0",

--- a/examples/remote/complicated_cargo_library/cargo/remote/smallvec-0.4.4.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/smallvec-0.4.4.BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.4",

--- a/examples/remote/complicated_cargo_library/cargo/remote/specs-0.10.0.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/specs-0.10.0.BUILD
@@ -49,7 +49,7 @@ rust_library(
         "@complicated_cargo_library__tuple_utils__0_2_0//:tuple_utils",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.10.0",

--- a/examples/remote/complicated_cargo_library/cargo/remote/syn-0.10.8.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/syn-0.10.8.BUILD
@@ -34,7 +34,7 @@ rust_library(
         "@complicated_cargo_library__unicode_xid__0_0_4//:unicode_xid",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.10.8",

--- a/examples/remote/complicated_cargo_library/cargo/remote/syn-0.11.11.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/syn-0.11.11.BUILD
@@ -35,7 +35,7 @@ rust_library(
         "@complicated_cargo_library__unicode_xid__0_0_4//:unicode_xid",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.11.11",

--- a/examples/remote/complicated_cargo_library/cargo/remote/synom-0.11.3.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/synom-0.11.3.BUILD
@@ -33,7 +33,7 @@ rust_library(
         "@complicated_cargo_library__unicode_xid__0_0_4//:unicode_xid",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.11.3",

--- a/examples/remote/complicated_cargo_library/cargo/remote/thread_local-0.3.5.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/thread_local-0.3.5.BUILD
@@ -35,7 +35,7 @@ rust_library(
         "@complicated_cargo_library__unreachable__1_0_0//:unreachable",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.5",

--- a/examples/remote/complicated_cargo_library/cargo/remote/time-0.1.39.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/time-0.1.39.BUILD
@@ -34,7 +34,7 @@ rust_library(
         "@complicated_cargo_library__libc__0_2_36//:libc",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.39",

--- a/examples/remote/complicated_cargo_library/cargo/remote/tuple_utils-0.2.0.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/tuple_utils-0.2.0.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.0",

--- a/examples/remote/complicated_cargo_library/cargo/remote/unicode-xid-0.0.4.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/unicode-xid-0.0.4.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.0.4",

--- a/examples/remote/complicated_cargo_library/cargo/remote/unreachable-1.0.0.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/unreachable-1.0.0.BUILD
@@ -33,7 +33,7 @@ rust_library(
         "@complicated_cargo_library__void__1_0_2//:void",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.0",

--- a/examples/remote/complicated_cargo_library/cargo/remote/utf8-ranges-1.0.0.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/utf8-ranges-1.0.0.BUILD
@@ -34,7 +34,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.0",

--- a/examples/remote/complicated_cargo_library/cargo/remote/void-1.0.2.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/void-1.0.2.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.2",

--- a/examples/remote/complicated_cargo_library/cargo/remote/winapi-0.3.4.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/winapi-0.3.4.BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.4",

--- a/examples/remote/complicated_cargo_library/cargo/remote/winapi-i686-pc-windows-gnu-0.4.0.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/winapi-i686-pc-windows-gnu-0.4.0.BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.0",

--- a/examples/remote/complicated_cargo_library/cargo/remote/winapi-x86_64-pc-windows-gnu-0.4.0.BUILD
+++ b/examples/remote/complicated_cargo_library/cargo/remote/winapi-x86_64-pc-windows-gnu-0.4.0.BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.0",

--- a/examples/remote/non_cratesio/cargo/remote/aho-corasick-0.6.4.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/aho-corasick-0.6.4.BUILD
@@ -36,7 +36,7 @@ rust_binary(
         "@non_cratesio__memchr__2_0_1//:memchr",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.6.4",
@@ -54,7 +54,7 @@ rust_library(
         "@non_cratesio__memchr__2_0_1//:memchr",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.6.4",

--- a/examples/remote/non_cratesio/cargo/remote/atty-0.2.8.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/atty-0.2.8.BUILD
@@ -34,7 +34,7 @@ rust_library(
         "@non_cratesio__libc__0_2_39//:libc",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.8",

--- a/examples/remote/non_cratesio/cargo/remote/bitflags-1.0.1.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/bitflags-1.0.1.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.1",

--- a/examples/remote/non_cratesio/cargo/remote/cfg-if-0.1.2.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/cfg-if-0.1.2.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.2",

--- a/examples/remote/non_cratesio/cargo/remote/env_logger-0.5.5.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/env_logger-0.5.5.BUILD
@@ -42,7 +42,7 @@ rust_library(
         "@non_cratesio__termcolor__0_3_5//:termcolor",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.5.5",

--- a/examples/remote/non_cratesio/cargo/remote/fuchsia-zircon-0.3.3.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/fuchsia-zircon-0.3.3.BUILD
@@ -34,7 +34,7 @@ rust_library(
         "@non_cratesio__fuchsia_zircon_sys__0_3_3//:fuchsia_zircon_sys",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.3",

--- a/examples/remote/non_cratesio/cargo/remote/fuchsia-zircon-sys-0.3.3.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/fuchsia-zircon-sys-0.3.3.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.3",

--- a/examples/remote/non_cratesio/cargo/remote/humantime-1.1.1.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/humantime-1.1.1.BUILD
@@ -35,7 +35,7 @@ rust_library(
         "@non_cratesio__quick_error__1_2_1//:quick_error",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.1.1",

--- a/examples/remote/non_cratesio/cargo/remote/lazy_static-1.0.0.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/lazy_static-1.0.0.BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.0",

--- a/examples/remote/non_cratesio/cargo/remote/libc-0.2.39.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/libc-0.2.39.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.39",

--- a/examples/remote/non_cratesio/cargo/remote/log-0.4.0.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/log-0.4.0.BUILD
@@ -34,7 +34,7 @@ rust_library(
         "@non_cratesio__cfg_if__0_1_2//:cfg_if",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.0",

--- a/examples/remote/non_cratesio/cargo/remote/log-0.4.1.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/log-0.4.1.BUILD
@@ -34,7 +34,7 @@ rust_library(
         "@non_cratesio__cfg_if__0_1_2//:cfg_if",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.1",

--- a/examples/remote/non_cratesio/cargo/remote/memchr-2.0.1.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/memchr-2.0.1.BUILD
@@ -35,7 +35,7 @@ rust_library(
         "@non_cratesio__libc__0_2_39//:libc",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "2.0.1",

--- a/examples/remote/non_cratesio/cargo/remote/quick-error-1.2.1.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/quick-error-1.2.1.BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.2.1",

--- a/examples/remote/non_cratesio/cargo/remote/rand-0.4.1.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/rand-0.4.1.BUILD
@@ -36,7 +36,7 @@ rust_library(
         "@non_cratesio__libc__0_2_39//:libc",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.1",

--- a/examples/remote/non_cratesio/cargo/remote/redox_syscall-0.1.37.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/redox_syscall-0.1.37.BUILD
@@ -36,7 +36,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.37",

--- a/examples/remote/non_cratesio/cargo/remote/redox_termios-0.1.1.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/redox_termios-0.1.1.BUILD
@@ -33,7 +33,7 @@ rust_library(
         "@non_cratesio__redox_syscall__0_1_37//:redox_syscall",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.1",

--- a/examples/remote/non_cratesio/cargo/remote/regex-0.2.9.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/regex-0.2.9.BUILD
@@ -46,7 +46,7 @@ rust_library(
         "@non_cratesio__utf8_ranges__1_0_0//:utf8_ranges",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.2.9",

--- a/examples/remote/non_cratesio/cargo/remote/regex-syntax-0.5.3.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/regex-syntax-0.5.3.BUILD
@@ -34,7 +34,7 @@ rust_library(
         "@non_cratesio__ucd_util__0_1_1//:ucd_util",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.5.3",

--- a/examples/remote/non_cratesio/cargo/remote/termcolor-0.3.5.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/termcolor-0.3.5.BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.5",

--- a/examples/remote/non_cratesio/cargo/remote/termion-1.5.1.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/termion-1.5.1.BUILD
@@ -48,7 +48,7 @@ rust_library(
         "@non_cratesio__libc__0_2_39//:libc",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.5.1",

--- a/examples/remote/non_cratesio/cargo/remote/thread_local-0.3.5.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/thread_local-0.3.5.BUILD
@@ -35,7 +35,7 @@ rust_library(
         "@non_cratesio__unreachable__1_0_0//:unreachable",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.5",

--- a/examples/remote/non_cratesio/cargo/remote/ucd-util-0.1.1.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/ucd-util-0.1.1.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.1",

--- a/examples/remote/non_cratesio/cargo/remote/unreachable-1.0.0.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/unreachable-1.0.0.BUILD
@@ -33,7 +33,7 @@ rust_library(
         "@non_cratesio__void__1_0_2//:void",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.0",

--- a/examples/remote/non_cratesio/cargo/remote/utf8-ranges-1.0.0.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/utf8-ranges-1.0.0.BUILD
@@ -34,7 +34,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.0",

--- a/examples/remote/non_cratesio/cargo/remote/void-1.0.2.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/void-1.0.2.BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "1.0.2",

--- a/examples/remote/non_cratesio/cargo/remote/winapi-0.3.4.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/winapi-0.3.4.BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.3.4",

--- a/examples/remote/non_cratesio/cargo/remote/winapi-i686-pc-windows-gnu-0.4.0.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/winapi-i686-pc-windows-gnu-0.4.0.BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.0",

--- a/examples/remote/non_cratesio/cargo/remote/winapi-x86_64-pc-windows-gnu-0.4.0.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/winapi-x86_64-pc-windows-gnu-0.4.0.BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.4.0",

--- a/examples/remote/non_cratesio/cargo/remote/wincolor-0.1.6.BUILD
+++ b/examples/remote/non_cratesio/cargo/remote/wincolor-0.1.6.BUILD
@@ -34,7 +34,7 @@ rust_library(
         "@non_cratesio__winapi__0_3_4//:winapi",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         "--target=x86_64-unknown-linux-gnu",
     ],
     version = "0.1.6",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/aho-corasick-0.6.4/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/aho-corasick-0.6.4/BUILD
@@ -36,7 +36,7 @@ rust_binary(
         "//vendored/complicated_cargo_library/cargo/vendor/memchr-2.0.1:memchr",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.6.4",
     crate_features = [
@@ -53,7 +53,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/memchr-2.0.1:memchr",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.6.4",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/arrayvec-0.3.25/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/arrayvec-0.3.25/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/odds-0.2.26:odds",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.25",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/arrayvec-0.4.7/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/arrayvec-0.4.7/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/nodrop-0.1.12:nodrop",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.4.7",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/atom-0.3.4/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/atom-0.3.4/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.4",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/bitflags-1.0.1/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/bitflags-1.0.1/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.0.1",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/cfg-if-0.1.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/cfg-if-0.1.2/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.1.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/conduit-mime-types-0.7.3/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/conduit-mime-types-0.7.3/BUILD
@@ -33,7 +33,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/rustc-serialize-0.3.24:rustc_serialize",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     data = glob(["data/**"]),
     version = "0.7.3",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-0.3.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-0.3.2/BUILD
@@ -34,7 +34,7 @@ rust_binary(
         ":crossbeam",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.2",
     crate_features = [
@@ -50,7 +50,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.2",
     crate_features = [
@@ -68,7 +68,7 @@ rust_binary(
         ":crossbeam",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-deque-0.2.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-deque-0.2.0/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/crossbeam-utils-0.2.2:crossbeam_utils",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-epoch-0.3.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-epoch-0.3.0/BUILD
@@ -39,7 +39,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/scopeguard-0.3.3:scopeguard",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-utils-0.2.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-utils-0.2.2/BUILD
@@ -33,7 +33,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/cfg-if-0.1.2:cfg_if",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/derivative-1.0.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/derivative-1.0.0/BUILD
@@ -36,7 +36,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/syn-0.10.8:syn",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.0.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/either-1.4.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/either-1.4.0/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.4.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/fnv-1.0.6/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/fnv-1.0.6/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.0.6",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/fuchsia-zircon-0.3.3/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/fuchsia-zircon-0.3.3/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/fuchsia-zircon-sys-0.3.3:fuchsia_zircon_sys",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.3",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/fuchsia-zircon-sys-0.3.3/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/fuchsia-zircon-sys-0.3.3/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.3",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/hibitset-0.3.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/hibitset-0.3.2/BUILD
@@ -35,7 +35,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/rayon-0.8.2:rayon",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/itertools-0.5.10/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/itertools-0.5.10/BUILD
@@ -35,7 +35,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/either-1.4.0:either",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.5.10",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/lazy_static-0.2.11/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/lazy_static-0.2.11/BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.11",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/lazy_static-1.0.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/lazy_static-1.0.0/BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.0.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/libc-0.2.36/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/libc-0.2.36/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.36",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/memchr-2.0.1/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/memchr-2.0.1/BUILD
@@ -35,7 +35,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/libc-0.2.36:libc",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "2.0.1",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/memoffset-0.2.1/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/memoffset-0.2.1/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.1",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/mopa-0.2.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/mopa-0.2.2/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/nodrop-0.1.12/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/nodrop-0.1.12/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.1.12",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/num_cpus-1.8.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/num_cpus-1.8.0/BUILD
@@ -33,7 +33,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/libc-0.2.36:libc",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.8.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/odds-0.2.26/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/odds-0.2.26/BUILD
@@ -35,7 +35,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.26",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/pulse-0.5.3/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/pulse-0.5.3/BUILD
@@ -36,7 +36,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/time-0.1.39:time",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.5.3",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/quote-0.3.15/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/quote-0.3.15/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.15",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/rand-0.4.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/rand-0.4.2/BUILD
@@ -36,7 +36,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/libc-0.2.36:libc",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.4.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-0.8.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-0.8.2/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/rayon-core-1.4.0:rayon_core",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.8.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-core-1.4.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-core-1.4.0/BUILD
@@ -38,7 +38,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/rand-0.4.2:rand",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.4.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/redox_syscall-0.1.37/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/redox_syscall-0.1.37/BUILD
@@ -36,7 +36,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.1.37",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/regex-0.2.6/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/regex-0.2.6/BUILD
@@ -45,7 +45,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/utf8-ranges-1.0.0:utf8_ranges",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.6",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/regex-syntax-0.4.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/regex-syntax-0.4.2/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.4.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/rustc-serialize-0.3.24/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/rustc-serialize-0.3.24/BUILD
@@ -35,7 +35,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.24",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/scopeguard-0.3.3/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/scopeguard-0.3.3/BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.3",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/shred-0.5.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/shred-0.5.2/BUILD
@@ -48,7 +48,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/smallvec-0.4.4:smallvec",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.5.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/shred-derive-0.3.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/shred-derive-0.3.0/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/syn-0.11.11:syn",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/smallvec-0.4.4/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/smallvec-0.4.4/BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.4.4",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/specs-0.10.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/specs-0.10.0/BUILD
@@ -49,7 +49,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/tuple_utils-0.2.0:tuple_utils",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.10.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.10.8/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.10.8/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.0.4:unicode_xid",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.10.8",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.11.11/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.11.11/BUILD
@@ -35,7 +35,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.0.4:unicode_xid",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.11.11",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/synom-0.11.3/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/synom-0.11.3/BUILD
@@ -33,7 +33,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.0.4:unicode_xid",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.11.3",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/thread_local-0.3.5/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/thread_local-0.3.5/BUILD
@@ -35,7 +35,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/unreachable-1.0.0:unreachable",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.5",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/time-0.1.39/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/time-0.1.39/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/libc-0.2.36:libc",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.1.39",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/tuple_utils-0.2.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/tuple_utils-0.2.0/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.0.4/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.0.4/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.0.4",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/unreachable-1.0.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/unreachable-1.0.0/BUILD
@@ -33,7 +33,7 @@ rust_library(
         "//vendored/complicated_cargo_library/cargo/vendor/void-1.0.2:void",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.0.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/utf8-ranges-1.0.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/utf8-ranges-1.0.0/BUILD
@@ -34,7 +34,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.0.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/void-1.0.2/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/void-1.0.2/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.0.2",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-0.3.4/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-0.3.4/BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.4",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.4.0",
     crate_features = [

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.4.0",
     crate_features = [

--- a/examples/vendored/hello_cargo_library/cargo/vendor/cfg-if-0.1.2/BUILD
+++ b/examples/vendored/hello_cargo_library/cargo/vendor/cfg-if-0.1.2/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.1.2",
     crate_features = [

--- a/examples/vendored/hello_cargo_library/cargo/vendor/fern-0.3.5/BUILD
+++ b/examples/vendored/hello_cargo_library/cargo/vendor/fern-0.3.5/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/hello_cargo_library/cargo/vendor/log-0.3.9:log",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.5",
     crate_features = [

--- a/examples/vendored/hello_cargo_library/cargo/vendor/log-0.3.9/BUILD
+++ b/examples/vendored/hello_cargo_library/cargo/vendor/log-0.3.9/BUILD
@@ -33,7 +33,7 @@ rust_library(
         "//vendored/hello_cargo_library/cargo/vendor/log-0.4.1:log",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.9",
     crate_features = [

--- a/examples/vendored/hello_cargo_library/cargo/vendor/log-0.4.1/BUILD
+++ b/examples/vendored/hello_cargo_library/cargo/vendor/log-0.4.1/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/hello_cargo_library/cargo/vendor/cfg-if-0.1.2:cfg_if",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.4.1",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/aho-corasick-0.6.4/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/aho-corasick-0.6.4/BUILD
@@ -36,7 +36,7 @@ rust_binary(
         "//vendored/non_cratesio_library/cargo/vendor/memchr-2.0.1:memchr",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.6.4",
     crate_features = [
@@ -53,7 +53,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/memchr-2.0.1:memchr",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.6.4",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/atty-0.2.8/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/atty-0.2.8/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/libc-0.2.39:libc",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.8",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/cfg-if-0.1.2/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/cfg-if-0.1.2/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.1.2",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/either-1.4.0/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/either-1.4.0/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.4.0",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/env_logger-0.5.5/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/env_logger-0.5.5/BUILD
@@ -42,7 +42,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/termcolor-0.3.5:termcolor",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.5.5",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-0.2.0-alpha/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-0.2.0-alpha/BUILD
@@ -39,7 +39,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/futures-util-0.2.0-alpha:futures_util",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.0-alpha",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-channel-0.2.0-alpha/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-channel-0.2.0-alpha/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/futures-core-0.2.0-alpha:futures_core",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.0-alpha",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-core-0.2.0-alpha/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-core-0.2.0-alpha/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/pin-api-0.1.3:pin_api",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.0-alpha",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-executor-0.2.0-alpha/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-executor-0.2.0-alpha/BUILD
@@ -36,7 +36,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/num_cpus-1.8.0:num_cpus",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.0-alpha",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-io-0.2.0-alpha/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-io-0.2.0-alpha/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/iovec-0.1.2:iovec",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.0-alpha",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-sink-0.2.0-alpha/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-sink-0.2.0-alpha/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/futures-core-0.2.0-alpha:futures_core",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.0-alpha",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-stable-0.2.0-alpha/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-stable-0.2.0-alpha/BUILD
@@ -35,7 +35,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/pin-api-0.1.3:pin_api",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.0-alpha",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-util-0.2.0-alpha/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-util-0.2.0-alpha/BUILD
@@ -38,7 +38,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/futures-sink-0.2.0-alpha:futures_sink",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.0-alpha",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/humantime-1.1.1/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/humantime-1.1.1/BUILD
@@ -35,7 +35,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/quick-error-1.2.1:quick_error",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.1.1",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/iovec-0.1.2/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/iovec-0.1.2/BUILD
@@ -33,7 +33,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/libc-0.2.39:libc",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.1.2",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/lazy_static-1.0.0/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/lazy_static-1.0.0/BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.0.0",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/libc-0.2.39/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/libc-0.2.39/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.39",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.0/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.0/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/cfg-if-0.1.2:cfg_if",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.4.0",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.1/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.1/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/cfg-if-0.1.2:cfg_if",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.4.1",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/memchr-2.0.1/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/memchr-2.0.1/BUILD
@@ -35,7 +35,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/libc-0.2.39:libc",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "2.0.1",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/num_cpus-1.8.0/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/num_cpus-1.8.0/BUILD
@@ -33,7 +33,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/libc-0.2.39:libc",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.8.0",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/pin-api-0.1.3/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/pin-api-0.1.3/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.1.3",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/quick-error-1.2.1/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/quick-error-1.2.1/BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.2.1",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/redox_syscall-0.1.37/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/redox_syscall-0.1.37/BUILD
@@ -36,7 +36,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.1.37",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/redox_termios-0.1.1/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/redox_termios-0.1.1/BUILD
@@ -33,7 +33,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/redox_syscall-0.1.37:redox_syscall",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.1.1",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/regex-0.2.9/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/regex-0.2.9/BUILD
@@ -46,7 +46,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/utf8-ranges-1.0.0:utf8_ranges",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.9",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/regex-syntax-0.5.3/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/regex-syntax-0.5.3/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/ucd-util-0.1.1:ucd_util",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.5.3",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/termcolor-0.3.5/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/termcolor-0.3.5/BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.5",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/termion-1.5.1/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/termion-1.5.1/BUILD
@@ -48,7 +48,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/libc-0.2.39:libc",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.5.1",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/thread_local-0.3.5/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/thread_local-0.3.5/BUILD
@@ -35,7 +35,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/unreachable-1.0.0:unreachable",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.5",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/ucd-util-0.1.1/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/ucd-util-0.1.1/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.1.1",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/unreachable-1.0.0/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/unreachable-1.0.0/BUILD
@@ -33,7 +33,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/void-1.0.2:void",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.0.0",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/utf8-ranges-1.0.0/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/utf8-ranges-1.0.0/BUILD
@@ -34,7 +34,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.0.0",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/void-1.0.2/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/void-1.0.2/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "1.0.2",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/winapi-0.2.8/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/winapi-0.2.8/BUILD
@@ -32,7 +32,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.2.8",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/winapi-0.3.4/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/winapi-0.3.4/BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.3.4",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.4.0",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD
@@ -33,7 +33,7 @@ rust_library(
     deps = [
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.4.0",
     crate_features = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/wincolor-0.1.6/BUILD
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/wincolor-0.1.6/BUILD
@@ -34,7 +34,7 @@ rust_library(
         "//vendored/non_cratesio_library/cargo/vendor/winapi-0.3.4:winapi",
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     version = "0.1.6",
     crate_features = [

--- a/impl/src/templates/partials/build_script.template
+++ b/impl/src/templates/partials/build_script.template
@@ -12,7 +12,7 @@ rust_binary(
       {%- endfor %}
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
     ],
     crate_features = [
       {%- for feature in crate.features %}

--- a/impl/src/templates/partials/rust_binary.template
+++ b/impl/src/templates/partials/rust_binary.template
@@ -16,7 +16,7 @@ rust_binary(
         {%- endfor %}
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         {%- for flag in crate.raze_settings.additional_flags %}
         "{{flag}}",
         {%- endfor %}

--- a/impl/src/templates/partials/rust_library.template
+++ b/impl/src/templates/partials/rust_library.template
@@ -20,7 +20,7 @@ rust_library(
         {%- endfor %}
     ],
     rustc_flags = [
-        "--cap-lints allow",
+        "--cap-lints=allow",
         {%- for flag in crate.raze_settings.additional_flags %}
         "{{flag}}",
         {%- endfor %}


### PR DESCRIPTION
Newer version of rules_rust use ctx.actions.args() quoting that would quote
"--cap-lints allow" as one argument. To be compatible with the new version
use "--cap-lints=allow".

This should fix one part of the issue from bazelbuild/rules_rust#151