### PR TITLE
Allow for aliases at the top level

### DIFF
--- a/impl/Cargo.lock
+++ b/impl/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "8504b63dd1249fd1745b7b4ef9b6f7b107ddeb3c95370043c7dbcc38653a2679"
 dependencies = [
  "gumdrop",
  "petgraph",
- "semver",
+ "semver 0.9.0",
  "serde",
  "toml 0.5.6",
  "url",
@@ -100,11 +100,13 @@ dependencies = [
  "cargo-lock",
  "cargo-platform",
  "cargo_metadata",
+ "derivative",
  "docopt",
  "hamcrest2",
- "itertools",
+ "itertools 0.8.2",
+ "itertools 0.9.0",
  "lazy_static",
- "semver",
+ "semver 0.10.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -117,11 +119,11 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e3374c604fb39d1a2f35ed5e4a4e30e60d01fab49446e08f1b3e9a90aef202"
+checksum = "052dbdd9db69a339d5fa9ac87bfe2e1319f709119f0345988a597af82bb1011c"
 dependencies = [
- "semver",
+ "semver 0.10.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -163,6 +165,17 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "lazy_static",
+]
+
+[[package]]
+name = "derivative"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c6d883546668a3e2011b6a716a7330b82eabb0151b138217f632c8243e17135"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
 ]
 
 [[package]]
@@ -281,9 +294,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90454ce4de40b7ca6a8968b5ef367bdab48413962588d0d2b1638d60090c35d7"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -345,6 +358,15 @@ name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -519,9 +541,9 @@ checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -553,11 +575,29 @@ checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+dependencies = [
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "proc-macro2"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
 dependencies = [
- "unicode-xid",
+ "unicode-xid 0.2.0",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+dependencies = [
+ "proc-macro2 0.4.30",
 ]
 
 [[package]]
@@ -566,7 +606,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42934bc9c8ab0d3b273a16d8551c8f0fcff46be73276ca083ec2414c15c4ba5e"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 1.0.12",
 ]
 
 [[package]]
@@ -700,6 +740,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
+dependencies = [
+ "semver-parser",
+ "serde",
+]
+
+[[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,9 +770,9 @@ version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -782,13 +832,24 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "syn"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4696caa4048ac7ce2bcd2e484b3cef88c1004e41b8e945a277e2c25dc0b72060"
 dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "unicode-xid 0.2.0",
 ]
 
 [[package]]
@@ -939,6 +1000,12 @@ checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -26,17 +26,22 @@ anyhow = "1.0.30"
 docopt = "1.0.2"
 cargo-lock = "4.0.1"
 cargo-platform = "0.1.0"
-cargo_metadata = "0.9.1"
+cargo_metadata = "0.10"
 itertools = "0.8.0"
+itertools_new = { version = "0.9.0", package = "itertools" }
 slug = "0.1.4"
 tera = "1.0.0"
-semver = { version = "0.9.0", features = ["serde"] }
 serde_derive = "1.0.84"
 serde = "1.0.84"
 toml = "0.4.10"
 serde_json = "1.0.34"
 tempdir = "0.3.7"
 spdx = "0.3.4"
+derivative = "1.0"
+
+[dependencies.semver]
+features = ["serde"]
+version = "0.10"
 
 [dev-dependencies]
 lazy_static = "1.2.0"

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -30,7 +30,7 @@ cargo_metadata = "0.9.1"
 itertools = "0.8.0"
 slug = "0.1.4"
 tera = "1.0.0"
-semver = "0.9.0"
+semver = { version = "0.9.0", features = ["serde"] }
 serde_derive = "1.0.84"
 serde = "1.0.84"
 toml = "0.4.10"

--- a/impl/src/bazel.rs
+++ b/impl/src/bazel.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use anyhow::Result;
-
 use tera::{self, Context, Tera};
 
 use crate::{
@@ -291,6 +290,7 @@ mod tests {
     rendering::{FileOutputs, RenderDetails},
     settings::CrateSettings,
   };
+  use semver::Version;
 
   use super::*;
 
@@ -316,7 +316,7 @@ mod tests {
   fn dummy_binary_crate_with_name(buildfile_suffix: &str) -> CrateContext {
     CrateContext {
       pkg_name: "test-binary".to_owned(),
-      pkg_version: "1.1.1".to_owned(),
+      pkg_version: Version::parse("1.1.1").unwrap(),
       edition: "2015".to_owned(),
       features: vec!["feature1".to_owned(), "feature2".to_owned()].to_owned(),
       expected_build_path: format!("vendor/test-binary-1.1.1/{}", buildfile_suffix),
@@ -350,7 +350,7 @@ mod tests {
   fn dummy_library_crate_with_name(buildfile_suffix: &str) -> CrateContext {
     CrateContext {
       pkg_name: "test-library".to_owned(),
-      pkg_version: "1.1.1".to_owned(),
+      pkg_version: Version::parse("1.1.1").unwrap(),
       edition: "2015".to_owned(),
       license: LicenseData::default(),
       raze_settings: CrateSettings::default(),

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -15,6 +15,7 @@
 use crate::settings::CrateSettings;
 use serde_derive::Serialize;
 use semver::Version;
+use derivative::Derivative;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct BuildableDependency {
@@ -24,9 +25,11 @@ pub struct BuildableDependency {
   pub is_proc_macro: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Clone, Derivative, Eq, PartialOrd, Ord, Serialize)]
+#[derivative(PartialEq, Hash)]
 pub struct DependencyAlias {
   pub target: String,
+  #[derivative(PartialEq="ignore", Hash="ignore")]
   pub alias: String,
 }
 

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -14,11 +14,12 @@
 
 use crate::settings::CrateSettings;
 use serde_derive::Serialize;
+use semver::Version;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct BuildableDependency {
   pub name: String,
-  pub version: String,
+  pub version: Version,
   pub buildable_target: String,
   pub is_proc_macro: bool,
 }
@@ -40,7 +41,7 @@ pub struct BuildableTarget {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct Metadep {
   pub name: String,
-  pub min_version: String,
+  pub min_version: Version,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
@@ -72,7 +73,7 @@ pub struct SourceDetails {
 #[derive(Debug, Clone, Serialize)]
 pub struct CrateContext {
   pub pkg_name: String,
-  pub pkg_version: String,
+  pub pkg_version: Version,
   pub edition: String,
   pub raze_settings: CrateSettings,
   pub license: LicenseData,

--- a/impl/src/metadata.rs
+++ b/impl/src/metadata.rs
@@ -17,7 +17,7 @@ use std::{fs, path::PathBuf};
 use anyhow::Result;
 
 use cargo_metadata::MetadataCommand;
-pub use cargo_metadata::{DependencyKind, Metadata, Node, Package, PackageId};
+pub use cargo_metadata::{Dependency, DependencyKind, Metadata, Node, Package, PackageId};
 
 use tempdir::TempDir;
 

--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use semver::Version;
+use semver::VersionReq;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-pub type CrateSettingsPerVersion = HashMap<Version, CrateSettings>;
+pub type CrateSettingsPerVersion = HashMap<VersionReq, CrateSettings>;
 
 /**
  * A "deserializable struct" for the whole Cargo.toml

--- a/impl/src/templates/workspace.BUILD.template
+++ b/impl/src/templates/workspace.BUILD.template
@@ -9,22 +9,10 @@ licenses([
   "notice" # See individual crates for specific licenses
 ])
 
-{%- for crate in crates %}
-{%- if crate.is_root_dependency and crate.lib_target_name %}
-{%- set crate_name_sanitized = crate.pkg_name | replace(from="-", to="_") %}
+{%- for alias in aliases %}
 alias(
-    name = "{{crate_name_sanitized}}",
-    actual = "{{crate.workspace_path_to_crate}}:{{crate_name_sanitized}}",
+    name = "{{alias.alias}}",
+    actual = "{{alias.target}}",
     tags = ["cargo-raze"],
 )
-{%- endif %}
-{%- for aliased_target in crate.raze_settings.extra_aliased_targets %}
-alias(
-    # Extra aliased target, from raze configuration
-    # N.B.: The exact form of this is subject to change.
-    name = "{{aliased_target}}",
-    actual = "{{crate.workspace_path_to_crate}}:{{aliased_target}}",
-    tags = ["cargo-raze"],
-)
-{%- endfor %}
 {%- endfor %}


### PR DESCRIPTION
So in closing out #123 for #162 an important use case was missed, that of allowing top level aliases in the cargo that raze itself is going to load.

This is pretty important for large monorepos where doing a full migration of types upfront is pretty challenging.

Previously aliases could only exist inside targets that cargo-raze
depends on and not in the raze "root" crate itself.

This means that a construction such as the following

```toml
bytes = "2.0"
bytes_old = { version = "1.0", package = "bytes" }
```

Could not allow for the production of top level bazel aliases such as:

```python
"//cargo:bytes",
"//cargo:bytes_old",
```

This naturally turns up in larger codebases where migrartions are in
progress from one crate to another.