### PR TITLE
Fix Broken smoke-test.sh

### DIFF
--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -74,7 +74,8 @@ for ex in $(find $EXAMPLES_DIR -mindepth 2 -maxdepth 2 -type d); do
     bazel_cargo_path="//$ex_type/$ex_name/cargo:all"
 
     echo "Running Bazel build for $bazel_path, $bazel_cargo_path"
-    bazel build "$bazel_path" && bazel build "$bazel_cargo_path"
+    bazel build "$bazel_path"
+    bazel build "$bazel_cargo_path"
 done
 
 cd "$PWD"

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -23,13 +23,18 @@ command_exists "bazel"
 rm -rf "$EXAMPLES_DIR/remote" "$EXAMPLES_DIR/vendored"
 cp -r "$TEST_DIR/remote" "$TEST_DIR/vendored" "$EXAMPLES_DIR"
 
+# Set up root BUILD file
+touch "$EXAMPLES_DIR/BUILD"
+
 # Set up the new WORKSPACE file
 cat > "$EXAMPLES_DIR/WORKSPACE" << EOF
-workspace(name = "io_bazel_rules_rust")
+workspace(name = "examples")
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "io_bazel_rules_rust",
-    commit = "f32695dcd02d9a19e42b9eb7f29a24a8ceb2b858",
+    commit = "5894d35bb7b5f982478dfbf71bc411426fae3451",
     remote = "https://github.com/bazelbuild/rules_rust.git",
 )
 

--- a/smoke_test/vendored/non_cratesio_library/cargo/Cargo.toml
+++ b/smoke_test/vendored/non_cratesio_library/cargo/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Bradlee Speice <bradlee.speice@gmail.com>"]
 
 [dependencies]
 
-futures = { git = "https://github.com/rust-lang-nursery/futures-rs.git", tag = "0.1.19" }
+futures = { git = "https://github.com/rust-lang-nursery/futures-rs.git", tag = "0.2.0" }
 env_logger = { git = "https://github.com/sebasmagri/env_logger.git", tag = "v0.5.5" }
 # Note that we use a (slightly) outdated version of log; because env_logger resolves a version
 # of `log` from crates.io that may clash with the resolution here, we need to force


### PR DESCRIPTION
Related: 
https://github.com/google/cargo-raze/pull/80
https://github.com/google/cargo-raze/pull/81

Waiting on #81 to finish and get submitted.

---

It seems smoke tests were broken in a variety of ways, some of which are really inexplicable:
1) **non_cratesio_library's futures dependency was plainly not compatible with the code.** It was trying to use a version of futures that didn't have functions it needed. CI for the PR that made the most recent changes passed, so perhaps we have some kind of caching issue?
2) **The workspace name for the example workspace was the same as rules_rust.** This apparently confuses Bazel greatly on newer versions of Bazel (but not older ones?)
3) Per the original PR name in smoke-test.sh **`bazel build X && bazel build Y` causes failures in the build of X to not trigger the `set -e` behavior.** 