### PR TITLE
Fix: Make crate license identification more robust

### DIFF
--- a/impl/Cargo.lock
+++ b/impl/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "slug",
+ "spdx",
  "tempdir",
  "tera",
  "toml 0.4.10",
@@ -761,6 +762,17 @@ name = "smallvec"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
+
+[[package]]
+name = "spdx"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a68f874c9aa7762aa10401e2ae004d977e7b6156074668eb4ce78dd0cb28255"
+dependencies = [
+ "lazy_static",
+ "regex",
+ "smallvec",
+]
 
 [[package]]
 name = "strsim"

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -36,6 +36,7 @@ serde = "1.0.84"
 toml = "0.4.10"
 serde_json = "1.0.34"
 tempdir = "0.3.7"
+spdx = "0.3.4"
 
 [dev-dependencies]
 lazy_static = "1.2.0"

--- a/impl/src/bazel.rs
+++ b/impl/src/bazel.rs
@@ -320,7 +320,10 @@ mod tests {
       edition: "2015".to_owned(),
       features: vec!["feature1".to_owned(), "feature2".to_owned()].to_owned(),
       expected_build_path: format!("vendor/test-binary-1.1.1/{}", buildfile_suffix),
-      licenses: Vec::new(),
+      licenses: LicenseData {
+        name: "no license".into(),
+        rating: "restricted".into(),
+      },
       raze_settings: CrateSettings::default(),
       dependencies: Vec::new(),
       proc_macro_dependencies: Vec::new(),
@@ -351,7 +354,10 @@ mod tests {
       pkg_name: "test-library".to_owned(),
       pkg_version: "1.1.1".to_owned(),
       edition: "2015".to_owned(),
-      licenses: Vec::new(),
+      licenses: LicenseData {
+        name: "no license".into(),
+        rating: "restricted".into(),
+      },
       raze_settings: CrateSettings::default(),
       features: vec!["feature1".to_owned(), "feature2".to_owned()].to_owned(),
       expected_build_path: format!("vendor/test-library-1.1.1/{}", buildfile_suffix),

--- a/impl/src/bazel.rs
+++ b/impl/src/bazel.rs
@@ -320,10 +320,7 @@ mod tests {
       edition: "2015".to_owned(),
       features: vec!["feature1".to_owned(), "feature2".to_owned()].to_owned(),
       expected_build_path: format!("vendor/test-binary-1.1.1/{}", buildfile_suffix),
-      license: LicenseData {
-        name: "no license".into(),
-        rating: "restricted".into(),
-      },
+      license: LicenseData::default(),
       raze_settings: CrateSettings::default(),
       dependencies: Vec::new(),
       proc_macro_dependencies: Vec::new(),
@@ -354,10 +351,7 @@ mod tests {
       pkg_name: "test-library".to_owned(),
       pkg_version: "1.1.1".to_owned(),
       edition: "2015".to_owned(),
-      license: LicenseData {
-        name: "no license".into(),
-        rating: "restricted".into(),
-      },
+      license: LicenseData::default(),
       raze_settings: CrateSettings::default(),
       features: vec!["feature1".to_owned(), "feature2".to_owned()].to_owned(),
       expected_build_path: format!("vendor/test-library-1.1.1/{}", buildfile_suffix),

--- a/impl/src/bazel.rs
+++ b/impl/src/bazel.rs
@@ -320,7 +320,7 @@ mod tests {
       edition: "2015".to_owned(),
       features: vec!["feature1".to_owned(), "feature2".to_owned()].to_owned(),
       expected_build_path: format!("vendor/test-binary-1.1.1/{}", buildfile_suffix),
-      licenses: LicenseData {
+      license: LicenseData {
         name: "no license".into(),
         rating: "restricted".into(),
       },
@@ -354,7 +354,7 @@ mod tests {
       pkg_name: "test-library".to_owned(),
       pkg_version: "1.1.1".to_owned(),
       edition: "2015".to_owned(),
-      licenses: LicenseData {
+      license: LicenseData {
         name: "no license".into(),
         rating: "restricted".into(),
       },

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -66,7 +66,7 @@ pub struct CrateContext {
   pub pkg_version: String,
   pub edition: String,
   pub raze_settings: CrateSettings,
-  pub licenses: Vec<LicenseData>,
+  pub licenses: LicenseData,
   pub features: Vec<String>,
   pub workspace_path_to_crate: String,
   pub dependencies: Vec<BuildableDependency>,

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -49,6 +49,15 @@ pub struct LicenseData {
   pub rating: String,
 }
 
+impl Default for LicenseData {
+  fn default() -> Self {
+    LicenseData {
+      name: "no license".into(),
+      rating: "restricted".into(),
+    }
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct GitRepo {
   pub remote: String,

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -66,7 +66,7 @@ pub struct CrateContext {
   pub pkg_version: String,
   pub edition: String,
   pub raze_settings: CrateSettings,
-  pub licenses: LicenseData,
+  pub license: LicenseData,
   pub features: Vec<String>,
   pub workspace_path_to_crate: String,
   pub dependencies: Vec<BuildableDependency>,

--- a/impl/src/license.rs
+++ b/impl/src/license.rs
@@ -63,19 +63,17 @@ pub struct BazelSpdxLicense {
 impl BazelSpdxLicense {
   fn combine_license_expr(license1: &Self, license2: &Self, operator: &str) -> String {
     // Surround license expressions with parenthesis if it isn't just the node name
-    let expr_str1: String;
-    if license1.name != license1.expression {
-      expr_str1 = format!("({})", license1.expression);
+    let expr_str1 = if license1.name != license1.expression {
+      format!("({})", license1.expression)
     } else {
-      expr_str1 = license1.expression.clone();
-    }
+      license1.expression.clone()
+    };
 
-    let expr_str2: String;
-    if license2.name != license2.expression {
-      expr_str2 = format!("({})", license2.expression);
+    let expr_str2 = if license2.name != license2.expression {
+      format!("({})", license2.expression)
     } else {
-      expr_str2 = license2.expression.clone();
-    }
+      license2.expression.clone()
+    };
 
     // Combine them using the operator
     format!("{} {} {}", expr_str1, operator, expr_str2)

--- a/impl/src/license.rs
+++ b/impl/src/license.rs
@@ -129,10 +129,7 @@ impl BazelSpdxLicense {
 /** Breaks apart a cargo license string and yields the available license types. */
 pub fn get_license_from_str(cargo_license_str: &str) -> LicenseData {
   if cargo_license_str.len() == 0 {
-    return LicenseData {
-      name: "no license".into(),
-      rating: BazelLicenseType::Restricted.to_bazel_rating().into(),
-    };
+    return LicenseData::default();
   }
 
   // Many crates have forward-slashes in their licenses. This requires Lax parsing mode

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -526,11 +526,7 @@ impl<'planner> CrateSubplanner<'planner> {
       .as_ref()
       .map_or("", String::as_str);
 
-    let bazel_license = license::get_available_licenses(licenses_str);
-    LicenseData {
-      name: format!("{} from expression \"{}\"", bazel_license.name, bazel_license.expression),
-      rating: bazel_license.license.to_bazel_rating().into(),
-    }
+    license::get_license_from_str(licenses_str)
   }
 
   /** Generates the set of dependencies for the contained crate. */

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::{
-  collections::{BTreeMap, HashMap, HashSet},
+  collections::{HashMap, HashSet},
   path::PathBuf,
   str::{self, FromStr},
 };
@@ -518,14 +518,19 @@ impl<'planner> CrateSubplanner<'planner> {
   }
 
   /** Generates license data from internal crate details. */
-  fn produce_licenses(&self) -> Vec<LicenseData> {
+  fn produce_licenses(&self) -> LicenseData {
     let licenses_str = self
       .crate_catalog_entry
       .package()
       .license
       .as_ref()
       .map_or("", String::as_str);
-    load_and_dedup_licenses(licenses_str)
+
+    let bazel_license = license::get_available_licenses(licenses_str);
+    LicenseData {
+      name: format!("{} from {}", bazel_license.name, bazel_license.expression),
+      rating: bazel_license.license.to_bazel_rating().into(),
+    }
   }
 
   /** Generates the set of dependencies for the contained crate. */
@@ -709,7 +714,11 @@ impl<'planner> CrateSubplanner<'planner> {
     &self,
     all_targets: &mut Vec<BuildableTarget>,
   ) -> Option<BuildableTarget> {
-    if !self.crate_settings.gen_buildrs.unwrap_or(self.settings.default_gen_buildrs) {
+    if !self
+      .crate_settings
+      .gen_buildrs
+      .unwrap_or(self.settings.default_gen_buildrs)
+    {
       return None;
     }
 
@@ -807,26 +816,6 @@ impl<'planner> CrateSubplanner<'planner> {
       )
     }
   }
-}
-
-fn load_and_dedup_licenses(licenses: &str) -> Vec<LicenseData> {
-  let mut rating_to_license_name = BTreeMap::new();
-  for (license_name, license_type) in license::get_available_licenses(licenses) {
-    let rating = license_type.to_bazel_rating();
-
-    rating_to_license_name
-      .entry(rating.to_string())
-      .and_modify(|license_names: &mut String| {
-        license_names.push_str(",");
-        license_names.push_str(&license_name);
-      })
-      .or_insert_with(|| license_name.to_owned());
-  }
-
-  rating_to_license_name
-    .into_iter()
-    .map(|(rating, name)| LicenseData { rating, name })
-    .collect::<Vec<_>>()
 }
 
 mod checks {
@@ -1052,35 +1041,6 @@ dependencies = [
     checks::check_resolve_matches_packages(&metadata).unwrap();
   }
 
-  #[test]
-  fn test_license_loading_works_with_no_license() {
-    let no_license_data = vec![LicenseData {
-      name: "no license".to_owned(),
-      rating: "restricted".to_owned(),
-    }];
-
-    assert_eq!(load_and_dedup_licenses(""), no_license_data);
-    assert_eq!(load_and_dedup_licenses("///"), no_license_data);
-  }
-
-  #[test]
-  fn test_license_loading_dedupes_equivalent_licenses() {
-    // WTFPL is "disallowed",but we map that down to the same thing as GPL
-    assert_eq!(
-      load_and_dedup_licenses("Unlicense/ WTFPL /GPL-3.0"),
-      vec![
-        LicenseData {
-          name: "GPL-3.0,WTFPL".to_owned(),
-          rating: "restricted".to_owned(),
-        },
-        LicenseData {
-          name: "Unlicense".to_owned(),
-          rating: "unencumbered".to_owned(),
-        },
-      ]
-    );
-  }
-
   // A wrapper around a MetadataFetcher which drops the
   // resolved dependency graph from the acquired metadata.
   #[derive(Default)]
@@ -1303,7 +1263,7 @@ dependencies = [
     [package]
     name = \"advanced_toml\"
     version = \"0.1.0\"
-    
+
     [lib]
     path = \"not_a_file.rs\"
 

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -498,7 +498,7 @@ impl<'planner> CrateSubplanner<'planner> {
       pkg_name: package.name.clone(),
       pkg_version: package.version.to_string(),
       edition: package.edition.clone(),
-      licenses: self.produce_licenses(),
+      license: self.produce_license(),
       features: self.node.features.clone(),
       is_root_dependency: self.crate_catalog_entry.is_root_dep(),
       dependencies: normal_deps,
@@ -518,7 +518,7 @@ impl<'planner> CrateSubplanner<'planner> {
   }
 
   /** Generates license data from internal crate details. */
-  fn produce_licenses(&self) -> LicenseData {
+  fn produce_license(&self) -> LicenseData {
     let licenses_str = self
       .crate_catalog_entry
       .package()
@@ -528,7 +528,7 @@ impl<'planner> CrateSubplanner<'planner> {
 
     let bazel_license = license::get_available_licenses(licenses_str);
     LicenseData {
-      name: format!("{} from {}", bazel_license.name, bazel_license.expression),
+      name: format!("{} from expression \"{}\"", bazel_license.name, bazel_license.expression),
       rating: bazel_license.license.to_bazel_rating().into(),
     }
   }

--- a/impl/src/templates/crate.BUILD.template
+++ b/impl/src/templates/crate.BUILD.template
@@ -12,9 +12,7 @@ package(default_visibility = [
 ])
 
 licenses([
-{%- for license in crate.licenses %}
-  "{{license.rating}}", # "{{license.name}}"
-{%- endfor %}
+  "{{crate.license.rating}}", # {{crate.license.name}}
 ])
 
 load(


### PR DESCRIPTION
This PR changes how cargo-raze identifies crate licenses. Currently, proper SPDX syntax is not properly recognized, so a crate with a license "MIT OR Apache-2.0" will be marked as restricted. While one solution would be to split the license string at "OR", I believe this implementation is much more robust, as it will support "AND" if that ever shows up in a crate license.

Using the SPDX crate, a crate's license string is parsed as an SPDX expression. The parser will verify that the licenses and syntax of the expression are valid. If a parse error is returned, the license is marked as restricted and a message is displayed next to the license in the build file. If multiple licenses are allowed ("OR"), the more permissive license is used. If multiple licenses are required ("AND"), the less permissive license is used.

Internal documentation states that the license field should only contain one parameter in the array, which should represent the least permissive license that the package is bound by. Therefore, the functionality has been changed to only show one license, rather than the previous functionality, which shows all types of licenses.