### PR TITLE
[settings] Add output_buildfile_suffix option

### DIFF
--- a/impl/src/rendering.rs
+++ b/impl/src/rendering.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use cargo::util::CargoResult;
+
 use planning::PlannedBuild;
 
 /**
@@ -41,4 +42,5 @@ pub struct FileOutputs {
 #[derive(Debug, Clone)]
 pub struct RenderDetails {
   pub path_prefix: String,
+  pub buildfile_suffix: String,
 }

--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -61,6 +61,13 @@ pub struct RazeSettings {
   /** How to generate the dependencies. See GenMode for details. */
   #[serde(default = "default_raze_settings_field_genmode")]
   pub genmode: GenMode,
+
+  /**
+    * Suffix for generated build files, uses whole value for Vendored mode
+    * Default: BUILD
+    */
+  #[serde(default = "default_raze_settings_field_output_buildfile_suffix")]
+  pub output_buildfile_suffix: String,
 }
 
 /** Override settings for individual crates (as part of RazeSettings). */
@@ -159,6 +166,7 @@ pub mod testing {
       crates: HashMap::new(),
       gen_workspace_prefix: "raze_test".to_owned(),
       genmode: GenMode::Remote,
+      output_buildfile_suffix: "BUILD".to_owned(),
     }
   }
 }
@@ -173,6 +181,10 @@ fn default_raze_settings_field_gen_workspace_prefix() -> String {
 
 fn default_raze_settings_field_genmode() -> GenMode {
   GenMode::Vendored
+}
+
+fn default_raze_settings_field_output_buildfile_suffix() -> String {
+  "BUILD".to_owned()
 }
 
 fn default_crate_settings_field_gen_buildrs() -> bool {

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -38,6 +38,7 @@ git_repository(
     remote = "https://github.com/bazelbuild/rules_rust.git",
 )
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "bazel_skylib",
     sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867",

--- a/smoke_test/vendored/hello_cargo_library/cargo/Cargo.toml
+++ b/smoke_test/vendored/hello_cargo_library/cargo/Cargo.toml
@@ -13,3 +13,4 @@ path = "fake_lib.rs"
 [raze]
 workspace_path = "//vendored/hello_cargo_library/cargo"
 target = "x86_64-unknown-linux-gnu"
+output_buildfile_suffix = "BUILD.bazel"


### PR DESCRIPTION
Related issue: #92 

Default is BUILD
Other values can be for example: BUILD.bazel
Any value is accepted.

This is to follow the default behaviour of other bazel related tools
that generate BUILD.bazel instead of BUILD firstly to separate
what is generated and what is written and to avoid name collisions on
case insensitive file systems (Windows + WSL) since some crates can
have a directory named build which leads to cargo-raze unable to create
a file called BUILD. A project having a directory named BUILD.bazel is
much less likely or less to none chance.

How to use (example):
Add following to the `Cargo.toml` file
```
[raze]
output_buildfile_suffix = "BUILD.bazel"
```

I am still very new to Rust, and may have written something not idiomatic at all, and would appreciate any advice to make it better.

EDIT:
This PR initially added a `GenMode` called VendoredBuildBazel but upon feedback changed to another option called `output_buildfile_suffix` to ensure greater control and compatibility with all `GenMode`s