### PR TITLE
Tag all cargo-raze rules with "cargo-raze" tag.

### DIFF
--- a/impl/src/templates/partials/build_script.template
+++ b/impl/src/templates/partials/build_script.template
@@ -26,6 +26,7 @@ cargo_build_script(
       {%- endfor %}
     ],
     data = glob(["**"]),
+    tags = ["cargo-raze"],
     version = "{{ crate.pkg_version }}",
     visibility = ["//visibility:private"],
 )

--- a/impl/src/templates/partials/common_attrs.template
+++ b/impl/src/templates/partials/common_attrs.template
@@ -25,6 +25,7 @@
     data = {{crate.raze_settings.data_attr}},
     {%- endif %}
     version = "{{ crate.pkg_version }}",
+    tags = ["cargo-raze"],
     crate_features = [
         {%- for feature in crate.features %}
         "{{feature}}",

--- a/impl/src/templates/partials/rust_library.template
+++ b/impl/src/templates/partials/rust_library.template
@@ -2,6 +2,7 @@
 alias(
   name = "{{ crate_name_sanitized }}",
   actual = ":{{ target_name_sanitized }}",
+  tags = ["cargo-raze"],
 )
 {%- endif %}
 

--- a/impl/src/templates/workspace.BUILD.template
+++ b/impl/src/templates/workspace.BUILD.template
@@ -15,6 +15,7 @@ licenses([
 alias(
     name = "{{crate_name_sanitized}}",
     actual = "{{crate.workspace_path_to_crate}}:{{crate_name_sanitized}}",
+    tags = ["cargo-raze"],
 )
 {%- endif %}
 {%- for aliased_target in crate.raze_settings.extra_aliased_targets %}
@@ -23,6 +24,7 @@ alias(
     # N.B.: The exact form of this is subject to change.
     name = "{{aliased_target}}",
     actual = "{{crate.workspace_path_to_crate}}:{{aliased_target}}",
+    tags = ["cargo-raze"],
 )
 {%- endfor %}
 {%- endfor %}


### PR DESCRIPTION
The tags can be used to exclude cargo-raze generated rules from, e.g.
"//...:all" targets. It is useful to prevent Bazel from building
unsupported targets in multiplatform configurations.