### PR TITLE
Allow matching triples directly

### DIFF
--- a/examples/remote/complicated_cargo_library/cargo/remote/winapi-0.3.9.BUILD.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/winapi-0.3.9.BUILD.bazel
@@ -36,7 +36,23 @@ rust_library(
     name = "winapi",
     crate_type = "lib",
     deps = [
-    ],
+    ] + selects.with_or({
+        # i686-pc-windows-gnu
+        (
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
+        ): [
+            "@remote_complicated_cargo_library__winapi_i686_pc_windows_gnu__0_4_0//:winapi_i686_pc_windows_gnu",
+        ],
+        "//conditions:default": [],
+    }) + selects.with_or({
+        # x86_64-pc-windows-gnu
+        (
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+        ): [
+            "@remote_complicated_cargo_library__winapi_x86_64_pc_windows_gnu__0_4_0//:winapi_x86_64_pc_windows_gnu",
+        ],
+        "//conditions:default": [],
+    }),
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
     edition = "2015",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-0.3.9/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-0.3.9/BUILD.bazel
@@ -36,7 +36,23 @@ rust_library(
     name = "winapi",
     crate_type = "lib",
     deps = [
-    ],
+    ] + selects.with_or({
+        # i686-pc-windows-gnu
+        (
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
+        ): [
+            "//vendored/complicated_cargo_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0:winapi_i686_pc_windows_gnu",
+        ],
+        "//conditions:default": [],
+    }) + selects.with_or({
+        # x86_64-pc-windows-gnu
+        (
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+        ): [
+            "//vendored/complicated_cargo_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0:winapi_x86_64_pc_windows_gnu",
+        ],
+        "//conditions:default": [],
+    }),
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
     edition = "2015",

--- a/impl/src/bazel.rs
+++ b/impl/src/bazel.rs
@@ -120,7 +120,7 @@ pub fn is_bazel_supported_platform(target: &str) -> (bool, bool) {
   (is_supported, matches_all)
 }
 
-/** Maps a Rust cfg target to a Bazel supported triples.
+/** Maps a Rust cfg or triple target to Bazel supported triples.
  *
  * Note, the Bazel triples must be defined in:
  * https://github.com/bazelbuild/rules_rust/blob/master/rust/platform/platform.bzl
@@ -128,7 +128,7 @@ pub fn is_bazel_supported_platform(target: &str) -> (bool, bool) {
 pub fn get_matching_bazel_triples(target: &str) -> Result<Vec<String>> {
   let target_exp = match target.starts_with("cfg(") {
     true => target.to_owned(),
-    false => format!("cfg(target=\"{}\")", target),
+    false => format!("cfg(target = \"{}\")", target),
   };
 
   let expression = Expression::parse(&target_exp)?;
@@ -139,6 +139,10 @@ pub fn get_matching_bazel_triples(target: &str) -> Result<Vec<String>> {
       match expression.eval(|pred| {
         match pred {
           Predicate::Target(tp) => tp.matches(target_info),
+          Predicate::KeyValue {
+            key,
+            val,
+          } => (*key == "target") && (*val == target_info.triple),
           // For now there is no other kind of matching
           _ => false,
         }


### PR DESCRIPTION
Before this change, the get_matching_bazel_triples would only allow matching cfg(...) targets. It seems that the intended behaviour was to allow passing triples (such as `x86_64-unknown-linux-gnu`) directly, as per the `format!("cfg(target = \"{}\")", target)` replacement at the beginning of the function. Unfortunately, the match was missing the right case below (`Predicate::Target(tp)` only matches builtin `target_{arch,os,...}`).

This makes this function more consistent with `is_bazel_supported_platform` above, and it seems to solve a bug where target specific dependencies specified with triples (such as is the case for the `winapi` crate in one of the `complicated_cargo_library` example) would be ignored.

FYI you can see the winapi targeted dependencies here: https://github.com/retep998/winapi-rs/blob/785f7f30a69c70687864ac650aebc123e942c1b3/Cargo.toml#L20-L23