### PR TITLE
Fix: Alias renamed dependencies in generated build rules.

### DIFF
--- a/impl/src/bazel.rs
+++ b/impl/src/bazel.rs
@@ -23,8 +23,6 @@ use crate::{
   util::RazeError,
 };
 
-use std::collections::HashMap;
-
 #[derive(Default)]
 pub struct BazelRenderer {
   internal_renderer: Tera,

--- a/impl/src/bazel.rs
+++ b/impl/src/bazel.rs
@@ -23,6 +23,8 @@ use crate::{
   util::RazeError,
 };
 
+use std::collections::HashMap;
+
 #[derive(Default)]
 pub struct BazelRenderer {
   internal_renderer: Tera,
@@ -321,6 +323,7 @@ mod tests {
       dependencies: Vec::new(),
       build_dependencies: Vec::new(),
       dev_dependencies: Vec::new(),
+      aliased_dependencies: Vec::new(),
       is_root_dependency: true,
       workspace_path_to_crate: "@raze__test_binary__1_1_1//".to_owned(),
       targets: vec![BuildableTarget {
@@ -352,6 +355,7 @@ mod tests {
       dependencies: Vec::new(),
       build_dependencies: Vec::new(),
       dev_dependencies: Vec::new(),
+      aliased_dependencies: Vec::new(),
       is_root_dependency: true,
       workspace_path_to_crate: "@raze__test_library__1_1_1//".to_owned(),
       targets: vec![BuildableTarget {

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -23,6 +23,12 @@ pub struct BuildableDependency {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub struct DependencyAlias {
+  pub target: String,
+  pub alias: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct BuildableTarget {
   pub name: String,
   pub kind: String,
@@ -65,7 +71,7 @@ pub struct CrateContext {
   pub dependencies: Vec<BuildableDependency>,
   pub build_dependencies: Vec<BuildableDependency>,
   pub dev_dependencies: Vec<BuildableDependency>,
-  pub aliased_dependencies: Vec<String>,
+  pub aliased_dependencies: Vec<DependencyAlias>,
   pub is_root_dependency: bool,
   pub targets: Vec<BuildableTarget>,
   pub build_script_target: Option<BuildableTarget>,

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -65,6 +65,7 @@ pub struct CrateContext {
   pub dependencies: Vec<BuildableDependency>,
   pub build_dependencies: Vec<BuildableDependency>,
   pub dev_dependencies: Vec<BuildableDependency>,
+  pub aliased_dependencies: Vec<String>,
   pub is_root_dependency: bool,
   pub targets: Vec<BuildableTarget>,
   pub build_script_target: Option<BuildableTarget>,

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -586,7 +586,7 @@ impl<'planner> CrateSubplanner<'planner> {
         if let Some(alias) = aliased_dep_names.get(&dep_package.name) {
           aliased_deps.push(DependencyAlias{
             target: buildable_target.clone(),
-            alias: util::sanitize_name(alias),
+            alias: util::sanitize_ident(alias),
           })
         }     
       }

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -590,13 +590,12 @@ impl<'planner> CrateSubplanner<'planner> {
         normal_deps.push(buildable_dependency);
         // Only add renamed normal deps to the HashMap
         let package_alias = renamed_dep_names.get(&dep_package.name);
-        if package_alias.is_some() {
-          // UNWRAP: Safe from check above.
+        package_alias.as_ref().map(|alias| {
           renamed_deps.insert(
             buildable_target.clone(),
-            package_alias.unwrap().replace("-", "_"),
+            alias.replace("-", "_"),
           );
-        }        
+        });      
       }
     }
 
@@ -655,13 +654,12 @@ impl<'planner> CrateSubplanner<'planner> {
       }
 
       // Check if the dependency has been renamed
-      if dep.rename.is_some() {
-        // UNWRAP: Safe from above check
+      dep.rename.as_ref().map(|rename| {
         renamed_dep_names.insert(
           dep.name.clone(),
-          format!("{}", dep.rename.as_ref().unwrap()),
+          format!("{}", rename),
         );
-      }
+      });
     }
 
     Ok(DependencyNames {

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -28,8 +28,8 @@ use itertools::Itertools;
 
 use crate::{
   context::{
-    BuildableDependency, BuildableTarget, CrateContext, GitRepo, LicenseData, SourceDetails,
-    WorkspaceContext,
+    BuildableDependency, BuildableTarget, CrateContext, DependencyAlias, GitRepo, LicenseData,
+    SourceDetails, WorkspaceContext,
   },
   license,
   metadata::{
@@ -77,7 +77,7 @@ struct DependencySet {
   // Dependencies that are required for tests
   dev_deps: Vec<BuildableDependency>,
   // Dependencies that have been renamed and need to be aliased in the build rule
-  aliased_deps: Vec<String>,
+  aliased_deps: Vec<DependencyAlias>,
 }
 
 /** An entry in the Crate catalog for a single crate. */
@@ -584,7 +584,10 @@ impl<'planner> CrateSubplanner<'planner> {
         normal_deps.push(buildable_dependency);
         // Only add aliased normal deps to the Vec
         if let Some(alias) = aliased_dep_names.get(&dep_package.name) {
-          aliased_deps.push(format!("\"{}\": \"{}\",", buildable_target.clone(), util::sanitize_name(alias)));
+          aliased_deps.push(DependencyAlias{
+            target: buildable_target.clone(),
+            alias: util::sanitize_name(alias),
+          })
         }     
       }
     }

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -584,11 +584,11 @@ impl<'planner> CrateSubplanner<'planner> {
         normal_deps.push(buildable_dependency);
         // Only add aliased normal deps to the Vec
         if let Some(alias) = aliased_dep_names.get(&dep_package.name) {
-          aliased_deps.push(DependencyAlias{
+          aliased_deps.push(DependencyAlias {
             target: buildable_target.clone(),
             alias: util::sanitize_ident(alias),
           })
-        }     
+        }
       }
     }
 
@@ -972,7 +972,10 @@ dependencies = [
     "
   }
 
-  fn make_workspace(toml_file: &'static str, lock_file: Option<&'static str>) -> (TempDir, CargoWorkspaceFiles) {
+  fn make_workspace(
+    toml_file: &'static str,
+    lock_file: Option<&'static str>,
+  ) -> (TempDir, CargoWorkspaceFiles) {
     let dir = TempDir::new("test_cargo_raze_metadata_dir").unwrap();
     let toml_path = {
       let path = dir.path().join("Cargo.toml");
@@ -986,7 +989,7 @@ dependencies = [
         let mut lock = File::create(&path).unwrap();
         lock.write_all(lock_file.as_bytes()).unwrap();
         Some(path)
-      },
+      }
       None => None,
     };
     let files = CargoWorkspaceFiles {
@@ -1271,7 +1274,7 @@ dependencies = [
 
   #[test]
   fn test_plan_build_produces_aliased_dependencies() {
-    let toml_file =     "
+    let toml_file = "
     [package]
     name = \"advanced_toml\"
     version = \"0.1.0\"
@@ -1296,20 +1299,32 @@ dependencies = [
       PlatformDetails::new("some_target_triple".to_owned(), Vec::new() /* attrs */),
     );
 
-    let crates_with_aliased_deps: Vec<CrateContext> = planned_build_res.unwrap().crate_contexts.into_iter().filter(|krate| krate.aliased_dependencies.len() != 0).collect();
-    
+    let crates_with_aliased_deps: Vec<CrateContext> = planned_build_res
+      .unwrap()
+      .crate_contexts
+      .into_iter()
+      .filter(|krate| krate.aliased_dependencies.len() != 0)
+      .collect();
+
     // Vec length shouldn't be 0
-    assert!(crates_with_aliased_deps.len() != 0, "Crates with aliased dependencies is 0");
+    assert!(
+      crates_with_aliased_deps.len() != 0,
+      "Crates with aliased dependencies is 0"
+    );
 
     // Find the actix-web crate
-    let actix_web_position = crates_with_aliased_deps.iter().position(|krate| krate.pkg_name == "actix-http");
+    let actix_web_position = crates_with_aliased_deps
+      .iter()
+      .position(|krate| krate.pkg_name == "actix-http");
     assert!(actix_web_position.is_some());
 
     // Get crate context using computed position
     let actix_http_context = crates_with_aliased_deps[actix_web_position.unwrap()].clone();
 
     assert!(actix_http_context.aliased_dependencies.len() == 1);
-    assert!(actix_http_context.aliased_dependencies[0].target ==  "@raze_test__failure__0_1_8//:failure");
+    assert!(
+      actix_http_context.aliased_dependencies[0].target == "@raze_test__failure__0_1_8//:failure"
+    );
     assert!(actix_http_context.aliased_dependencies[0].alias == "fail_ure");
   }
 

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -543,8 +543,7 @@ impl<'planner> CrateSubplanner<'planner> {
     let mut build_deps = Vec::new();
     let mut dev_deps = Vec::new();
     let mut normal_deps = Vec::new();
-    // Explicitly typed due to compiler error.
-    let mut renamed_deps: HashMap<String, String> = HashMap::new();
+    let mut renamed_deps = HashMap::new();
 
     let all_skipped_deps = self
       .crate_settings
@@ -576,20 +575,11 @@ impl<'planner> CrateSubplanner<'planner> {
       let buildable_dependency = BuildableDependency {
         name: dep_package.name.clone(),
         version: dep_package.version.to_string(),
-        buildable_target,
+        buildable_target: buildable_target.clone(),
       };
 
       if build_dep_names.contains(&dep_package.name) {
         build_deps.push(buildable_dependency.clone());
-        // Only add renamed build deps to the HashMap
-        let package_alias = renamed_dep_names.get(&dep_package.name);
-        if package_alias.is_some() {
-          // UNWRAP: Safe from check above.
-          renamed_deps.insert(
-            buildable_dependency.buildable_target.clone(),
-            package_alias.unwrap().clone(),
-          );
-        }
       }
 
       if dev_dep_names.contains(&dep_package.name) {
@@ -598,6 +588,15 @@ impl<'planner> CrateSubplanner<'planner> {
 
       if normal_dep_names.contains(&dep_package.name) {
         normal_deps.push(buildable_dependency);
+        // Only add renamed normal deps to the HashMap
+        let package_alias = renamed_dep_names.get(&dep_package.name);
+        if package_alias.is_some() {
+          // UNWRAP: Safe from check above.
+          renamed_deps.insert(
+            buildable_target.clone(),
+            package_alias.unwrap().replace("-", "_"),
+          );
+        }        
       }
     }
 

--- a/impl/src/templates/partials/rust_binary.template
+++ b/impl/src/templates/partials/rust_binary.template
@@ -36,7 +36,7 @@ rust_binary(
         "{{feature}}",
         {%- endfor %}
     ],
-    {%- if length(crate.aliased_dependencies) != 0 %}
+    {%- if length(crate.aliased_dependencies) is not 0 %}
     aliases = {
         {%- for alias in aliased_dependencies %}
         {{alias}}

--- a/impl/src/templates/partials/rust_binary.template
+++ b/impl/src/templates/partials/rust_binary.template
@@ -38,7 +38,7 @@ rust_binary(
     ],
     {%- if crate.aliased_dependencies | length != 0 %}
     aliases = {
-        {%- for alias in aliased_dependencies %}
+        {%- for alias in crate.aliased_dependencies %}
         {{alias}}
         {%- endfor %}
     },

--- a/impl/src/templates/partials/rust_binary.template
+++ b/impl/src/templates/partials/rust_binary.template
@@ -36,7 +36,7 @@ rust_binary(
         "{{feature}}",
         {%- endfor %}
     ],
-    {%- if crate.aliased_dependencies | length is not 0 %}
+    {%- if crate.aliased_dependencies | length != 0 %}
     aliases = {
         {%- for alias in aliased_dependencies %}
         {{alias}}

--- a/impl/src/templates/partials/rust_binary.template
+++ b/impl/src/templates/partials/rust_binary.template
@@ -36,4 +36,11 @@ rust_binary(
         "{{feature}}",
         {%- endfor %}
     ],
+    {%- if length(crate.aliased_dependencies) != 0 %}
+    aliases = {
+        {%- for alias in aliased_dependencies %}
+        {{alias}}
+        {%- endfor %}
+    },
+    {%- endif %}
 )

--- a/impl/src/templates/partials/rust_binary.template
+++ b/impl/src/templates/partials/rust_binary.template
@@ -39,7 +39,7 @@ rust_binary(
     {%- if crate.aliased_dependencies | length != 0 %}
     aliases = {
         {%- for alias in crate.aliased_dependencies %}
-        {{alias}}
+        "{{alias.target}}": "{{alias.alias}}",
         {%- endfor %}
     },
     {%- endif %}

--- a/impl/src/templates/partials/rust_binary.template
+++ b/impl/src/templates/partials/rust_binary.template
@@ -36,7 +36,7 @@ rust_binary(
         "{{feature}}",
         {%- endfor %}
     ],
-    {%- if length(crate.aliased_dependencies) is not 0 %}
+    {%- if crate.aliased_dependencies | length is not 0 %}
     aliases = {
         {%- for alias in aliased_dependencies %}
         {{alias}}

--- a/impl/src/templates/partials/rust_library.template
+++ b/impl/src/templates/partials/rust_library.template
@@ -37,7 +37,7 @@ rust_library(
         "{{feature}}",
         {%- endfor %}
     ],
-    {%- if crate.aliased_dependencies | length is not 0 %}
+    {%- if crate.aliased_dependencies | length != 0 %}
     aliases = {
         {%- for alias in aliased_dependencies %}
         {{alias}}

--- a/impl/src/templates/partials/rust_library.template
+++ b/impl/src/templates/partials/rust_library.template
@@ -40,7 +40,7 @@ rust_library(
     {%- if crate.aliased_dependencies | length != 0 %}
     aliases = {
         {%- for alias in crate.aliased_dependencies %}
-        {{alias}}
+        "{{alias.target}}": "{{alias.alias}}",
         {%- endfor %}
     },
     {%- endif %}

--- a/impl/src/templates/partials/rust_library.template
+++ b/impl/src/templates/partials/rust_library.template
@@ -39,7 +39,7 @@ rust_library(
     ],
     {%- if crate.aliased_dependencies | length != 0 %}
     aliases = {
-        {%- for alias in aliased_dependencies %}
+        {%- for alias in crate.aliased_dependencies %}
         {{alias}}
         {%- endfor %}
     },

--- a/impl/src/templates/partials/rust_library.template
+++ b/impl/src/templates/partials/rust_library.template
@@ -37,4 +37,11 @@ rust_library(
         "{{feature}}",
         {%- endfor %}
     ],
+        {%- if length(crate.aliased_dependencies) != 0 %}
+    aliases = {
+        {%- for alias in aliased_dependencies %}
+        {{alias}}
+        {%- endfor %}
+    },
+    {%- endif %}
 )

--- a/impl/src/templates/partials/rust_library.template
+++ b/impl/src/templates/partials/rust_library.template
@@ -37,7 +37,7 @@ rust_library(
         "{{feature}}",
         {%- endfor %}
     ],
-    {%- if length(crate.aliased_dependencies) is not 0 %}
+    {%- if crate.aliased_dependencies | length is not 0 %}
     aliases = {
         {%- for alias in aliased_dependencies %}
         {{alias}}

--- a/impl/src/templates/partials/rust_library.template
+++ b/impl/src/templates/partials/rust_library.template
@@ -37,7 +37,7 @@ rust_library(
         "{{feature}}",
         {%- endfor %}
     ],
-        {%- if length(crate.aliased_dependencies) != 0 %}
+    {%- if length(crate.aliased_dependencies) is not 0 %}
     aliases = {
         {%- for alias in aliased_dependencies %}
         {{alias}}

--- a/impl/src/util.rs
+++ b/impl/src/util.rs
@@ -163,6 +163,10 @@ pub fn sanitize_ident(ident: &str) -> String {
   slug::slugify(&ident).replace("-", "_")
 }
 
+pub fn sanitize_name(name: &str) -> String {
+  slug::slugify(&name).replace("-", "_")
+}
+
 /** Gets the proper system attributes for the provided platform triple using rustc. */
 fn fetch_attrs(target: &str) -> Result<Vec<Cfg>> {
   let args = vec![format!("--target={}", target), "--print=cfg".to_owned()];

--- a/impl/src/util.rs
+++ b/impl/src/util.rs
@@ -163,10 +163,6 @@ pub fn sanitize_ident(ident: &str) -> String {
   slug::slugify(&ident).replace("-", "_")
 }
 
-pub fn sanitize_name(name: &str) -> String {
-  slug::slugify(&name).replace("-", "_")
-}
-
 /** Gets the proper system attributes for the provided platform triple using rustc. */
 fn fetch_attrs(target: &str) -> Result<Vec<Cfg>> {
   let args = vec![format!("--target={}", target), "--print=cfg".to_owned()];


### PR DESCRIPTION
This PR fixes #143 by checking for renamed packages while exploring dependencies. If a package has been renamed, it will be added to the `aliases` parameter in the generated build rule.

I am still fairly new to Rust programming and it's best practices, so please feel free to nit my implementation.

Once you approve of the implementation, I can write unit tests before merging.