### PR TITLE
Fixed issue generating valid Starlark files when no dependencies are defined

### DIFF
--- a/impl/src/templates/remote_crates.bzl.template
+++ b/impl/src/templates/remote_crates.bzl.template
@@ -16,8 +16,9 @@ def _new_git_repository(name, **kwargs):
         new_git_repository(name=name, **kwargs)
 
 def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
-{% for crate in crates %}
-    {%- if crate.source_details.git_data %}
+{%- if crates %}
+    {% for crate in crates %}
+        {%- if crate.source_details.git_data %}
     _new_git_repository(
         name = "{{workspace.gen_workspace_prefix}}__{{crate.pkg_name | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}}",
         remote = "{{crate.source_details.git_data.remote}}",
@@ -26,7 +27,7 @@ def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
         init_submodules = True,
         {%- include "templates/partials/remote_crates_patch.template" %}
     )
-    {%- else %}
+        {%- else %}
     _new_http_archive(
         name = "{{workspace.gen_workspace_prefix}}__{{crate.pkg_name | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}}",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/{{crate.pkg_name}}/{{crate.pkg_name}}-{{crate.pkg_version}}.crate",
@@ -38,5 +39,8 @@ def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
         {%- include "templates/partials/remote_crates_patch.template" %}
         build_file = Label("{{workspace.workspace_path}}/remote:{{crate.pkg_name}}-{{crate.pkg_version}}.{{workspace.output_buildfile_suffix}}"),
     )
-    {%- endif %}
-{% endfor %}
+        {%- endif %}
+    {% endfor %}
+{%- else %}
+    pass
+{% endif %}


### PR DESCRIPTION
I stubbed out a project that I was going to use `cargo-raze` with and noticed that because I did not define any dependencies in my `Cargo.toml` file, `cargo-raze` did not generate valid starlark in the resulting `crates.bzl`. I'm not sure what I should do in the way of updating any tests for this within the repo. But I've added a small repro case in this pull request that fixes the issue.

[test.zip](https://github.com/google/cargo-raze/files/5104185/test.zip)
```
├── BUILD.bazel
├── Cargo.lock
├── Cargo.toml
├── WORKSPACE
├── crates.bzl
├── lib
│   ├── BUILD
│   ├── hello-time.cc
│   └── hello-time.h
├── main
│   ├── BUILD
│   ├── hello-greet.cc
│   ├── hello-greet.h
│   └── hello-world.cc
└── remote
    └── BUILD.bazel

3 directories, 13 files
```
Note: The C++ files in the test are copied from https://github.com/bazelbuild/examples/tree/master/cpp-tutorial/stage3

To test, download the zip, and run `cargo raze` and `bazel build //...`. This now succeeds in with these changes.
```command
cargo raze
```
```output
Loaded override settings: RazeSettings {
    workspace_path: "//cargo",
    target: "x86_64-unknown-linux-gnu",
    crates: {},
    gen_workspace_prefix: "raze",
    genmode: Remote,
    output_buildfile_suffix: "BUILD.bazel",
    default_gen_buildrs: false,
}
Generated ./remote/BUILD.bazel successfully
Generated ./BUILD.bazel successfully
Generated ./crates.bzl successfully
```
```command
bazel build //...
```
```output
INFO: Invocation ID: 4d489fb7-e6bf-4295-9edf-6fbe139a09d2
INFO: Analyzed 3 targets (27 packages loaded, 129 targets configured).
INFO: Found 3 targets...
INFO: Elapsed time: 4.545s, Critical Path: 0.06s
INFO: 8 processes: 8 remote cache hit.
INFO: Build completed successfully, 11 total actions
```