### PR TITLE
Fix incorrect package source id String in CargoInternalsMetadataFetcher

### DIFF
--- a/impl/src/metadata.rs
+++ b/impl/src/metadata.rs
@@ -343,8 +343,7 @@ impl<'config> MetadataFetcher for CargoInternalsMetadataFetcher<'config> {
           })
           .collect();
 
-        // UNWRAP: It's cargo's responsibility to ensure a serializable source_id
-        let pkg_source = serde_json::to_string(&package_id.source_id()).unwrap();
+        let pkg_source = package_id.source_id().into_url().to_string();
 
         // Cargo use SHA256 for checksum so we can use them directly
         let sha256 = package


### PR DESCRIPTION
This addresses the panic described in https://github.com/google/cargo-raze/issues/139#issuecomment-594678552.