### PR TITLE
Add --output param specifying output folder for generated files.

### DIFF
--- a/impl/src/bazel.rs
+++ b/impl/src/bazel.rs
@@ -230,7 +230,7 @@ impl BuildRenderer for BazelRenderer {
 
     // N.B. File needs to exist so that contained xyz-1.2.3.BUILD can be referenced
     file_outputs.push(FileOutputs {
-      path: format!("remote/{}", buildfile_suffix),
+      path: format!("{}/remote/{}", path_prefix, buildfile_suffix),
       contents: String::new(),
     });
 


### PR DESCRIPTION
Also fix:
* remote folder created on dry run
* remote/BUILD folder does not use prefix path parameter