### PR TITLE
Change &String function parameters to &str

### DIFF
--- a/impl/src/bazel.rs
+++ b/impl/src/bazel.rs
@@ -77,10 +77,10 @@ static SUPPORTED_PLATFORM_TRIPLES: &'static [&'static str] = &[
  * | `cfg(foo)`                            | `(false, false)` | `foo` is not a strongly defined cfg value.       |
  * | `cfg(target_os = "redox")`            | `(false, false)` | `redox` is not a supported platform.             |
  */
-pub fn is_bazel_supported_platform(target: &String) -> (bool, bool) {
+pub fn is_bazel_supported_platform(target: &str) -> (bool, bool) {
   // Ensure the target is represented as an expression
   let target_exp = match target.starts_with("cfg(") {
-    true => target.clone(),
+    true => target.to_owned(),
     false => format!("cfg(target = \"{}\")", target),
   };
 
@@ -125,9 +125,9 @@ pub fn is_bazel_supported_platform(target: &String) -> (bool, bool) {
  * Note, the Bazel triples must be defined in:
  * https://github.com/bazelbuild/rules_rust/blob/master/rust/platform/platform.bzl
  */
-pub fn get_matching_bazel_triples(target: &String) -> Result<Vec<String>> {
+pub fn get_matching_bazel_triples(target: &str) -> Result<Vec<String>> {
   let target_exp = match target.starts_with("cfg(") {
-    true => target.clone(),
+    true => target.to_owned(),
     false => format!("cfg(target=\"{}\")", target),
   };
 
@@ -845,39 +845,39 @@ mod tests {
   #[test]
   fn detect_bazel_platforms() {
     assert_eq!(
-      is_bazel_supported_platform(&"cfg(not(fuchsia))".to_string()),
+      is_bazel_supported_platform("cfg(not(fuchsia))"),
       (true, true)
     );
     assert_eq!(
-      is_bazel_supported_platform(&"cfg(not(target_os = \"redox\"))".to_string()),
+      is_bazel_supported_platform("cfg(not(target_os = \"redox\"))"),
       (true, true)
     );
     assert_eq!(
-      is_bazel_supported_platform(&"cfg(unix)".to_string()),
+      is_bazel_supported_platform("cfg(unix)"),
       (true, false)
     );
     assert_eq!(
-      is_bazel_supported_platform(&"cfg(not(windows))".to_string()),
+      is_bazel_supported_platform("cfg(not(windows))"),
       (true, false)
     );
     assert_eq!(
-      is_bazel_supported_platform(&"cfg(target = \"x86_64-apple-darwin\")".to_string()),
+      is_bazel_supported_platform("cfg(target = \"x86_64-apple-darwin\")"),
       (true, false)
     );
     assert_eq!(
-      is_bazel_supported_platform(&"x86_64-apple-darwin".to_string()),
+      is_bazel_supported_platform("x86_64-apple-darwin"),
       (true, false)
     );
     assert_eq!(
-      is_bazel_supported_platform(&"unknown-unknown-unknown".to_string()),
+      is_bazel_supported_platform("unknown-unknown-unknown"),
       (false, false)
     );
     assert_eq!(
-      is_bazel_supported_platform(&"cfg(foo)".to_string()),
+      is_bazel_supported_platform("cfg(foo)"),
       (false, false)
     );
     assert_eq!(
-      is_bazel_supported_platform(&"cfg(target_os = \"redox\")".to_string()),
+      is_bazel_supported_platform("cfg(target_os = \"redox\")"),
       (false, false)
     );
   }

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -204,7 +204,7 @@ impl CrateCatalogEntry {
    *
    * Not for use except during planning as path is local to run location.
    */
-  pub fn expected_vendored_path(&self, workspace_path: &String) -> String {
+  pub fn expected_vendored_path(&self, workspace_path: &str) -> String {
     let mut dir = find_workspace_root().unwrap_or(PathBuf::from("."));
 
     // Trim the absolute label identifier from the start of the workspace path
@@ -391,7 +391,7 @@ impl<'planner> WorkspaceSubplanner<'planner> {
     if self.settings.genmode != GenMode::Remote {
       checks::check_all_vendored(
         self.crate_catalog.entries(),
-        &self.settings.workspace_path.to_string(),
+        &self.settings.workspace_path,
       )?;
     }
 
@@ -976,7 +976,7 @@ mod checks {
   // Verifies that all provided packages are vendored (in VENDOR_DIR relative to CWD)
   pub fn check_all_vendored(
     crate_catalog_entries: &[CrateCatalogEntry],
-    workspace_path: &String,
+    workspace_path: &str,
   ) -> Result<()> {
     let missing_package_ident_iter = crate_catalog_entries
       .iter()

--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -304,7 +304,7 @@ fn incompatible_relative_workspace_path() -> bool {
 }
 
 /** Formats a registry url to include the name and version fo the target package */
-pub fn format_registry_url(registry_url: &String, name: &String, version: &String) -> String {
+pub fn format_registry_url(registry_url: &str, name: &str, version: &str) -> String {
   registry_url
     .replace("{crate}", name)
     .replace("{version}", version)


### PR DESCRIPTION
The use of `&String` in function parameters is discouraged in favor of
`&str` as it otherwise forces passing heap-allocated values (which
doesn't include e.g. string literals).

A small contribution before other, more meaningful ones hopefully :-)