### PR TITLE
Support binary dependencies that do not have associated libs

### DIFF
--- a/impl/src/bazel.rs
+++ b/impl/src/bazel.rs
@@ -301,6 +301,7 @@ mod tests {
       build_script_target: None,
       source_details: SourceDetails { git_data: None },
       sha256: None,
+      lib_target_name: None,
     }
   }
 
@@ -329,6 +330,7 @@ mod tests {
       build_script_target: None,
       source_details: SourceDetails { git_data: None },
       sha256: None,
+      lib_target_name: Some("test_library".to_owned()),
     }
   }
 

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -76,8 +76,9 @@ pub struct CrateContext {
   // I'm punting on this now because this requires a more serious look at the renderer code.
   pub expected_build_path: String,
 
-  // Does this crate contain a lib target with the same name as the crate?
-  pub has_eponymous_lib: bool,
+  // The name of the main lib target for this crate (if present).
+  // Currently only one such lib can exist per crate.
+  pub lib_target_name: Option<String>
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -76,7 +76,7 @@ pub struct CrateContext {
   // I'm punting on this now because this requires a more serious look at the renderer code.
   pub expected_build_path: String,
 
-  // Does this crate have a lib with the same name?
+  // Does this crate contain a lib target with the same name as the crate?
   pub has_eponymous_lib: bool,
 }
 

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -75,6 +75,9 @@ pub struct CrateContext {
   //
   // I'm punting on this now because this requires a more serious look at the renderer code.
   pub expected_build_path: String,
+
+  // Does this crate have a lib with the same name?
+  pub has_eponymous_lib: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -407,7 +407,8 @@ impl<'planner> CrateSubplanner<'planner> {
     {
       for target in &targets {
         if target.name == package.name {
-          has_eponymous_lib = true
+          has_eponymous_lib = true;
+          break;
         }
       }
     }

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -403,6 +403,14 @@ impl<'planner> CrateSubplanner<'planner> {
     let build_script_target_opt = self.take_build_script_target(&mut targets);
 
     let package = self.crate_catalog_entry.package();
+    let mut has_eponymous_lib = false;
+    {
+      for target in &targets {
+        if target.name == package.name {
+          has_eponymous_lib = true
+        }
+      }
+    }
     Ok(CrateContext {
       pkg_name: package.name.clone(),
       pkg_version: package.version.clone(),
@@ -424,6 +432,7 @@ impl<'planner> CrateSubplanner<'planner> {
         .crate_catalog_entry
         .local_build_path(&self.settings),
       sha256: package.sha256.clone(),
+      has_eponymous_lib: has_eponymous_lib,
     })
   }
 

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -403,11 +403,11 @@ impl<'planner> CrateSubplanner<'planner> {
     let build_script_target_opt = self.take_build_script_target(&mut targets);
 
     let package = self.crate_catalog_entry.package();
-    let mut has_eponymous_lib = false;
+    let mut lib_target_name = None;
     {
       for target in &targets {
-        if target.name == package.name {
-          has_eponymous_lib = true;
+        if target.kind == "lib" {
+          lib_target_name = Some(target.name.clone());
           break;
         }
       }
@@ -433,7 +433,7 @@ impl<'planner> CrateSubplanner<'planner> {
         .crate_catalog_entry
         .local_build_path(&self.settings),
       sha256: package.sha256.clone(),
-      has_eponymous_lib: has_eponymous_lib,
+      lib_target_name: lib_target_name,
     })
   }
 

--- a/impl/src/templates/partials/rust_binary.template
+++ b/impl/src/templates/partials/rust_binary.template
@@ -7,9 +7,9 @@ rust_binary(
     edition = "{{ target.edition }}",
     srcs = glob(["**/*.rs"]),
     deps = [
-        {%- if crate.has_eponymous_lib %}
+        {%- if crate.lib_target_name %}
         # Binaries get an implicit dependency on their crate's lib
-        ":{{crate.pkg_name | replace(from="-", to="_") }}",
+        ":{{crate.lib_target_name}}",
         {%- endif %}
         {%- for dependency in crate.dependencies %}
         "{{dependency.buildable_target}}",

--- a/impl/src/templates/partials/rust_binary.template
+++ b/impl/src/templates/partials/rust_binary.template
@@ -7,8 +7,10 @@ rust_binary(
     edition = "{{ target.edition }}",
     srcs = glob(["**/*.rs"]),
     deps = [
-        # Binaries get an implicit dependency on their lib
+        {%- if crate.has_eponymous_lib %}
+        # Binaries get an implicit dependency on their crate's lib
         ":{{crate.pkg_name | replace(from="-", to="_") }}",
+        {%- endif %}
         {%- for dependency in crate.dependencies %}
         "{{dependency.buildable_target}}",
         {%- endfor %}

--- a/impl/src/templates/workspace.BUILD.template
+++ b/impl/src/templates/workspace.BUILD.template
@@ -10,7 +10,7 @@ licenses([
 ])
 
 {%- for crate in crates %}
-{%- if crate.is_root_dependency %}
+{%- if crate.is_root_dependency and crate.lib_target_name %}
 {%- set crate_name_sanitized = crate.pkg_name | replace(from="-", to="_") %}
 alias(
     name = "{{crate_name_sanitized}}",


### PR DESCRIPTION
This PR also fixes an outstanding issue where multi-(output-)target crates whose lib target was not named after the crate would have the wrong lib dependency declared.

Also now omits root deps from alias BUILD file if the dep does not have a lib.

Fixes https://github.com/google/cargo-raze/issues/83