### PR TITLE
Semver matching

### DIFF
--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -35,7 +35,7 @@ glob = "0.3.0"
 itertools = "0.9.0"
 log = "0.4.11"
 rustc-serialize = "0.3.24"
-semver = "0.11.0"
+semver = { version = "0.11.0", features = ["serde"] }
 serde = "1.0.117"
 serde_derive = "1.0.117"
 slug = "0.1.4"

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -14,6 +14,7 @@
 
 use crate::settings::CrateSettings;
 use serde::Serialize;
+use semver::Version;
 
 /** A struct containing information about a crate's dependency that's buildable in Bazel
  *
@@ -24,7 +25,7 @@ use serde::Serialize;
 pub struct BuildableDependency {
   pub buildable_target: String,
   pub name: String,
-  pub version: String,
+  pub version: Version,
   pub is_proc_macro: bool,
 }
 
@@ -47,7 +48,7 @@ pub struct BuildableTarget {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct Metadep {
   pub name: String,
-  pub min_version: String,
+  pub min_version: Version,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
@@ -100,7 +101,7 @@ pub struct CrateTargetedDepContext {
 #[derive(Debug, Clone, Serialize)]
 pub struct CrateContext {
   pub pkg_name: String,
-  pub pkg_version: String,
+  pub pkg_version: Version,
   pub edition: String,
   pub raze_settings: CrateSettings,
   pub default_deps: CrateDependencyContext,

--- a/impl/src/rendering/bazel.rs
+++ b/impl/src/rendering/bazel.rs
@@ -323,6 +323,8 @@ impl BuildRenderer for BazelRenderer {
 mod tests {
   use hamcrest2::{core::expect, prelude::*};
 
+  use semver::Version;
+
   use crate::{
     context::*,
     metadata::CargoWorkspaceFiles,
@@ -357,7 +359,7 @@ mod tests {
   fn dummy_binary_crate_with_name(buildfile_suffix: &str) -> CrateContext {
     CrateContext {
       pkg_name: "test-binary".to_owned(),
-      pkg_version: "1.1.1".to_owned(),
+      pkg_version: Version::parse("1.1.1").unwrap(),
       edition: "2015".to_owned(),
       features: vec!["feature1".to_owned(), "feature2".to_owned()].to_owned(),
       expected_build_path: format!("vendor/test-binary-1.1.1/{}", buildfile_suffix),
@@ -397,7 +399,7 @@ mod tests {
   fn dummy_library_crate_with_name(buildfile_suffix: &str) -> CrateContext {
     CrateContext {
       pkg_name: "test-library".to_owned(),
-      pkg_version: "1.1.1".to_owned(),
+      pkg_version: Version::parse("1.1.1").unwrap(),
       edition: "2015".to_owned(),
       license: LicenseData::default(),
       raze_settings: CrateSettings::default(),

--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 use crate::error::RazeError;
-use semver::Version;
+use semver::VersionReq;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fs::File, io::Read, path::Path};
 
-pub type CrateSettingsPerVersion = HashMap<Version, CrateSettings>;
+pub type CrateSettingsPerVersion = HashMap<VersionReq, CrateSettings>;
 
 /**
  * A "deserializable struct" for the whole Cargo.toml


### PR DESCRIPTION
This is a little WIP, as we / I need to add unit and integration tests for this.

In reworking #123 a little, to allow for aliases to be presented in the "root" raze crate and to avoid a problem with crates presenting multiple versions of aliases I added in _basic_ support for using the semver library to do matches for alias determination.

It occured to me, that rather than _just_ use semver in that one specific place we should expose the richness of the semver objects into raze more generally. As such this commit exposes semver to raze and allows it to use semver for both version details and in matching configuration settings.

# Semver Matching
Raze settings come in the form of a [TOML] section like so

```toml
[raze.crates.some-crate.'1.2.3']
some_new_setting = true
```

Where the version number (in the above example `1.2.3`) is a literal, hardcoded
value.

This works but is a little inflexible for dependencies, _especially_
dependencies that are transiant and update a lot (for instance `syn`).

Since Cargo follows [Semver] we can use this fact, along with the richness of
the exported and serialisable `semver::Version` types to perform section
matching with [Semver] in the same fashion as Cargo itself.

This means that the above example can be written with semver expressions, for
example it can be written as:

```toml
[raze.crates.some-crate.'1.2.*']
some_new_setting = true

[raze.crates.some-crate.'~1.2.3']
some_new_setting = true

[raze.crates.some-crate.'^1.2.3']
some_new_setting = true

[raze.crates.some-crate.'=1.6.6']
some_new_setting = true
```

_Note_: Bare versions follow the semantics _as if they had_ specified a `^`,
which is in keeping with [Cargo semver semantics] but is distinct from previous
behaviour of raze (in which these would be interpreted as exacting or `=`).

This is deliberate as we should aim to mirror the semantics of cargo as much as
possible to avoid confusion.

We presently do not allow for multiple matches in raze settings, this is
intentional and is presented to the end user as an error.

[TOML]: https://github.com/toml-lang/toml
[Semver]: https://semver.org/spec/v2.0.0.html
[Cargo semver semantics]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio