### PR TITLE
Support cargo-raze into "//"

### DIFF
--- a/impl/src/bin/cargo-raze.rs
+++ b/impl/src/bin/cargo-raze.rs
@@ -170,16 +170,7 @@ fn validate_settings(settings: &mut RazeSettings) -> CargoResult<()> {
     }));
   }
 
-  if settings.workspace_path == "//" {
-    return Err(CargoError::from(RazeError::Config {
-          field_path_opt: Some("raze.workspace_path".to_owned()),
-          message: format!("Path must must not be '//' (it is currently unsupported). \
-                            Its probably not what you want anyway, as this would vendor the \
-                            crates directly into //vendor.")
-    }));
-  }
-
-  if settings.workspace_path.ends_with("/") {
+  if settings.workspace_path != "//" && settings.workspace_path.ends_with("/") {
     settings.workspace_path.pop();
   }
 

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -207,10 +207,14 @@ impl CrateCatalogEntry {
         "@{}__{}__{}//",
         &settings.gen_workspace_prefix, &self.sanitized_name, &self.sanitized_version
       ),
-      GenMode::Vendored => format!(
-        "{}/vendor/{}",
-        &settings.workspace_path, &self.package_ident
-      ),
+      GenMode::Vendored => {
+        // Convert "settings.workspace_path" to dir. Workspace roots are special cased, no need to append /
+        if settings.workspace_path.ends_with("//") {
+          format!("{}vendor/{}", settings.workspace_path, &self.package_ident)
+        } else {
+          format!("{}/vendor/{}", settings.workspace_path, &self.package_ident)
+        }
+      },
     }
   }
 
@@ -224,10 +228,14 @@ impl CrateCatalogEntry {
         &self.sanitized_version,
         &self.sanitized_name
       ),
-      GenMode::Vendored => format!(
-        "{}/vendor/{}:{}",
-        &settings.workspace_path, &self.package_ident, &self.sanitized_name
-      ),
+      GenMode::Vendored => {
+       // Convert "settings.workspace_path" to dir. Workspace roots are special cased, no need to append /
+        if settings.workspace_path.ends_with("//") {
+          format!("{}vendor/{}:{}", settings.workspace_path, &self.package_ident, &self.sanitized_name)
+        } else {
+          format!("{}/vendor/{}:{}", settings.workspace_path, &self.package_ident, &self.sanitized_name)
+        }
+      },
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/google/cargo-raze/issues/42

In supporting "vendor into workspace root", there are two options. Fix the handling of bazel paths by introducing a Label type, implementing deserialization of labels and a Path api on them. **OR**, handle the corner case.

This PR does the latter. This is a perpetuation of terrible stringly typed label nonsense that was also observed earlier today in [this comment](https://github.com/google/cargo-raze/pull/94#issuecomment-487251750) on https://github.com/google/cargo-raze/pull/94. I need to introduce real types for these labels and identifiers instead of just juggling strings. 

I also need to refactor raze itself to better support tests. This change is *also* hard to test. Bonus difficulty: a smoke test can't even test this because smoke tests vendor into a common workspace, not rooted in their dir. Good stuff. I tested this locally with the following procedure:

```
$ mkdir /tmp/example
$ cat << 'EOF' >> /tmp/example/Cargo.toml
[package]
name = "example"
version = "0.1.0"

[dependencies]
security-framework-sys = "0.3.1"

[lib]
path = "fake_lib.rs"

[raze]
workspace_path = "//"
EOF
$ cat << 'EOF' >> /tmp/example/WORKSPACE
workspace(name = "examples")

load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")

git_repository(
    name = "io_bazel_rules_rust",
    commit = "5894d35bb7b5f982478dfbf71bc411426fae3451",
    remote = "https://github.com/bazelbuild/rules_rust.git",
)

load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

http_archive(
    name = "bazel_skylib",
    sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867",
    strip_prefix = "bazel-skylib-0.6.0",
    url = "https://github.com/bazelbuild/bazel-skylib/archive/0.6.0.tar.gz",
)

load("@io_bazel_rules_rust//:workspace.bzl", "bazel_version")

bazel_version(name = "bazel_version")

load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")

rust_repositories()
EOF
$ $(cd /tmp/example && cargo vendor -x -q && cargo raze && bazel build //vendor/...)
```