### PR TITLE
Added support for custom registry urls

### DIFF
--- a/impl/src/bazel.rs
+++ b/impl/src/bazel.rs
@@ -567,6 +567,7 @@ mod tests {
         git_data: None,
       },
       sha256: None,
+      registry_url: "https://crates.io/api/v1/crates/test-binary/1.1.1/download".to_string(),
       lib_target_name: None,
     }
   }
@@ -606,6 +607,7 @@ mod tests {
         git_data: None,
       },
       sha256: None,
+      registry_url: "https://crates.io/api/v1/crates/test-binary/1.1.1/download".to_string(),
       lib_target_name: Some("test_library".to_owned()),
     }
   }

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -105,6 +105,7 @@ pub struct CrateContext {
   pub build_script_target: Option<BuildableTarget>,
   pub source_details: SourceDetails,
   pub sha256: Option<String>,
+  pub registry_url: String,
 
   // TODO(acmcarther): This is used internally by renderer to know where to put the build file. It
   // probably should live somewhere else. Renderer params (separate from context) should live

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -40,7 +40,7 @@ use crate::{
   metadata::{
     CargoWorkspaceFiles, DependencyKind, Metadata, MetadataFetcher, Node, Package, PackageId,
   },
-  settings::{CrateSettings, GenMode, RazeSettings},
+  settings::{format_registry_url, CrateSettings, GenMode, RazeSettings},
   util::{self, PlatformDetails, RazeError, PLEASE_FILE_A_BUG},
 };
 
@@ -579,6 +579,11 @@ impl<'planner> CrateSubplanner<'planner> {
       source_details: self.produce_source_details(),
       expected_build_path: self.crate_catalog_entry.local_build_path(&self.settings),
       sha256: self.sha256.clone(),
+      registry_url: format_registry_url(
+        &self.settings.registry,
+        &package.name,
+        &package.version.to_string(),
+      ),
       lib_target_name,
       targets,
     };

--- a/impl/src/templates/remote_crates.bzl.template
+++ b/impl/src/templates/remote_crates.bzl.template
@@ -27,7 +27,7 @@ def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
     maybe(
         http_archive,
         name = "{{workspace.gen_workspace_prefix}}__{{crate.pkg_name | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}}",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/{{crate.pkg_name}}/{{crate.pkg_name}}-{{crate.pkg_version}}.crate",
+        url = "{{ crate.registry_url }}",
         type = "tar.gz",
         {%  if crate.sha256 -%}
         sha256 = "{{crate.sha256}}",


### PR DESCRIPTION
This change allows for users to change the registry url used in the output Bazel files. The new setting:

```toml
[raze]
registry = "https://crates-io.s3-us-west-1.amazonaws.com/crates/{crate}/{crate}-{version}.crate"
```

Is a templated string that will replace `{crate}` with the name of the crate and `{version}` with the version of the crate. This change should not impact any existing files generated from `v5.0.0` of `cargo-raze`