### PR TITLE
Remove requirement for lib in crate for adding aliases

### DIFF
--- a/impl/src/templates/workspace.BUILD.template
+++ b/impl/src/templates/workspace.BUILD.template
@@ -10,7 +10,7 @@ licenses([
 ])
 
 {%- for crate in crates %}
-{%- if crate.is_root_dependency and crate.lib_target_name %}
+{%- if crate.is_root_dependency %}
 {%- set crate_name_sanitized = crate.pkg_name | replace(from="-", to="_") %}
 alias(
     name = "{{crate_name_sanitized}}",


### PR DESCRIPTION
I'm not sure why I originally added this constraint, but I'll remove it and see if CI accepts it.

cc @mfarrugi
https://github.com/google/cargo-raze/issues/89