### PR TITLE
Add dump_metadata bin for quickly producing serialized metadata

### DIFF
--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -13,6 +13,17 @@ A Cargo subcommand to generate Bazel BUILD files
 [badges]
 travis-ci = { repository = "google/cargo-raze", branch = "master" }
 
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "cargo-raze"
+path = "src/bin/cargo-raze.rs"
+
+[[bin]]
+name = "dump_metadata"
+path = "src/bin/dump_metadata.rs"
+
 [dependencies]
 failure = "0.1.5"
 docopt = "1.0.2"

--- a/impl/src/bin/cargo-raze.rs
+++ b/impl/src/bin/cargo-raze.rs
@@ -11,7 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
+extern crate cargo_raze;
 extern crate cargo;
 extern crate itertools;
 extern crate serde;
@@ -29,14 +31,14 @@ extern crate failure;
 #[macro_use]
 extern crate hamcrest;
 
-mod bazel;
-mod context;
-mod license;
-mod metadata;
-mod planning;
-mod rendering;
-mod settings;
-mod util;
+use cargo_raze::bazel;
+use cargo_raze::context;
+use cargo_raze::license;
+use cargo_raze::metadata;
+use cargo_raze::planning;
+use cargo_raze::rendering;
+use cargo_raze::settings;
+use cargo_raze::util;
 
 use bazel::BazelRenderer;
 use cargo::CargoError;

--- a/impl/src/bin/cargo-raze.rs
+++ b/impl/src/bin/cargo-raze.rs
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 extern crate cargo_raze;
 extern crate cargo;
@@ -32,8 +31,6 @@ extern crate failure;
 extern crate hamcrest;
 
 use cargo_raze::bazel;
-use cargo_raze::context;
-use cargo_raze::license;
 use cargo_raze::metadata;
 use cargo_raze::planning;
 use cargo_raze::rendering;
@@ -54,7 +51,6 @@ use rendering::FileOutputs;
 use rendering::RenderDetails;
 use settings::GenMode;
 use settings::RazeSettings;
-use std::env;
 use std::fs::File;
 use std::fs;
 use std::io::Read;

--- a/impl/src/bin/dump_metadata.rs
+++ b/impl/src/bin/dump_metadata.rs
@@ -1,0 +1,166 @@
+extern crate cargo;
+extern crate cargo_raze;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+extern crate tempdir;
+extern crate docopt;
+extern crate failure;
+
+use docopt::Docopt;
+use std::env;
+use std::path::PathBuf;
+use std::string::ToString;
+use std::fs::File;
+use std::io::Write;
+use std::fmt;
+use std::error::Error as StdError;
+use cargo::CliResult;
+use cargo::CargoError;
+use cargo::util::CargoResult;
+use cargo::util::Config;
+
+use cargo_raze::metadata::MetadataFetcher;
+use cargo_raze::metadata::CargoWorkspaceFiles;
+use cargo_raze::metadata::Metadata;
+use cargo_raze::metadata::CargoSubcommandMetadataFetcher;
+use cargo_raze::metadata::CargoInternalsMetadataFetcher;
+
+#[derive(Debug)]
+struct DumpError(String);
+
+#[derive(Debug, Deserialize)]
+struct Options {
+  arg_path_to_toml: String,
+  flag_noinfer_lock_file: Option<bool>,
+  flag_output_file: Option<String>,
+  flag_pretty_print: bool,
+}
+
+#[derive(Debug)]
+struct ValidatedOptions {
+  path_to_toml: String,
+  infer_lock_file: bool,
+  pretty_print: bool,
+  output_file_opt: Option<String>,
+}
+
+const USAGE: &'static str = r#"
+Loads and serializes metadata for a provided Cargo.toml
+
+Usage:
+    dump_metadata <path-to-toml> [options]
+
+Options:
+    -h, --help                  Print this message
+    --noinfer-lock-file         Disable inferring lock file from toml path
+    --pretty-print              Whether or not to pretty-print the output
+    --output-file=<path>        A filepath to print the generated output to
+"#;
+
+impl StdError for DumpError {}
+impl fmt::Display for DumpError {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "dump_metadata failed with cause: \"{}\"", self.0)
+  }
+}
+
+fn validate_opts(options: &Options) -> Result<ValidatedOptions, String> {
+  let mut infer_lock_file = true;
+  if options.flag_noinfer_lock_file.is_some() {
+    infer_lock_file = !options.flag_noinfer_lock_file.unwrap() // CHECKED above
+  }
+
+  Ok(ValidatedOptions {
+    path_to_toml: options.arg_path_to_toml.clone(),
+    infer_lock_file: infer_lock_file,
+    pretty_print: options.flag_pretty_print.clone(),
+    output_file_opt: options.flag_output_file.clone()
+  })
+}
+
+fn find_workspace_files(options: &ValidatedOptions) -> CargoResult<CargoWorkspaceFiles> {
+  let opt_toml_path = PathBuf::from(&options.path_to_toml);
+
+  // Find abs path to toml
+  let abs_toml_path = if opt_toml_path.is_absolute() {
+    opt_toml_path
+  } else {
+    env::current_dir()
+      .map_err(|e| CargoError::from(DumpError(e.to_string())))?
+      .join(opt_toml_path)
+  };
+
+  // Verify that toml file exists
+  {
+    File::open(&abs_toml_path).map_err(|e| {
+      CargoError::from(DumpError(format!("opening {:?}: {}", abs_toml_path, e.to_string())))
+    })?;
+  }
+
+  // Try to find an associated lock file
+  let mut abs_lock_path_opt = None;
+  if options.infer_lock_file {
+    let expected_abs_lock_path =
+      abs_toml_path
+        .parent()
+        .unwrap() // CHECKED: Toml must live in a dir
+        .join("Cargo.lock");
+
+    if File::open(&abs_toml_path).is_ok() {
+      abs_lock_path_opt = Some(expected_abs_lock_path);
+    }
+  }
+
+  Ok(CargoWorkspaceFiles {
+    toml_path: abs_toml_path,
+    lock_path_opt: abs_lock_path_opt,
+  })
+}
+
+fn dump_metadata(options: ValidatedOptions, cargo_config: &mut Config) -> CargoResult<()> {
+  let workspace_files = find_workspace_files(&options)?;
+
+  let mut metadata_fetcher = CargoInternalsMetadataFetcher::new(&cargo_config);
+  let metadata = metadata_fetcher.fetch_metadata(workspace_files)?;
+  let output_text = if options.pretty_print {
+    serde_json::to_string_pretty(&metadata)?
+  } else {
+    serde_json::to_string(&metadata)?
+  };
+
+  if options.output_file_opt.is_none() {
+    println!("{}", output_text)
+  } else {
+    let output_file_path = options.output_file_opt.unwrap(); // CHECKED above
+    let mut file_out = File::create(&output_file_path)?;
+    file_out.write_all(output_text.as_bytes())?;
+  }
+
+  Ok(())
+}
+
+
+fn real_main(validated_opts: ValidatedOptions, cargo_config: &mut Config) -> CliResult {
+  dump_metadata(validated_opts, cargo_config)?;
+
+  Ok(())
+}
+
+fn main() {
+  let mut config = Config::default().unwrap();
+
+  let opts: Options = Docopt::new(USAGE)
+    .and_then(|d| d.deserialize())
+    .unwrap_or_else(|e| e.exit());
+
+  let validated_opts = validate_opts(&opts).unwrap();
+
+  let result = real_main(validated_opts, &mut config);
+
+  if let Err(e) = result {
+    cargo::exit_with_error(e, &mut *config.shell());
+  }
+}
+

--- a/impl/src/bin/dump_metadata.rs
+++ b/impl/src/bin/dump_metadata.rs
@@ -37,8 +37,6 @@ use cargo::util::Config;
 
 use cargo_raze::metadata::MetadataFetcher;
 use cargo_raze::metadata::CargoWorkspaceFiles;
-use cargo_raze::metadata::Metadata;
-use cargo_raze::metadata::CargoSubcommandMetadataFetcher;
 use cargo_raze::metadata::CargoInternalsMetadataFetcher;
 
 #[derive(Debug)]

--- a/impl/src/bin/dump_metadata.rs
+++ b/impl/src/bin/dump_metadata.rs
@@ -1,3 +1,17 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 extern crate cargo;
 extern crate cargo_raze;
 extern crate serde;

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -1,0 +1,39 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate cargo;
+extern crate itertools;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+extern crate slug;
+extern crate tempdir;
+extern crate tera;
+extern crate toml;
+extern crate docopt;
+extern crate failure;
+
+#[cfg(test)]
+#[macro_use]
+extern crate hamcrest;
+
+pub mod bazel;
+pub mod context;
+pub mod license;
+pub mod metadata;
+pub mod planning;
+pub mod rendering;
+pub mod settings;
+pub mod util;

--- a/impl/src/metadata.rs
+++ b/impl/src/metadata.rs
@@ -59,7 +59,7 @@ pub struct CargoWorkspaceFiles {
  * own "ExportInfo":
  * https://github.com/rust-lang/cargo/blob/9c78c3a17ac4bc0c8b3b837095f60aa84d09c426/src/cargo/ops/cargo_output_metadata.rs#L78-L85
  */
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Metadata {
   pub packages: Vec<Package>,
   pub resolve: Resolve,
@@ -75,7 +75,7 @@ pub struct Metadata {
  * own "SerializedPackage":
  * https://github.com/rust-lang/cargo/blob/9c78c3a17ac4bc0c8b3b837095f60aa84d09c426/src/cargo/core/package.rs#L32-L50
  */
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Package {
   pub name: String,
   pub version: String,
@@ -99,7 +99,7 @@ pub struct Package {
  * own "SerializedDependency":
  * https://github.com/rust-lang/cargo/blob/75ec2d3a8d045f90792b3ce5d7050cad43bfb3bf/src/cargo/core/dependency.rs#L49-L60
  */
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Dependency {
   pub name: String,
   pub source: String,
@@ -119,7 +119,7 @@ pub struct Dependency {
  * own "SerializedTarget":
  * https://github.com/rust-lang/cargo/blob/c24a09772c2c1cb315970dbc721f2a42d4515f21/src/cargo/core/manifest.rs#L188-L197
  */
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Target {
   pub name: String,
   pub kind: Vec<String>,
@@ -135,7 +135,7 @@ pub struct Target {
  * own "MetadataResolve":
  * https://github.com/rust-lang/cargo/blob/9c78c3a17ac4bc0c8b3b837095f60aa84d09c426/src/cargo/ops/cargo_output_metadata.rs#L91-L95
  */
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Resolve {
   pub nodes: Vec<ResolveNode>,
   pub root: PackageId,
@@ -148,7 +148,7 @@ pub struct Resolve {
  * own "Node":
  * https://github.com/rust-lang/cargo/blob/9c78c3a17ac4bc0c8b3b837095f60aa84d09c426/src/cargo/ops/cargo_output_metadata.rs#L102-L106
  */
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ResolveNode {
   pub id: PackageId,
   pub dependencies: Vec<PackageId>,


### PR DESCRIPTION
The docopt for this new binary
```
Loads and serializes metadata for a provided Cargo.toml
 Usage:
    dump_metadata <path-to-toml> [options]
 Options:
    -h, --help                  Print this message
    --noinfer-lock-file         Disable inferring lock file from toml path
    --pretty-print              Whether or not to pretty-print the output
    --output-file=<path>        A filepath to print the generated output to
```

This PR adds a new bin to sit alongside the base "cargo-raze" bin. This binary generates metadata of the form that cargo-raze itself generates, and should be useful to help understand Cargo.toml files as cargo-raze understands them.

The binary is not intended to be used by end users. This PR adds a "cargo-raze" library to support the cargo-raze binary and this new dump_metadata binary, but the library is not intended to be general purpose. Users who depend on cargo-raze as a library do so at their own peril.

This PR was made to support understanding the `ripgrep` case in https://github.com/google/cargo-raze/issues/83