### PR TITLE
Avoid silently dropping rules with conflicting names

### DIFF
--- a/impl/src/templates/remote_crates.bzl.template
+++ b/impl/src/templates/remote_crates.bzl.template
@@ -6,18 +6,10 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
-def _new_http_archive(name, **kwargs):
-    if not native.existing_rule(name):
-        http_archive(name=name, **kwargs)
-
-def _new_git_repository(name, **kwargs):
-    if not native.existing_rule(name):
-        new_git_repository(name=name, **kwargs)
-
 def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
 {% for crate in crates %}
     {%- if crate.source_details.git_data %}
-    _new_git_repository(
+    new_git_repository(
         name = "{{workspace.gen_workspace_prefix}}__{{crate.pkg_name | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}}",
         remote = "{{crate.source_details.git_data.remote}}",
         commit = "{{crate.source_details.git_data.commit}}",
@@ -26,7 +18,7 @@ def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
         {%- include "templates/partials/remote_crates_patch.template" %}
     )
     {%- else %}
-    _new_http_archive(
+    http_archive(
         name = "{{workspace.gen_workspace_prefix}}__{{crate.pkg_name | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}}",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/{{crate.pkg_name}}/{{crate.pkg_name}}-{{crate.pkg_version}}.crate",
         type = "tar.gz",


### PR DESCRIPTION
I ran into the following problem on a repository of mine which used Cargo Raze and Rules Rust:

- I had a dependency -- byteorder -- where I tried adding some compile-time flags in my Cargo.toml file.
- I noticed that, after re-running raze, I'd see a BUILD file for the target which included the flags I wanted...
- ... but when running Bazel, those flags were silently dropped!
- Eventually, this was traced back to an invocation of `rust_proto_repositories()` within my WORKSPACE file. Here's what happened: because my Cargo.toml file depended on an http_archive *also* checked into `rules_rust`, accessed by the `rust_proto_repositories` invocation, "which one got used" was order-dependent. The other was silently dropped.

I consider this a bug. This PR attempts to rectify this problem by changing the BUILD file generation of Raze such that multiple dependencies on the same target are no longer order-dependent. Instead, they explicitly flag an error.

If this change is considered undesirable, I'm happy to chatting about alternatives - but IMO the order-dependent alternative was pretty subtle.