### PR TITLE
Support additional enviroment variable for build script

### DIFF
--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -140,8 +140,6 @@ pub struct CrateSettings {
 
   /**
    * Additional environment variables to add when running the build script.
-   *
-   * Values should looks like "KEY=VALUE".
    */
   #[serde(default)]
   pub buildrs_additional_environment_variables: HashMap<String, String>,

--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -144,7 +144,7 @@ pub struct CrateSettings {
    * Values should looks like "KEY=VALUE".
    */
   #[serde(default)]
-  pub buildrs_additional_environment_variables: Vec<String>,
+  pub buildrs_additional_environment_variables: HashMap<String, String>,
 
   /**
    * The arguments given to the patch tool.
@@ -233,7 +233,7 @@ impl Default for CrateSettings {
       additional_env: HashMap::new(),
       gen_buildrs: default_crate_settings_field_gen_buildrs(),
       data_attr: default_crate_settings_field_data_attr(),
-      buildrs_additional_environment_variables: Vec::new(),
+      buildrs_additional_environment_variables: HashMap::new(),
       patch_args: Vec::new(),
       patch_cmds: Vec::new(),
       patch_cmds_win: Vec::new(),

--- a/impl/src/templates/partials/build_script.template
+++ b/impl/src/templates/partials/build_script.template
@@ -25,6 +25,11 @@ cargo_build_script(
       "{{feature}}",
       {%- endfor %}
     ],
+    build_script_env = {
+        {%- for key, value in crate.raze_settings.buildrs_additional_environment_variables %}	
+        "{{key}}": "{{value}}",
+        {%- endfor %}
+    },
     data = glob(["**"]),
     tags = ["cargo-raze"],
     version = "{{ crate.pkg_version }}",

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -33,7 +33,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "io_bazel_rules_rust",
-    commit = "77ad6cccd16eea725bff3a2311d483dbea51347c",
+    commit = "fda9a1ce6482973adfda022cadbfa6b300e269c3",
     remote = "https://github.com/bazelbuild/rules_rust.git",
 )
 


### PR DESCRIPTION
Since the switch to the cargo_build_script rule, the
buildrs_additional_environment_variables was no longer working, this
change add this support back.

Fixes #179 