### PR TITLE
Remote mode: use Label() and non native git/http.

### DIFF
--- a/impl/src/templates/remote_crates.bzl.template
+++ b/impl/src/templates/remote_crates.bzl.template
@@ -3,14 +3,16 @@ cargo-raze crate workspace functions
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
 def _new_http_archive(name, **kwargs):
     if not native.existing_rule(name):
-        native.new_http_archive(name=name, **kwargs)
+        http_archive(name=name, **kwargs)
 
 def _new_git_repository(name, **kwargs):
     if not native.existing_rule(name):
-        native.new_git_repository(name=name, **kwargs)
+        new_git_repository(name=name, **kwargs)
 
 def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
 {% for crate in crates %}
@@ -19,7 +21,7 @@ def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
         name = "{{workspace.gen_workspace_prefix}}__{{crate.pkg_name | slugify | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}}",
         remote = "{{crate.source_details.git_data.remote}}",
         commit = "{{crate.source_details.git_data.commit}}",
-        build_file = "{{workspace.workspace_path}}/remote:{{crate.pkg_name}}-{{crate.pkg_version}}.BUILD",
+        build_file = Label("{{workspace.workspace_path}}/remote:{{crate.pkg_name}}-{{crate.pkg_version}}.BUILD"),
         init_submodules = True
     )
     {%- else %}
@@ -31,7 +33,7 @@ def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
         sha256 = "{{crate.sha256}}",
         {% endif -%}
         strip_prefix = "{{crate.pkg_name}}-{{crate.pkg_version}}",
-        build_file = "{{workspace.workspace_path}}/remote:{{crate.pkg_name}}-{{crate.pkg_version}}.BUILD"
+        build_file = Label("{{workspace.workspace_path}}/remote:{{crate.pkg_name}}-{{crate.pkg_version}}.BUILD")
     )
     {%- endif %}
 {% endfor %}


### PR DESCRIPTION
* native.new_git_repository is replaced by the skylark
new_git_repository
* native.new_http_archive is replaced by the skylark http_archive
* Surround labels with the Label function so that crate.bzl can be
  used from other repositories.