### PR TITLE
Resolve formatting changes in to rust_binary and rust_library templates

### DIFF
--- a/impl/src/templates/partials/rust_binary.template
+++ b/impl/src/templates/partials/rust_binary.template
@@ -24,13 +24,13 @@ rust_binary(
         "{{flag}}",
         {%- endfor %}
     ],
-    {% if crate.raze_settings.additional_env %}
+    {%- if crate.raze_settings.additional_env %}
     rustc_env = {
-        {% for key, value in crate.raze_settings.additional_env %}
+        {%- for key, value in crate.raze_settings.additional_env %}
         "{{key}}": "{{value}}",
-        {% endfor %}
+        {%- endfor %}
     },
-    {% endif %}
+    {%- endif %}
     {%- if crate.build_script_target %}
     out_dir_tar = ":{{ crate.pkg_name | replace(from="-", to="_")}}_build_script_executor",
     {%- endif %}

--- a/impl/src/templates/partials/rust_library.template
+++ b/impl/src/templates/partials/rust_library.template
@@ -25,13 +25,13 @@ rust_library(
         "{{flag}}",
         {%- endfor %}
     ],
-    {% if crate.raze_settings.additional_env %}
+    {%- if crate.raze_settings.additional_env %}
     rustc_env = {
-        {% for key, value in crate.raze_settings.additional_env %}
+        {%- for key, value in crate.raze_settings.additional_env %}
         "{{key}}": "{{value}}",
-        {% endfor %}
+        {%- endfor %}
     },
-    {% endif %}
+    {%- endif %}
     {%- if crate.build_script_target %}
     out_dir_tar = ":{{ crate.pkg_name | replace(from="-", to="_")}}_build_script_executor",
     {%- endif %}


### PR DESCRIPTION
It looks like a `-` was missing in #161, which added additional_env
support.  This causes a blank line with extra whitespace to show up
relative to 0.3.1, or older.

This adds that back in, which matches the rest of the template file and
resolves the whitespace issue.