### PR TITLE
Add additional_env setting for rules_rust rustc_env

### DIFF
--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -109,6 +109,10 @@ pub struct CrateSettings {
   #[serde(default)]
   pub additional_flags: Vec<String>,
 
+  /** Environment variables to be added to the crate compilation process. */
+  #[serde(default)]
+  pub additional_env: HashMap<String, String>,
+
   /**
    * Whether or not to generate the build script that goes with this crate.
    *
@@ -218,6 +222,7 @@ impl Default for CrateSettings {
       skipped_deps: Vec::new(),
       extra_aliased_targets: Vec::new(),
       additional_flags: Vec::new(),
+      additional_env: HashMap::new(),
       gen_buildrs: default_crate_settings_field_gen_buildrs(),
       data_attr: default_crate_settings_field_data_attr(),
       buildrs_additional_environment_variables: Vec::new(),

--- a/impl/src/templates/partials/rust_binary.template
+++ b/impl/src/templates/partials/rust_binary.template
@@ -24,6 +24,13 @@ rust_binary(
         "{{flag}}",
         {%- endfor %}
     ],
+    {% if crate.raze_settings.additional_env %}
+    rustc_env = {
+        {% for key, value in crate.raze_settings.additional_env %}
+        "{{key}}": "{{value}}",
+        {% endfor %}
+    },
+    {% endif %}
     {%- if crate.build_script_target %}
     out_dir_tar = ":{{ crate.pkg_name | replace(from="-", to="_")}}_build_script_executor",
     {%- endif %}

--- a/impl/src/templates/partials/rust_library.template
+++ b/impl/src/templates/partials/rust_library.template
@@ -25,6 +25,13 @@ rust_library(
         "{{flag}}",
         {%- endfor %}
     ],
+    {% if crate.raze_settings.additional_env %}
+    rustc_env = {
+        {% for key, value in crate.raze_settings.additional_env %}
+        "{{key}}": "{{value}}",
+        {% endfor %}
+    },
+    {% endif %}
     {%- if crate.build_script_target %}
     out_dir_tar = ":{{ crate.pkg_name | replace(from="-", to="_")}}_build_script_executor",
     {%- endif %}

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -33,7 +33,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "io_bazel_rules_rust",
-    commit = "8d3cb6878cf1447e81cd3d7f97057e70285fc833",
+    commit = "57c6f4ec6b25b07958d91c658d0142dc0943e848",
     remote = "https://github.com/bazelbuild/rules_rust.git",
 )
 

--- a/smoke_test/remote/complicated_cargo_library/cargo/Cargo.toml
+++ b/smoke_test/remote/complicated_cargo_library/cargo/Cargo.toml
@@ -42,6 +42,8 @@ additional_flags = [
   # Add an unused flag
   "--cfg=not_used"
 ]
+# Add an unused environment variable
+additional_env = { NOT_USED_KEY = "not_used_value" }
 
 [raze.crates.clang-sys.'0.21.1']
 gen_buildrs = true

--- a/smoke_test/vendored/complicated_cargo_library/cargo/Cargo.toml
+++ b/smoke_test/vendored/complicated_cargo_library/cargo/Cargo.toml
@@ -29,6 +29,8 @@ additional_flags = [
   # Add an unused flag
   "--cfg=not_used"
 ]
+# Add an unused environment variable
+additional_env = { NOT_USED_KEY = "not_used_value" }
 
 [raze.crates.clang-sys.'0.21.1']
 gen_buildrs = true


### PR DESCRIPTION
Recently, the [`rustc_env` attribute was added to `rules_rust`](https://github.com/bazelbuild/rules_rust/pull/314). This allows making arbitrary environment variables available to `rustc` during compilation, such as the [`PROTOC` variable in `prost-build`](https://github.com/danburkert/prost/blob/2de785aca480779ab0d4442d4bc91a696e3e6c89/prost-build/src/lib.rs#L689).


This PR adds a corresponding setting to `raze`, which is forwarded to the underlying `rust_library` or `rust_binary` rule:
```toml
[raze.crates.prost-build.'0.5.0']
additional_env = { PROTOC = "/usr/local/bin/protoc" }
```

For backwards compatibility, the attribute is only set on the underlying rule if at least one key is specified.