### PR TITLE
Update version of bazel used by Travis CI (0.17.1 -> 3.1.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 before_install:
   - OS=linux
   - ARCH=x86_64
-  - V=0.17.1
+  - V=3.1.0
   - GH_BASE="https://github.com/bazelbuild/bazel/releases/download/$V"
   - GH_ARTIFACT="bazel-$V-installer-$OS-$ARCH.sh"
   - URL="$GH_BASE/$GH_ARTIFACT"


### PR DESCRIPTION
Travis is failing with the following error:

ERROR:
/home/travis/.cache/bazel/_bazel_travis/9838a0d5b93391760180ad93f9f7ea99/external/io_bazel_rules_rust/rust/repositories.bzl:3:1:
file '@bazel_tools//tools/build_defs/repo:utils.bzl' does not contain
symbol 'maybe'

Source:
https://travis-ci.org/github/google/cargo-raze/builds/686275069

The maybe symbol was added to "//tools/build_defs/repo"
in June, 2019. However, the version of Bazel used within Travis
is fairly old (0.17.1); this change moves it to the most recent
revision of Bazel.