### PR TITLE
[Planning] Allow proc-macros to export (#119)

### DIFF
--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -442,7 +442,7 @@ impl<'planner> CrateSubplanner<'planner> {
     let mut lib_target_name = None;
     {
       for target in &targets {
-        if target.kind == "lib" {
+        if target.kind == "lib" || target.kind == "proc-macro" {
           lib_target_name = Some(target.name.clone());
           break;
         }


### PR DESCRIPTION
This is a minor fix for #119, rather than edit the template (which seems to get fixed and unfixed) we allow the lib to be a proc-macro as well as an rlib