### PR TITLE
Bump Bazel on Travis to 0.17.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 before_install:
   - OS=linux
   - ARCH=x86_64
-  - V=0.11.1
+  - V=0.17.1
   - GH_BASE="https://github.com/bazelbuild/bazel/releases/download/$V"
   - GH_ARTIFACT="bazel-$V-installer-$OS-$ARCH.sh"
   - URL="$GH_BASE/$GH_ARTIFACT"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ git_repository(
     remote = "https://github.com/bazelbuild/rules_rust.git",
 )
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
-
 rust_repositories()
 ```
 
@@ -239,7 +238,7 @@ new_local_repository(
 ```
 
 In a few cases, the sys crate may need to be overridden entirely. This can be
-facilitated by removing and supplementing dependencies in the Cargo.toml, 
+facilitated by removing and supplementing dependencies in the Cargo.toml,
 pre-generation:
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ WORKSPACE. Here is an example:
 ```python
 git_repository(
     name = "io_bazel_rules_rust",
-    commit = "df95c3e3cd5afd87a69fa71dc9a56a0d0baa7823",
+    commit = "f32695dcd02d9a19e42b9eb7f29a24a8ceb2b858",
     remote = "https://github.com/bazelbuild/rules_rust.git",
 )
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -33,6 +33,15 @@ git_repository(
     remote = "https://github.com/bazelbuild/rules_rust.git",
 )
 
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867",
+    strip_prefix = "bazel-skylib-0.6.0",
+    url = "https://github.com/bazelbuild/bazel-skylib/archive/0.6.0.tar.gz",
+)
+load("@io_bazel_rules_rust//:workspace.bzl", "bazel_version")
+bazel_version(name = "bazel_version")
+
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
 rust_repositories()
 

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -29,7 +29,7 @@ workspace(name = "io_bazel_rules_rust")
 
 git_repository(
     name = "io_bazel_rules_rust",
-    commit = "af9821bf3378b525ec3db0af3b1ca388920a8fb0",
+    commit = "f32695dcd02d9a19e42b9eb7f29a24a8ceb2b858",
     remote = "https://github.com/bazelbuild/rules_rust.git",
 )
 


### PR DESCRIPTION
0.17 is the minimum version supported by rules_rust at this point.

Still unclear why Bazel build failures didn't cause a Travis failure (https://travis-ci.org/google/cargo-raze/builds/477524733). Maybe 0.11 doesn't return a bad exit code during loading phase failures?