### PR TITLE
Fixed rust-analyzer errors

### DIFF
--- a/impl/src/bin/cargo-raze.rs
+++ b/impl/src/bin/cargo-raze.rs
@@ -31,7 +31,7 @@ use cargo_raze::{
   util::PlatformDetails,
 };
 
-use serde_derive::Deserialize;
+use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 struct Options {

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::settings::CrateSettings;
-use serde_derive::Serialize;
+use serde::Serialize;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct BuildableDependency {

--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -14,7 +14,7 @@
 
 use super::util::RazeError;
 use semver::Version;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fs::File, io::Read, path::Path};
 
 pub type CrateSettingsPerVersion = HashMap<Version, CrateSettings>;


### PR DESCRIPTION
This resolved the following issues flagged by rust-analyzer:

<img width="531" alt="Screen Shot 2020-10-08 at 6 26 46 AM" src="https://user-images.githubusercontent.com/26427366/95464877-517a1400-092f-11eb-98ed-d60bb8be3a6b.png">

That said though, there should be no behavioral difference in the code.