### PR TITLE
Add build script dependencies on sys crates build scripts.

### DIFF
--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -581,6 +581,11 @@ impl<'planner> CrateSubplanner<'planner> {
       }
 
       if normal_dep_names.contains(&dep_package.name) {
+        // sys crates build files may generate DEP_* environment variables that
+        // need to be visible in their direct dependency build files.
+        if dep_package.name.ends_with("-sys") {
+          build_deps.push(buildable_dependency.clone());
+        }
         normal_deps.push(buildable_dependency);
         // Only add aliased normal deps to the Vec
         if let Some(alias) = aliased_dep_names.get(&dep_package.name) {


### PR DESCRIPTION
System crates build scripts may produce environment variables
that may be used by their direct dependencies build script.

For example openssl-sys generates DEP_OPENSSL_VERSION variable
that is then used by openssl crate build scripts.