### PR TITLE
Allow customizing generated BUILD files

### DIFF
--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -181,6 +181,16 @@ pub struct CrateSettings {
    */
   #[serde(default)]
   pub patches: Vec<String>,
+
+  /**
+   * Path to a file to be included as part of the generated BUILD file.
+   *
+   * For example, some crates include non-Rust code typically built through a build.rs script. They
+   * can be made compatible by manually writing appropriate Bazel targets, and including them into
+   * the crate through a combination of additional_build_file and additional_deps.
+   */
+  #[serde(default)]
+  pub additional_build_file: Option<String>,
 }
 
 /**
@@ -215,6 +225,7 @@ impl Default for CrateSettings {
       patch_cmds_win: Vec::new(),
       patch_tool: None,
       patches: Vec::new(),
+      additional_build_file: None,
     }
   }
 }

--- a/impl/src/templates/partials/remote_crates_patch.template
+++ b/impl/src/templates/partials/remote_crates_patch.template
@@ -1,31 +1,31 @@
 {%- if crate.raze_settings.patches %}
-    patches = [
-        {% for patch in crate.raze_settings.patches -%}
-        "{{patch}}",
-        {%- endfor %}
-    ],
+        patches = [
+            {% for patch in crate.raze_settings.patches -%}
+            "{{patch}}",
+            {%- endfor %}
+        ],
 {%- endif %}
 {%- if crate.raze_settings.patch_args %}
-    patch_args = [
-        {% for patch_arg in crate.raze_settings.patch_args -%}
-        "{{patch_arg}}",
-        {%- endfor %}
-    ],
+        patch_args = [
+            {% for patch_arg in crate.raze_settings.patch_args -%}
+            "{{patch_arg}}",
+            {%- endfor %}
+        ],
 {%- endif %}
 {%- if crate.raze_settings.patch_cmds %}
-    patch_cmds = [
-        {% for patch_cmd in crate.raze_settings.patch_cmds -%}
-        "{{patch_cmd}}",
-        {%- endfor %}
-    ],
+        patch_cmds = [
+            {% for patch_cmd in crate.raze_settings.patch_cmds -%}
+            "{{patch_cmd}}",
+            {%- endfor %}
+        ],
 {%- endif %}
 {%- if crate.raze_settings.patch_cmds_win %}
-    patch_cmds_win = [
-        {% for patch_cmd in crate.raze_settings.patch_cmds_win -%}
-        "{{patch_cmd}}",
-        {%- endfor %}
-    ],
+        patch_cmds_win = [
+            {% for patch_cmd in crate.raze_settings.patch_cmds_win -%}
+            "{{patch_cmd}}",
+            {%- endfor %}
+        ],
 {%- endif %}
 {%- if crate.raze_settings.patch_tool %}
-    patch_tool = "{{crate.raze_settings.patch_tool}}",
-{%- endif %}
+        patch_tool = "{{crate.raze_settings.patch_tool}}",
+{%- endif -%}

--- a/impl/src/templates/remote_crates.bzl.template
+++ b/impl/src/templates/remote_crates.bzl.template
@@ -23,7 +23,7 @@ def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
         commit = "{{crate.source_details.git_data.commit}}",
         build_file = Label("{{workspace.workspace_path}}/remote:{{crate.pkg_name}}-{{crate.pkg_version}}.{{workspace.output_buildfile_suffix}}"),
         init_submodules = True,
-        {%- include "templates/partials/remote_crates_patch.template" -%}
+        {%- include "templates/partials/remote_crates_patch.template" %}
     )
     {%- else %}
     _new_http_archive(

--- a/smoke_test/remote/complicated_cargo_library/BUILD
+++ b/smoke_test/remote/complicated_cargo_library/BUILD
@@ -4,6 +4,7 @@ rust_binary(
     name = "complicated_cargo_library",
     srcs = ["src/main.rs"],
     deps = [
+        "//remote/complicated_cargo_library/cargo:libloading",
         "//remote/complicated_cargo_library/cargo:regex",
         "//remote/complicated_cargo_library/cargo:specs",
     ],

--- a/smoke_test/remote/complicated_cargo_library/cargo/Cargo.toml
+++ b/smoke_test/remote/complicated_cargo_library/cargo/Cargo.toml
@@ -6,8 +6,11 @@ version = "0.1.0"
 path = "fake_lib.rs"
 
 [dependencies]
-regex = "0.2.5"
-specs = "0.10.0"
+# Newer versions of libloading don't depend on C code anymore, so we're using an older version to
+# test additional_build_file.
+libloading = "=0.5.2"
+regex = "=0.2.5"
+specs = "=0.10.0"
 security-framework-sys = "0.2.2"
 
 [raze]
@@ -22,6 +25,10 @@ additional_flags = [
     "--cfg=use_proc_macro",
 ]
 
+[raze.crates.libloading.'0.5.2']
+additional_deps = [":global_static"]
+additional_build_file = "libloading_global_static.BUILD"
+
 [raze.crates.regex.'0.2.5']
 skipped_deps = [
   # This will break the regex crate
@@ -29,7 +36,7 @@ skipped_deps = [
 ]
 additional_deps = [
   # Add an unused dep
-  "@complicated__specs__0_10_0//:specs"
+  "@complicated_cargo_library__specs__0_10_0//:specs"
 ]
 additional_flags = [
   # Add an unused flag

--- a/smoke_test/remote/complicated_cargo_library/cargo/libloading_global_static.BUILD
+++ b/smoke_test/remote/complicated_cargo_library/cargo/libloading_global_static.BUILD
@@ -1,0 +1,5 @@
+cc_library(
+    name = "global_static",
+    srcs = ["src/os/unix/global_static.c"],
+    copts = ["-fPIC"],
+)

--- a/smoke_test/remote/complicated_cargo_library/src/main.rs
+++ b/smoke_test/remote/complicated_cargo_library/src/main.rs
@@ -1,3 +1,4 @@
+extern crate libloading;
 extern crate regex;
 extern crate specs;
 
@@ -5,4 +6,7 @@ use regex::Match;
 
 fn main() {
   println!("hello world");
+
+  // Make sure libloading is not optimized out
+  let _lib = libloading::Library::new("/path/to/liblibrary.so");
 }


### PR DESCRIPTION
This adds a new crate option `additional_build_file` for appending custom content to the generated
BUILD files. For example, to include custom Bazel targets for building non-Rust parts of a crate.

I started out with an option to completely override the BUILD file, but I think that's more trouble than it's worth maintenance-wise. So far I haven't needed to change anything Raze generates besides adding to it (e.g. `cc_library` targets).

@mfarrugi - have you run into any cases where this wouldn't be sufficient?

Suggestions welcome on a better name. I was thinking of adding `additional_build_file_contents` to mirror Bazel's `build_file`/`build_file_contents`, but that seems too much.

Fixes #58.