### PR TITLE
docs: update instructions for lockfile generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,16 +120,11 @@ targets.
 $ cargo install cargo-raze
 ```
 
-Then, generate a lock file for your dependencies
+Following that, vendor your dependencies from within the cargo/ directory. This
+will also update your `Cargo.lock` file.
 
 ```bash
-$ cargo generate-lockfile
-```
-
-Following that, vendor your dependencies from within the cargo/ directory.
-
-```bash
-$ cargo vendor --versioned-dirs --locked
+$ cargo vendor --versioned-dirs
 ```
 
 Finally, generate your BUILD files, again from within the cargo/ directory

--- a/examples/remote/non_cratesio/README.md
+++ b/examples/remote/non_cratesio/README.md
@@ -7,9 +7,8 @@
 2. Generate a Cargo.toml with desired dependencies into cargo/Cargo.toml
 3. Add a [raze] section with your desired options (see cargo-raze `settings::CargoToml` for
    the exact details)
-4. Run `cargo generate-lockfile` from `cargo/`
-5. Run `cargo vendor --versioned-dirs --locked` from `cargo/`
-6. Run `cargo raze` from `cargo/`
+4. Run `cargo vendor --versioned-dirs` from `cargo/`
+5. Run `cargo raze` from `cargo/`
 
 At this point you will have a dependency specification that Bazel can understand. You will also have starter BUILD files that referene the specified dependencies and generate rust_library rules.
 

--- a/examples/vendored/complicated_cargo_library/README.md
+++ b/examples/vendored/complicated_cargo_library/README.md
@@ -7,7 +7,7 @@ This is similar to hello_cargo_library, but has more dependencies.
 In order to build this example, the dependencies must be vendored. This can be achieved by performing the following:
 
 1. Navigate to `./examples/vendored/complicated_cargo_library` from the root of the `cargo-raze` checkout
-2. Run `cargo vendor --versioned-dirs --locked cargo/vendor`
+2. Run `cargo vendor --versioned-dirs cargo/vendor`
 3. Rerun `cargo raze` to regenerate the Bazel BUILD files
 
 At this point you should now be able to run `bazel build ...` to compile the source code.

--- a/examples/vendored/hello_cargo_library/README.md
+++ b/examples/vendored/hello_cargo_library/README.md
@@ -5,7 +5,7 @@
 In order to build this example, the dependencies must be vendored. This can be achieved by performing the following:
 
 1. Navigate to `./examples/vendored/hello_cargo_library` from the root of the `cargo-raze` checkout
-2. Run `cargo vendor --versioned-dirs --locked cargo/vendor`
+2. Run `cargo vendor --versioned-dirs cargo/vendor`
 3. Rerun `cargo raze` to regenerate the Bazel BUILD files
 
 At this point you should now be able to run `bazel build ...` to compile the source code.

--- a/examples/vendored/non_cratesio_library/README.md
+++ b/examples/vendored/non_cratesio_library/README.md
@@ -5,7 +5,7 @@
 In order to build this example, the dependencies must be vendored. This can be achieved by performing the following:
 
 1. Navigate to `./examples/vendored/non_cratesio_library` from the root of the `cargo-raze` checkout
-2. Run `cargo vendor --versioned-dirs --locked cargo/vendor`
+2. Run `cargo vendor --versioned-dirs cargo/vendor`
 3. Rerun `cargo raze` to regenerate the Bazel BUILD files
 
 At this point you should now be able to run `bazel build ...` to compile the source code.

--- a/examples/vendored/regression_test/README.md
+++ b/examples/vendored/regression_test/README.md
@@ -7,9 +7,8 @@
 2. Generate a Cargo.toml with desired dependencies into cargo/Cargo.toml
 3. Add a [raze] section with your desired options (see cargo-raze `settings::CargoToml` for
    the exact details)
-4. Run `cargo generate-lockfile` from `cargo/`
-5. Run `cargo vendor --versioned-dirs --locked` from `cargo/`
-6. Run `cargo raze` from `cargo/`
+4. Run `cargo vendor --versioned-dirs` from `cargo/`
+5. Run `cargo raze` from `cargo/`
 
 At this point you will have a dependency specification that Bazel can understand. You will also have starter BUILD files that referene the specified dependencies and generate rust_library rules.
 

--- a/smoke_test/remote/non_cratesio/README.md
+++ b/smoke_test/remote/non_cratesio/README.md
@@ -7,9 +7,8 @@
 2. Generate a Cargo.toml with desired dependencies into cargo/Cargo.toml
 3. Add a [raze] section with your desired options (see cargo-raze `settings::CargoToml` for
    the exact details)
-4. Run `cargo generate-lockfile` from `cargo/`
-5. Run `cargo vendor --versioned-dirs --locked` from `cargo/`
-6. Run `cargo raze` from `cargo/`
+4. Run `cargo vendor --versioned-dirs` from `cargo/`
+5. Run `cargo raze` from `cargo/`
 
 At this point you will have a dependency specification that Bazel can understand. You will also have starter BUILD files that referene the specified dependencies and generate rust_library rules.
 

--- a/smoke_test/vendored/complicated_cargo_library/README.md
+++ b/smoke_test/vendored/complicated_cargo_library/README.md
@@ -7,7 +7,7 @@ This is similar to hello_cargo_library, but has more dependencies.
 In order to build this example, the dependencies must be vendored. This can be achieved by performing the following:
 
 1. Navigate to `./examples/vendored/complicated_cargo_library` from the root of the `cargo-raze` checkout
-2. Run `cargo vendor --versioned-dirs --locked cargo/vendor`
+2. Run `cargo vendor --versioned-dirs cargo/vendor`
 3. Rerun `cargo raze` to regenerate the Bazel BUILD files
 
 At this point you should now be able to run `bazel build ...` to compile the source code.

--- a/smoke_test/vendored/hello_cargo_library/README.md
+++ b/smoke_test/vendored/hello_cargo_library/README.md
@@ -5,7 +5,7 @@
 In order to build this example, the dependencies must be vendored. This can be achieved by performing the following:
 
 1. Navigate to `./examples/vendored/hello_cargo_library` from the root of the `cargo-raze` checkout
-2. Run `cargo vendor --versioned-dirs --locked cargo/vendor`
+2. Run `cargo vendor --versioned-dirs cargo/vendor`
 3. Rerun `cargo raze` to regenerate the Bazel BUILD files
 
 At this point you should now be able to run `bazel build ...` to compile the source code.

--- a/smoke_test/vendored/non_cratesio_library/README.md
+++ b/smoke_test/vendored/non_cratesio_library/README.md
@@ -5,7 +5,7 @@
 In order to build this example, the dependencies must be vendored. This can be achieved by performing the following:
 
 1. Navigate to `./examples/vendored/non_cratesio_library` from the root of the `cargo-raze` checkout
-2. Run `cargo vendor --versioned-dirs --locked cargo/vendor`
+2. Run `cargo vendor --versioned-dirs cargo/vendor`
 3. Rerun `cargo raze` to regenerate the Bazel BUILD files
 
 At this point you should now be able to run `bazel build ...` to compile the source code.

--- a/smoke_test/vendored/regression_test/README.md
+++ b/smoke_test/vendored/regression_test/README.md
@@ -7,9 +7,8 @@
 2. Generate a Cargo.toml with desired dependencies into cargo/Cargo.toml
 3. Add a [raze] section with your desired options (see cargo-raze `settings::CargoToml` for
    the exact details)
-4. Run `cargo generate-lockfile` from `cargo/`
-5. Run `cargo vendor --versioned-dirs --locked` from `cargo/`
-6. Run `cargo raze` from `cargo/`
+4. Run `cargo vendor --versioned-dirs` from `cargo/`
+5. Run `cargo raze` from `cargo/`
 
 At this point you will have a dependency specification that Bazel can understand. You will also have starter BUILD files that referene the specified dependencies and generate rust_library rules.
 


### PR DESCRIPTION
`cargo vendor` currently outputs helptext regarding updating
`.cargo/config.toml` in order to replace crates.io sources with the
vendored sources, e.g.:

```
➜ cargo vendor --versioned-dirs
To use vendored sources, add this to your .cargo/config for this
project:

[source.crates-io]
replace-with = "vendored-sources"

[source.vendored-sources]
directory = "path/to/vendor"
```

If a user adds this to their `.cargo/config.toml` configuration prior to
the first run of `cargo vendor`, then `cargo generate-lockfile` and
`cargo vendor --locked` will fail to update the lockfile.

This patch removes the instructions related to generating the lockfile
with `cargo generate-lockfile` (and the subsequent `--locked` flag to
`cargo vendor`), instead preferring to let `cargo vendor` manage the
lockfile. The updated series of commands works in all cases, including
first runs which already have a `.cargo/config.toml` file replacing
`crates-io` sources. It's also now one command and one flag shorter,
which some people might like too, I guess.