### PR TITLE
Ignore workspace crates when doing crate planning and vendor validation

### DIFF
--- a/impl/src/util.rs
+++ b/impl/src/util.rs
@@ -23,9 +23,6 @@ use cargo::CargoError;
 use cargo::core::TargetKind;
 use cargo::util::CargoResult;
 use cargo::util::Cfg;
-use failure::Context;
-use failure::Error;
-use failure::Fail;
 use slug;
 
 pub const PLEASE_FILE_A_BUG: &'static str =


### PR DESCRIPTION
Fixes https://github.com/google/cargo-raze/issues/111

Does not add any BUILD generation for workspace crates. This is a sensible next step if there are opinions about where those files should land.