### PR TITLE
Update registry url

### DIFF
--- a/examples/remote/complicated_cargo_library/cargo/crates.bzl
+++ b/examples/remote/complicated_cargo_library/cargo/crates.bzl
@@ -14,7 +14,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__MacTypes_sys__1_3_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/MacTypes-sys/MacTypes-sys-1.3.0.crate",
+        url = "https://crates.io/api/v1/crates/MacTypes-sys/1.3.0/download",
         type = "tar.gz",
         sha256 = "7dbbe033994ae2198a18517c7132d952a29fb1db44249a1234779da7c50f4698",
         strip_prefix = "MacTypes-sys-1.3.0",
@@ -24,7 +24,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__aho_corasick__0_6_10",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/aho-corasick/aho-corasick-0.6.10.crate",
+        url = "https://crates.io/api/v1/crates/aho-corasick/0.6.10/download",
         type = "tar.gz",
         sha256 = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5",
         strip_prefix = "aho-corasick-0.6.10",
@@ -34,7 +34,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__arrayvec__0_3_25",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/arrayvec/arrayvec-0.3.25.crate",
+        url = "https://crates.io/api/v1/crates/arrayvec/0.3.25/download",
         type = "tar.gz",
         sha256 = "06f59fe10306bb78facd90d28c2038ad23ffaaefa85bac43c8a434cde383334f",
         strip_prefix = "arrayvec-0.3.25",
@@ -44,7 +44,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__atom__0_3_5",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/atom/atom-0.3.5.crate",
+        url = "https://crates.io/api/v1/crates/atom/0.3.5/download",
         type = "tar.gz",
         sha256 = "3c86699c3f02778ec07158376991c8f783dd1f2f95c579ffaf0738dc984b2fe2",
         strip_prefix = "atom-0.3.5",
@@ -54,7 +54,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__autocfg__1_0_1",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/autocfg/autocfg-1.0.1.crate",
+        url = "https://crates.io/api/v1/crates/autocfg/1.0.1/download",
         type = "tar.gz",
         sha256 = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a",
         strip_prefix = "autocfg-1.0.1",
@@ -64,7 +64,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__cc__1_0_60",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/cc/cc-1.0.60.crate",
+        url = "https://crates.io/api/v1/crates/cc/1.0.60/download",
         type = "tar.gz",
         sha256 = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c",
         strip_prefix = "cc-1.0.60",
@@ -74,7 +74,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__cfg_if__0_1_10",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/cfg-if/cfg-if-0.1.10.crate",
+        url = "https://crates.io/api/v1/crates/cfg-if/0.1.10/download",
         type = "tar.gz",
         sha256 = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822",
         strip_prefix = "cfg-if-0.1.10",
@@ -84,7 +84,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__core_foundation_sys__0_5_1",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/core-foundation-sys/core-foundation-sys-0.5.1.crate",
+        url = "https://crates.io/api/v1/crates/core-foundation-sys/0.5.1/download",
         type = "tar.gz",
         sha256 = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa",
         strip_prefix = "core-foundation-sys-0.5.1",
@@ -94,7 +94,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__crossbeam__0_3_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/crossbeam/crossbeam-0.3.2.crate",
+        url = "https://crates.io/api/v1/crates/crossbeam/0.3.2/download",
         type = "tar.gz",
         sha256 = "24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19",
         strip_prefix = "crossbeam-0.3.2",
@@ -104,7 +104,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__crossbeam_channel__0_4_4",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/crossbeam-channel/crossbeam-channel-0.4.4.crate",
+        url = "https://crates.io/api/v1/crates/crossbeam-channel/0.4.4/download",
         type = "tar.gz",
         sha256 = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87",
         strip_prefix = "crossbeam-channel-0.4.4",
@@ -114,7 +114,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__crossbeam_deque__0_7_3",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/crossbeam-deque/crossbeam-deque-0.7.3.crate",
+        url = "https://crates.io/api/v1/crates/crossbeam-deque/0.7.3/download",
         type = "tar.gz",
         sha256 = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285",
         strip_prefix = "crossbeam-deque-0.7.3",
@@ -124,7 +124,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__crossbeam_epoch__0_8_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/crossbeam-epoch/crossbeam-epoch-0.8.2.crate",
+        url = "https://crates.io/api/v1/crates/crossbeam-epoch/0.8.2/download",
         type = "tar.gz",
         sha256 = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace",
         strip_prefix = "crossbeam-epoch-0.8.2",
@@ -134,7 +134,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__crossbeam_utils__0_7_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/crossbeam-utils/crossbeam-utils-0.7.2.crate",
+        url = "https://crates.io/api/v1/crates/crossbeam-utils/0.7.2/download",
         type = "tar.gz",
         sha256 = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8",
         strip_prefix = "crossbeam-utils-0.7.2",
@@ -144,7 +144,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__derivative__1_0_4",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/derivative/derivative-1.0.4.crate",
+        url = "https://crates.io/api/v1/crates/derivative/1.0.4/download",
         type = "tar.gz",
         sha256 = "3c6d883546668a3e2011b6a716a7330b82eabb0151b138217f632c8243e17135",
         strip_prefix = "derivative-1.0.4",
@@ -154,7 +154,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__fnv__1_0_7",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/fnv/fnv-1.0.7.crate",
+        url = "https://crates.io/api/v1/crates/fnv/1.0.7/download",
         type = "tar.gz",
         sha256 = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
         strip_prefix = "fnv-1.0.7",
@@ -164,7 +164,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__hermit_abi__0_1_15",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/hermit-abi/hermit-abi-0.1.15.crate",
+        url = "https://crates.io/api/v1/crates/hermit-abi/0.1.15/download",
         type = "tar.gz",
         sha256 = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9",
         strip_prefix = "hermit-abi-0.1.15",
@@ -174,7 +174,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__hibitset__0_3_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/hibitset/hibitset-0.3.2.crate",
+        url = "https://crates.io/api/v1/crates/hibitset/0.3.2/download",
         type = "tar.gz",
         sha256 = "b78998e3c243d71525596e8f373dfc4b82703f25907b9e4d260383cff8307d84",
         strip_prefix = "hibitset-0.3.2",
@@ -184,7 +184,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__lazy_static__1_4_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/lazy_static/lazy_static-1.4.0.crate",
+        url = "https://crates.io/api/v1/crates/lazy_static/1.4.0/download",
         type = "tar.gz",
         sha256 = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
         strip_prefix = "lazy_static-1.4.0",
@@ -194,7 +194,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__libc__0_2_77",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/libc/libc-0.2.77.crate",
+        url = "https://crates.io/api/v1/crates/libc/0.2.77/download",
         type = "tar.gz",
         sha256 = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235",
         strip_prefix = "libc-0.2.77",
@@ -204,7 +204,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__libloading__0_5_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/libloading/libloading-0.5.2.crate",
+        url = "https://crates.io/api/v1/crates/libloading/0.5.2/download",
         type = "tar.gz",
         sha256 = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753",
         strip_prefix = "libloading-0.5.2",
@@ -214,7 +214,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__maybe_uninit__2_0_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/maybe-uninit/maybe-uninit-2.0.0.crate",
+        url = "https://crates.io/api/v1/crates/maybe-uninit/2.0.0/download",
         type = "tar.gz",
         sha256 = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00",
         strip_prefix = "maybe-uninit-2.0.0",
@@ -224,7 +224,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__memchr__2_3_3",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/memchr/memchr-2.3.3.crate",
+        url = "https://crates.io/api/v1/crates/memchr/2.3.3/download",
         type = "tar.gz",
         sha256 = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400",
         strip_prefix = "memchr-2.3.3",
@@ -234,7 +234,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__memoffset__0_5_5",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/memoffset/memoffset-0.5.5.crate",
+        url = "https://crates.io/api/v1/crates/memoffset/0.5.5/download",
         type = "tar.gz",
         sha256 = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f",
         strip_prefix = "memoffset-0.5.5",
@@ -244,7 +244,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__mopa__0_2_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/mopa/mopa-0.2.2.crate",
+        url = "https://crates.io/api/v1/crates/mopa/0.2.2/download",
         type = "tar.gz",
         sha256 = "a785740271256c230f57462d3b83e52f998433a7062fc18f96d5999474a9f915",
         strip_prefix = "mopa-0.2.2",
@@ -254,7 +254,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__nodrop__0_1_14",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/nodrop/nodrop-0.1.14.crate",
+        url = "https://crates.io/api/v1/crates/nodrop/0.1.14/download",
         type = "tar.gz",
         sha256 = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb",
         strip_prefix = "nodrop-0.1.14",
@@ -264,7 +264,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__num_cpus__1_13_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/num_cpus/num_cpus-1.13.0.crate",
+        url = "https://crates.io/api/v1/crates/num_cpus/1.13.0/download",
         type = "tar.gz",
         sha256 = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3",
         strip_prefix = "num_cpus-1.13.0",
@@ -274,7 +274,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__odds__0_2_26",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/odds/odds-0.2.26.crate",
+        url = "https://crates.io/api/v1/crates/odds/0.2.26/download",
         type = "tar.gz",
         sha256 = "4eae0151b9dacf24fcc170d9995e511669a082856a91f958a2fe380bfab3fb22",
         strip_prefix = "odds-0.2.26",
@@ -284,7 +284,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__proc_macro2__0_4_30",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/proc-macro2/proc-macro2-0.4.30.crate",
+        url = "https://crates.io/api/v1/crates/proc-macro2/0.4.30/download",
         type = "tar.gz",
         sha256 = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759",
         strip_prefix = "proc-macro2-0.4.30",
@@ -294,7 +294,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__pulse__0_5_3",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/pulse/pulse-0.5.3.crate",
+        url = "https://crates.io/api/v1/crates/pulse/0.5.3/download",
         type = "tar.gz",
         sha256 = "655612b6c8d96a8a02f331fe296cb4f925b68e87c1d195544675abca2d9b9af0",
         strip_prefix = "pulse-0.5.3",
@@ -304,7 +304,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__quote__0_3_15",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/quote/quote-0.3.15.crate",
+        url = "https://crates.io/api/v1/crates/quote/0.3.15/download",
         type = "tar.gz",
         sha256 = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a",
         strip_prefix = "quote-0.3.15",
@@ -314,7 +314,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__quote__0_6_13",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/quote/quote-0.6.13.crate",
+        url = "https://crates.io/api/v1/crates/quote/0.6.13/download",
         type = "tar.gz",
         sha256 = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1",
         strip_prefix = "quote-0.6.13",
@@ -324,7 +324,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__rayon__0_8_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/rayon/rayon-0.8.2.crate",
+        url = "https://crates.io/api/v1/crates/rayon/0.8.2/download",
         type = "tar.gz",
         sha256 = "b614fe08b6665cb9a231d07ac1364b0ef3cb3698f1239ee0c4c3a88a524f54c8",
         strip_prefix = "rayon-0.8.2",
@@ -334,7 +334,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__rayon_core__1_8_1",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/rayon-core/rayon-core-1.8.1.crate",
+        url = "https://crates.io/api/v1/crates/rayon-core/1.8.1/download",
         type = "tar.gz",
         sha256 = "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf",
         strip_prefix = "rayon-core-1.8.1",
@@ -344,7 +344,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__regex__0_2_5",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/regex/regex-0.2.5.crate",
+        url = "https://crates.io/api/v1/crates/regex/0.2.5/download",
         type = "tar.gz",
         sha256 = "744554e01ccbd98fff8c457c3b092cd67af62a555a43bfe97ae8a0451f7799fa",
         strip_prefix = "regex-0.2.5",
@@ -354,7 +354,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__regex_syntax__0_4_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/regex-syntax/regex-syntax-0.4.2.crate",
+        url = "https://crates.io/api/v1/crates/regex-syntax/0.4.2/download",
         type = "tar.gz",
         sha256 = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e",
         strip_prefix = "regex-syntax-0.4.2",
@@ -364,7 +364,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__scopeguard__1_1_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/scopeguard/scopeguard-1.1.0.crate",
+        url = "https://crates.io/api/v1/crates/scopeguard/1.1.0/download",
         type = "tar.gz",
         sha256 = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd",
         strip_prefix = "scopeguard-1.1.0",
@@ -374,7 +374,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__security_framework_sys__0_2_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/security-framework-sys/security-framework-sys-0.2.2.crate",
+        url = "https://crates.io/api/v1/crates/security-framework-sys/0.2.2/download",
         type = "tar.gz",
         sha256 = "40d95f3d7da09612affe897f320d78264f0d2320f3e8eea27d12bd1bd94445e2",
         strip_prefix = "security-framework-sys-0.2.2",
@@ -384,7 +384,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__shred__0_5_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/shred/shred-0.5.2.crate",
+        url = "https://crates.io/api/v1/crates/shred/0.5.2/download",
         type = "tar.gz",
         sha256 = "7d3abceaa9d0a9b47ab84b53c6029c21bcad7d7dd63e14db51ea0680faee2159",
         strip_prefix = "shred-0.5.2",
@@ -394,7 +394,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__shred_derive__0_3_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/shred-derive/shred-derive-0.3.0.crate",
+        url = "https://crates.io/api/v1/crates/shred-derive/0.3.0/download",
         type = "tar.gz",
         sha256 = "a4a894913b6e93fe2cd712a3bc955ec6f6b01c675c1c58b02fdfa13f77868049",
         strip_prefix = "shred-derive-0.3.0",
@@ -404,7 +404,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__smallvec__0_4_5",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/smallvec/smallvec-0.4.5.crate",
+        url = "https://crates.io/api/v1/crates/smallvec/0.4.5/download",
         type = "tar.gz",
         sha256 = "f90c5e5fe535e48807ab94fc611d323935f39d4660c52b26b96446a7b33aef10",
         strip_prefix = "smallvec-0.4.5",
@@ -414,7 +414,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__specs__0_10_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/specs/specs-0.10.0.crate",
+        url = "https://crates.io/api/v1/crates/specs/0.10.0/download",
         type = "tar.gz",
         sha256 = "a210dc96ea065cb88391aa6956ed1b2a14051c668b5bc18bac66a95c215b639f",
         strip_prefix = "specs-0.10.0",
@@ -424,7 +424,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__syn__0_11_11",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/syn/syn-0.11.11.crate",
+        url = "https://crates.io/api/v1/crates/syn/0.11.11/download",
         type = "tar.gz",
         sha256 = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad",
         strip_prefix = "syn-0.11.11",
@@ -434,7 +434,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__syn__0_15_44",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/syn/syn-0.15.44.crate",
+        url = "https://crates.io/api/v1/crates/syn/0.15.44/download",
         type = "tar.gz",
         sha256 = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5",
         strip_prefix = "syn-0.15.44",
@@ -444,7 +444,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__synom__0_11_3",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/synom/synom-0.11.3.crate",
+        url = "https://crates.io/api/v1/crates/synom/0.11.3/download",
         type = "tar.gz",
         sha256 = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6",
         strip_prefix = "synom-0.11.3",
@@ -454,7 +454,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__thread_local__0_3_6",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/thread_local/thread_local-0.3.6.crate",
+        url = "https://crates.io/api/v1/crates/thread_local/0.3.6/download",
         type = "tar.gz",
         sha256 = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b",
         strip_prefix = "thread_local-0.3.6",
@@ -464,7 +464,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__time__0_1_44",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/time/time-0.1.44.crate",
+        url = "https://crates.io/api/v1/crates/time/0.1.44/download",
         type = "tar.gz",
         sha256 = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255",
         strip_prefix = "time-0.1.44",
@@ -474,7 +474,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__tuple_utils__0_2_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/tuple_utils/tuple_utils-0.2.0.crate",
+        url = "https://crates.io/api/v1/crates/tuple_utils/0.2.0/download",
         type = "tar.gz",
         sha256 = "cbfecd7bb8f0a3e96b3b31c46af2677a55a588767c0091f484601424fcb20e7e",
         strip_prefix = "tuple_utils-0.2.0",
@@ -484,7 +484,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__unicode_xid__0_0_4",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/unicode-xid/unicode-xid-0.0.4.crate",
+        url = "https://crates.io/api/v1/crates/unicode-xid/0.0.4/download",
         type = "tar.gz",
         sha256 = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc",
         strip_prefix = "unicode-xid-0.0.4",
@@ -494,7 +494,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__unicode_xid__0_1_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/unicode-xid/unicode-xid-0.1.0.crate",
+        url = "https://crates.io/api/v1/crates/unicode-xid/0.1.0/download",
         type = "tar.gz",
         sha256 = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc",
         strip_prefix = "unicode-xid-0.1.0",
@@ -504,7 +504,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__utf8_ranges__1_0_4",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/utf8-ranges/utf8-ranges-1.0.4.crate",
+        url = "https://crates.io/api/v1/crates/utf8-ranges/1.0.4/download",
         type = "tar.gz",
         sha256 = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba",
         strip_prefix = "utf8-ranges-1.0.4",
@@ -514,7 +514,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__wasi__0_10_0_wasi_snapshot_preview1",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/wasi/wasi-0.10.0+wasi-snapshot-preview1.crate",
+        url = "https://crates.io/api/v1/crates/wasi/0.10.0+wasi-snapshot-preview1/download",
         type = "tar.gz",
         sha256 = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f",
         strip_prefix = "wasi-0.10.0+wasi-snapshot-preview1",
@@ -524,7 +524,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__winapi__0_3_9",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi/winapi-0.3.9.crate",
+        url = "https://crates.io/api/v1/crates/winapi/0.3.9/download",
         type = "tar.gz",
         sha256 = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
         strip_prefix = "winapi-0.3.9",
@@ -534,7 +534,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__winapi_i686_pc_windows_gnu__0_4_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi-i686-pc-windows-gnu/winapi-i686-pc-windows-gnu-0.4.0.crate",
+        url = "https://crates.io/api/v1/crates/winapi-i686-pc-windows-gnu/0.4.0/download",
         type = "tar.gz",
         sha256 = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
         strip_prefix = "winapi-i686-pc-windows-gnu-0.4.0",
@@ -544,7 +544,7 @@ def remote_complicated_cargo_library_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_complicated_cargo_library__winapi_x86_64_pc_windows_gnu__0_4_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate",
+        url = "https://crates.io/api/v1/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download",
         type = "tar.gz",
         sha256 = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
         strip_prefix = "winapi-x86_64-pc-windows-gnu-0.4.0",

--- a/examples/remote/non_cratesio/cargo/crates.bzl
+++ b/examples/remote/non_cratesio/cargo/crates.bzl
@@ -14,7 +14,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__aho_corasick__0_6_10",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/aho-corasick/aho-corasick-0.6.10.crate",
+        url = "https://crates.io/api/v1/crates/aho-corasick/0.6.10/download",
         type = "tar.gz",
         sha256 = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5",
         strip_prefix = "aho-corasick-0.6.10",
@@ -24,7 +24,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__atty__0_2_14",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/atty/atty-0.2.14.crate",
+        url = "https://crates.io/api/v1/crates/atty/0.2.14/download",
         type = "tar.gz",
         sha256 = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8",
         strip_prefix = "atty-0.2.14",
@@ -34,7 +34,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__bitflags__1_2_1",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/bitflags/bitflags-1.2.1.crate",
+        url = "https://crates.io/api/v1/crates/bitflags/1.2.1/download",
         type = "tar.gz",
         sha256 = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693",
         strip_prefix = "bitflags-1.2.1",
@@ -44,7 +44,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__cfg_if__0_1_10",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/cfg-if/cfg-if-0.1.10.crate",
+        url = "https://crates.io/api/v1/crates/cfg-if/0.1.10/download",
         type = "tar.gz",
         sha256 = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822",
         strip_prefix = "cfg-if-0.1.10",
@@ -63,7 +63,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__fuchsia_zircon__0_3_3",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/fuchsia-zircon/fuchsia-zircon-0.3.3.crate",
+        url = "https://crates.io/api/v1/crates/fuchsia-zircon/0.3.3/download",
         type = "tar.gz",
         sha256 = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82",
         strip_prefix = "fuchsia-zircon-0.3.3",
@@ -73,7 +73,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__fuchsia_zircon_sys__0_3_3",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/fuchsia-zircon-sys/fuchsia-zircon-sys-0.3.3.crate",
+        url = "https://crates.io/api/v1/crates/fuchsia-zircon-sys/0.3.3/download",
         type = "tar.gz",
         sha256 = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7",
         strip_prefix = "fuchsia-zircon-sys-0.3.3",
@@ -83,7 +83,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__hermit_abi__0_1_15",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/hermit-abi/hermit-abi-0.1.15.crate",
+        url = "https://crates.io/api/v1/crates/hermit-abi/0.1.15/download",
         type = "tar.gz",
         sha256 = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9",
         strip_prefix = "hermit-abi-0.1.15",
@@ -93,7 +93,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__humantime__1_3_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/humantime/humantime-1.3.0.crate",
+        url = "https://crates.io/api/v1/crates/humantime/1.3.0/download",
         type = "tar.gz",
         sha256 = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f",
         strip_prefix = "humantime-1.3.0",
@@ -103,7 +103,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__lazy_static__1_4_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/lazy_static/lazy_static-1.4.0.crate",
+        url = "https://crates.io/api/v1/crates/lazy_static/1.4.0/download",
         type = "tar.gz",
         sha256 = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
         strip_prefix = "lazy_static-1.4.0",
@@ -113,7 +113,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__libc__0_2_77",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/libc/libc-0.2.77.crate",
+        url = "https://crates.io/api/v1/crates/libc/0.2.77/download",
         type = "tar.gz",
         sha256 = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235",
         strip_prefix = "libc-0.2.77",
@@ -132,7 +132,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__log__0_4_11",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/log/log-0.4.11.crate",
+        url = "https://crates.io/api/v1/crates/log/0.4.11/download",
         type = "tar.gz",
         sha256 = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b",
         strip_prefix = "log-0.4.11",
@@ -142,7 +142,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__memchr__2_3_3",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/memchr/memchr-2.3.3.crate",
+        url = "https://crates.io/api/v1/crates/memchr/2.3.3/download",
         type = "tar.gz",
         sha256 = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400",
         strip_prefix = "memchr-2.3.3",
@@ -152,7 +152,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__quick_error__1_2_3",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/quick-error/quick-error-1.2.3.crate",
+        url = "https://crates.io/api/v1/crates/quick-error/1.2.3/download",
         type = "tar.gz",
         sha256 = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0",
         strip_prefix = "quick-error-1.2.3",
@@ -171,7 +171,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__regex__0_2_11",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/regex/regex-0.2.11.crate",
+        url = "https://crates.io/api/v1/crates/regex/0.2.11/download",
         type = "tar.gz",
         sha256 = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384",
         strip_prefix = "regex-0.2.11",
@@ -181,7 +181,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__regex_syntax__0_5_6",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/regex-syntax/regex-syntax-0.5.6.crate",
+        url = "https://crates.io/api/v1/crates/regex-syntax/0.5.6/download",
         type = "tar.gz",
         sha256 = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7",
         strip_prefix = "regex-syntax-0.5.6",
@@ -191,7 +191,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__termcolor__0_3_6",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/termcolor/termcolor-0.3.6.crate",
+        url = "https://crates.io/api/v1/crates/termcolor/0.3.6/download",
         type = "tar.gz",
         sha256 = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83",
         strip_prefix = "termcolor-0.3.6",
@@ -201,7 +201,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__thread_local__0_3_6",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/thread_local/thread_local-0.3.6.crate",
+        url = "https://crates.io/api/v1/crates/thread_local/0.3.6/download",
         type = "tar.gz",
         sha256 = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b",
         strip_prefix = "thread_local-0.3.6",
@@ -211,7 +211,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__ucd_util__0_1_8",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/ucd-util/ucd-util-0.1.8.crate",
+        url = "https://crates.io/api/v1/crates/ucd-util/0.1.8/download",
         type = "tar.gz",
         sha256 = "c85f514e095d348c279b1e5cd76795082cf15bd59b93207832abe0b1d8fed236",
         strip_prefix = "ucd-util-0.1.8",
@@ -221,7 +221,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__utf8_ranges__1_0_4",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/utf8-ranges/utf8-ranges-1.0.4.crate",
+        url = "https://crates.io/api/v1/crates/utf8-ranges/1.0.4/download",
         type = "tar.gz",
         sha256 = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba",
         strip_prefix = "utf8-ranges-1.0.4",
@@ -231,7 +231,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__winapi__0_3_9",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi/winapi-0.3.9.crate",
+        url = "https://crates.io/api/v1/crates/winapi/0.3.9/download",
         type = "tar.gz",
         sha256 = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
         strip_prefix = "winapi-0.3.9",
@@ -241,7 +241,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__winapi_i686_pc_windows_gnu__0_4_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi-i686-pc-windows-gnu/winapi-i686-pc-windows-gnu-0.4.0.crate",
+        url = "https://crates.io/api/v1/crates/winapi-i686-pc-windows-gnu/0.4.0/download",
         type = "tar.gz",
         sha256 = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
         strip_prefix = "winapi-i686-pc-windows-gnu-0.4.0",
@@ -251,7 +251,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__winapi_x86_64_pc_windows_gnu__0_4_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate",
+        url = "https://crates.io/api/v1/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download",
         type = "tar.gz",
         sha256 = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
         strip_prefix = "winapi-x86_64-pc-windows-gnu-0.4.0",
@@ -261,7 +261,7 @@ def remote_non_cratesio_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_non_cratesio__wincolor__0_1_6",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/wincolor/wincolor-0.1.6.crate",
+        url = "https://crates.io/api/v1/crates/wincolor/0.1.6/download",
         type = "tar.gz",
         sha256 = "eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767",
         strip_prefix = "wincolor-0.1.6",

--- a/examples/remote/regression_test/cargo/crates.bzl
+++ b/examples/remote/regression_test/cargo/crates.bzl
@@ -14,7 +14,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__MacTypes_sys__2_1_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/MacTypes-sys/MacTypes-sys-2.1.0.crate",
+        url = "https://crates.io/api/v1/crates/MacTypes-sys/2.1.0/download",
         type = "tar.gz",
         sha256 = "eaf9f0d0b1cc33a4d2aee14fb4b2eac03462ef4db29c8ac4057327d8a71ad86f",
         strip_prefix = "MacTypes-sys-2.1.0",
@@ -24,7 +24,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__aho_corasick__0_6_10",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/aho-corasick/aho-corasick-0.6.10.crate",
+        url = "https://crates.io/api/v1/crates/aho-corasick/0.6.10/download",
         type = "tar.gz",
         sha256 = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5",
         strip_prefix = "aho-corasick-0.6.10",
@@ -34,7 +34,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__arrayvec__0_3_25",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/arrayvec/arrayvec-0.3.25.crate",
+        url = "https://crates.io/api/v1/crates/arrayvec/0.3.25/download",
         type = "tar.gz",
         sha256 = "06f59fe10306bb78facd90d28c2038ad23ffaaefa85bac43c8a434cde383334f",
         strip_prefix = "arrayvec-0.3.25",
@@ -44,7 +44,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__arrayvec__0_4_10",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/arrayvec/arrayvec-0.4.10.crate",
+        url = "https://crates.io/api/v1/crates/arrayvec/0.4.10/download",
         type = "tar.gz",
         sha256 = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71",
         strip_prefix = "arrayvec-0.4.10",
@@ -54,7 +54,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__atom__0_3_5",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/atom/atom-0.3.5.crate",
+        url = "https://crates.io/api/v1/crates/atom/0.3.5/download",
         type = "tar.gz",
         sha256 = "3c86699c3f02778ec07158376991c8f783dd1f2f95c579ffaf0738dc984b2fe2",
         strip_prefix = "atom-0.3.5",
@@ -64,7 +64,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__cc__1_0_58",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/cc/cc-1.0.58.crate",
+        url = "https://crates.io/api/v1/crates/cc/1.0.58/download",
         type = "tar.gz",
         sha256 = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518",
         strip_prefix = "cc-1.0.58",
@@ -74,7 +74,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__cfg_if__0_1_7",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/cfg-if/cfg-if-0.1.7.crate",
+        url = "https://crates.io/api/v1/crates/cfg-if/0.1.7/download",
         type = "tar.gz",
         sha256 = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4",
         strip_prefix = "cfg-if-0.1.7",
@@ -84,7 +84,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__core_foundation_sys__0_5_1",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/core-foundation-sys/core-foundation-sys-0.5.1.crate",
+        url = "https://crates.io/api/v1/crates/core-foundation-sys/0.5.1/download",
         type = "tar.gz",
         sha256 = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa",
         strip_prefix = "core-foundation-sys-0.5.1",
@@ -94,7 +94,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__crossbeam__0_3_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/crossbeam/crossbeam-0.3.2.crate",
+        url = "https://crates.io/api/v1/crates/crossbeam/0.3.2/download",
         type = "tar.gz",
         sha256 = "24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19",
         strip_prefix = "crossbeam-0.3.2",
@@ -104,7 +104,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__crossbeam_deque__0_2_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/crossbeam-deque/crossbeam-deque-0.2.0.crate",
+        url = "https://crates.io/api/v1/crates/crossbeam-deque/0.2.0/download",
         type = "tar.gz",
         sha256 = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3",
         strip_prefix = "crossbeam-deque-0.2.0",
@@ -114,7 +114,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__crossbeam_epoch__0_3_1",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/crossbeam-epoch/crossbeam-epoch-0.3.1.crate",
+        url = "https://crates.io/api/v1/crates/crossbeam-epoch/0.3.1/download",
         type = "tar.gz",
         sha256 = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150",
         strip_prefix = "crossbeam-epoch-0.3.1",
@@ -124,7 +124,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__crossbeam_utils__0_2_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/crossbeam-utils/crossbeam-utils-0.2.2.crate",
+        url = "https://crates.io/api/v1/crates/crossbeam-utils/0.2.2/download",
         type = "tar.gz",
         sha256 = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9",
         strip_prefix = "crossbeam-utils-0.2.2",
@@ -134,7 +134,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__derivative__1_0_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/derivative/derivative-1.0.2.crate",
+        url = "https://crates.io/api/v1/crates/derivative/1.0.2/download",
         type = "tar.gz",
         sha256 = "6073e9676dbebdddeabaeb63e3b7cefd23c86f5c41d381ee1237cc77b1079898",
         strip_prefix = "derivative-1.0.2",
@@ -144,7 +144,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__fnv__1_0_6",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/fnv/fnv-1.0.6.crate",
+        url = "https://crates.io/api/v1/crates/fnv/1.0.6/download",
         type = "tar.gz",
         sha256 = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3",
         strip_prefix = "fnv-1.0.6",
@@ -154,7 +154,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__hibitset__0_3_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/hibitset/hibitset-0.3.2.crate",
+        url = "https://crates.io/api/v1/crates/hibitset/0.3.2/download",
         type = "tar.gz",
         sha256 = "b78998e3c243d71525596e8f373dfc4b82703f25907b9e4d260383cff8307d84",
         strip_prefix = "hibitset-0.3.2",
@@ -164,7 +164,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__lazy_static__1_3_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/lazy_static/lazy_static-1.3.0.crate",
+        url = "https://crates.io/api/v1/crates/lazy_static/1.3.0/download",
         type = "tar.gz",
         sha256 = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14",
         strip_prefix = "lazy_static-1.3.0",
@@ -174,7 +174,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__libc__0_2_53",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/libc/libc-0.2.53.crate",
+        url = "https://crates.io/api/v1/crates/libc/0.2.53/download",
         type = "tar.gz",
         sha256 = "ec350a9417dfd244dc9a6c4a71e13895a4db6b92f0b106f07ebbc3f3bc580cee",
         strip_prefix = "libc-0.2.53",
@@ -184,7 +184,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__libloading__0_5_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/libloading/libloading-0.5.2.crate",
+        url = "https://crates.io/api/v1/crates/libloading/0.5.2/download",
         type = "tar.gz",
         sha256 = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753",
         strip_prefix = "libloading-0.5.2",
@@ -194,7 +194,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__memchr__2_2_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/memchr/memchr-2.2.0.crate",
+        url = "https://crates.io/api/v1/crates/memchr/2.2.0/download",
         type = "tar.gz",
         sha256 = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39",
         strip_prefix = "memchr-2.2.0",
@@ -204,7 +204,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__memoffset__0_2_1",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/memoffset/memoffset-0.2.1.crate",
+        url = "https://crates.io/api/v1/crates/memoffset/0.2.1/download",
         type = "tar.gz",
         sha256 = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3",
         strip_prefix = "memoffset-0.2.1",
@@ -214,7 +214,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__mopa__0_2_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/mopa/mopa-0.2.2.crate",
+        url = "https://crates.io/api/v1/crates/mopa/0.2.2/download",
         type = "tar.gz",
         sha256 = "a785740271256c230f57462d3b83e52f998433a7062fc18f96d5999474a9f915",
         strip_prefix = "mopa-0.2.2",
@@ -224,7 +224,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__nodrop__0_1_13",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/nodrop/nodrop-0.1.13.crate",
+        url = "https://crates.io/api/v1/crates/nodrop/0.1.13/download",
         type = "tar.gz",
         sha256 = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945",
         strip_prefix = "nodrop-0.1.13",
@@ -234,7 +234,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__num_cpus__1_10_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/num_cpus/num_cpus-1.10.0.crate",
+        url = "https://crates.io/api/v1/crates/num_cpus/1.10.0/download",
         type = "tar.gz",
         sha256 = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba",
         strip_prefix = "num_cpus-1.10.0",
@@ -244,7 +244,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__odds__0_2_26",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/odds/odds-0.2.26.crate",
+        url = "https://crates.io/api/v1/crates/odds/0.2.26/download",
         type = "tar.gz",
         sha256 = "4eae0151b9dacf24fcc170d9995e511669a082856a91f958a2fe380bfab3fb22",
         strip_prefix = "odds-0.2.26",
@@ -254,7 +254,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__proc_macro2__0_4_28",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/proc-macro2/proc-macro2-0.4.28.crate",
+        url = "https://crates.io/api/v1/crates/proc-macro2/0.4.28/download",
         type = "tar.gz",
         sha256 = "ba92c84f814b3f9a44c5cfca7d2ad77fa10710867d2bbb1b3d175ab5f47daa12",
         strip_prefix = "proc-macro2-0.4.28",
@@ -264,7 +264,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__pulse__0_5_3",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/pulse/pulse-0.5.3.crate",
+        url = "https://crates.io/api/v1/crates/pulse/0.5.3/download",
         type = "tar.gz",
         sha256 = "655612b6c8d96a8a02f331fe296cb4f925b68e87c1d195544675abca2d9b9af0",
         strip_prefix = "pulse-0.5.3",
@@ -274,7 +274,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__quote__0_3_15",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/quote/quote-0.3.15.crate",
+        url = "https://crates.io/api/v1/crates/quote/0.3.15/download",
         type = "tar.gz",
         sha256 = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a",
         strip_prefix = "quote-0.3.15",
@@ -284,7 +284,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__quote__0_6_12",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/quote/quote-0.6.12.crate",
+        url = "https://crates.io/api/v1/crates/quote/0.6.12/download",
         type = "tar.gz",
         sha256 = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db",
         strip_prefix = "quote-0.6.12",
@@ -294,7 +294,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__rayon__0_8_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/rayon/rayon-0.8.2.crate",
+        url = "https://crates.io/api/v1/crates/rayon/0.8.2/download",
         type = "tar.gz",
         sha256 = "b614fe08b6665cb9a231d07ac1364b0ef3cb3698f1239ee0c4c3a88a524f54c8",
         strip_prefix = "rayon-0.8.2",
@@ -304,7 +304,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__rayon_core__1_4_1",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/rayon-core/rayon-core-1.4.1.crate",
+        url = "https://crates.io/api/v1/crates/rayon-core/1.4.1/download",
         type = "tar.gz",
         sha256 = "b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356",
         strip_prefix = "rayon-core-1.4.1",
@@ -314,7 +314,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__redox_syscall__0_1_54",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/redox_syscall/redox_syscall-0.1.54.crate",
+        url = "https://crates.io/api/v1/crates/redox_syscall/0.1.54/download",
         type = "tar.gz",
         sha256 = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252",
         strip_prefix = "redox_syscall-0.1.54",
@@ -324,7 +324,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__regex__0_2_5",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/regex/regex-0.2.5.crate",
+        url = "https://crates.io/api/v1/crates/regex/0.2.5/download",
         type = "tar.gz",
         sha256 = "744554e01ccbd98fff8c457c3b092cd67af62a555a43bfe97ae8a0451f7799fa",
         strip_prefix = "regex-0.2.5",
@@ -334,7 +334,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__regex_syntax__0_4_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/regex-syntax/regex-syntax-0.4.2.crate",
+        url = "https://crates.io/api/v1/crates/regex-syntax/0.4.2/download",
         type = "tar.gz",
         sha256 = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e",
         strip_prefix = "regex-syntax-0.4.2",
@@ -344,7 +344,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__scopeguard__0_3_3",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/scopeguard/scopeguard-0.3.3.crate",
+        url = "https://crates.io/api/v1/crates/scopeguard/0.3.3/download",
         type = "tar.gz",
         sha256 = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27",
         strip_prefix = "scopeguard-0.3.3",
@@ -354,7 +354,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__security_framework_sys__0_2_3",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/security-framework-sys/security-framework-sys-0.2.3.crate",
+        url = "https://crates.io/api/v1/crates/security-framework-sys/0.2.3/download",
         type = "tar.gz",
         sha256 = "3d6696852716b589dff9e886ff83778bb635150168e83afa8ac6b8a78cb82abc",
         strip_prefix = "security-framework-sys-0.2.3",
@@ -364,7 +364,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__shred__0_5_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/shred/shred-0.5.2.crate",
+        url = "https://crates.io/api/v1/crates/shred/0.5.2/download",
         type = "tar.gz",
         sha256 = "7d3abceaa9d0a9b47ab84b53c6029c21bcad7d7dd63e14db51ea0680faee2159",
         strip_prefix = "shred-0.5.2",
@@ -374,7 +374,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__shred_derive__0_3_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/shred-derive/shred-derive-0.3.0.crate",
+        url = "https://crates.io/api/v1/crates/shred-derive/0.3.0/download",
         type = "tar.gz",
         sha256 = "a4a894913b6e93fe2cd712a3bc955ec6f6b01c675c1c58b02fdfa13f77868049",
         strip_prefix = "shred-derive-0.3.0",
@@ -384,7 +384,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__smallvec__0_4_5",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/smallvec/smallvec-0.4.5.crate",
+        url = "https://crates.io/api/v1/crates/smallvec/0.4.5/download",
         type = "tar.gz",
         sha256 = "f90c5e5fe535e48807ab94fc611d323935f39d4660c52b26b96446a7b33aef10",
         strip_prefix = "smallvec-0.4.5",
@@ -394,7 +394,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__specs__0_10_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/specs/specs-0.10.0.crate",
+        url = "https://crates.io/api/v1/crates/specs/0.10.0/download",
         type = "tar.gz",
         sha256 = "a210dc96ea065cb88391aa6956ed1b2a14051c668b5bc18bac66a95c215b639f",
         strip_prefix = "specs-0.10.0",
@@ -404,7 +404,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__syn__0_11_11",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/syn/syn-0.11.11.crate",
+        url = "https://crates.io/api/v1/crates/syn/0.11.11/download",
         type = "tar.gz",
         sha256 = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad",
         strip_prefix = "syn-0.11.11",
@@ -414,7 +414,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__syn__0_15_33",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/syn/syn-0.15.33.crate",
+        url = "https://crates.io/api/v1/crates/syn/0.15.33/download",
         type = "tar.gz",
         sha256 = "ec52cd796e5f01d0067225a5392e70084acc4c0013fa71d55166d38a8b307836",
         strip_prefix = "syn-0.15.33",
@@ -424,7 +424,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__synom__0_11_3",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/synom/synom-0.11.3.crate",
+        url = "https://crates.io/api/v1/crates/synom/0.11.3/download",
         type = "tar.gz",
         sha256 = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6",
         strip_prefix = "synom-0.11.3",
@@ -434,7 +434,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__thread_local__0_3_6",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/thread_local/thread_local-0.3.6.crate",
+        url = "https://crates.io/api/v1/crates/thread_local/0.3.6/download",
         type = "tar.gz",
         sha256 = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b",
         strip_prefix = "thread_local-0.3.6",
@@ -444,7 +444,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__time__0_1_42",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/time/time-0.1.42.crate",
+        url = "https://crates.io/api/v1/crates/time/0.1.42/download",
         type = "tar.gz",
         sha256 = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f",
         strip_prefix = "time-0.1.42",
@@ -454,7 +454,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__tuple_utils__0_2_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/tuple_utils/tuple_utils-0.2.0.crate",
+        url = "https://crates.io/api/v1/crates/tuple_utils/0.2.0/download",
         type = "tar.gz",
         sha256 = "cbfecd7bb8f0a3e96b3b31c46af2677a55a588767c0091f484601424fcb20e7e",
         strip_prefix = "tuple_utils-0.2.0",
@@ -464,7 +464,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__unicode_xid__0_0_4",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/unicode-xid/unicode-xid-0.0.4.crate",
+        url = "https://crates.io/api/v1/crates/unicode-xid/0.0.4/download",
         type = "tar.gz",
         sha256 = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc",
         strip_prefix = "unicode-xid-0.0.4",
@@ -474,7 +474,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__unicode_xid__0_1_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/unicode-xid/unicode-xid-0.1.0.crate",
+        url = "https://crates.io/api/v1/crates/unicode-xid/0.1.0/download",
         type = "tar.gz",
         sha256 = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc",
         strip_prefix = "unicode-xid-0.1.0",
@@ -484,7 +484,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__utf8_ranges__1_0_2",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/utf8-ranges/utf8-ranges-1.0.2.crate",
+        url = "https://crates.io/api/v1/crates/utf8-ranges/1.0.2/download",
         type = "tar.gz",
         sha256 = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737",
         strip_prefix = "utf8-ranges-1.0.2",
@@ -494,7 +494,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__winapi__0_3_7",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi/winapi-0.3.7.crate",
+        url = "https://crates.io/api/v1/crates/winapi/0.3.7/download",
         type = "tar.gz",
         sha256 = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770",
         strip_prefix = "winapi-0.3.7",
@@ -504,7 +504,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__winapi_i686_pc_windows_gnu__0_4_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi-i686-pc-windows-gnu/winapi-i686-pc-windows-gnu-0.4.0.crate",
+        url = "https://crates.io/api/v1/crates/winapi-i686-pc-windows-gnu/0.4.0/download",
         type = "tar.gz",
         sha256 = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
         strip_prefix = "winapi-i686-pc-windows-gnu-0.4.0",
@@ -514,7 +514,7 @@ def remote_regression_test_fetch_remote_crates():
     maybe(
         http_archive,
         name = "remote_regression_test__winapi_x86_64_pc_windows_gnu__0_4_0",
-        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate",
+        url = "https://crates.io/api/v1/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download",
         type = "tar.gz",
         sha256 = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
         strip_prefix = "winapi-x86_64-pc-windows-gnu-0.4.0",

--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -288,7 +288,7 @@ fn default_raze_settings_field_gen_buildrs() -> bool {
 }
 
 fn default_raze_settings_registry() -> String {
-  "https://crates-io.s3-us-west-1.amazonaws.com/crates/{crate}/{crate}-{version}.crate".to_string()
+  "https://crates.io/api/v1/crates/{crate}/{version}/download".to_string()
 }
 
 fn default_crate_settings_field_gen_buildrs() -> Option<bool> {
@@ -421,7 +421,7 @@ pub mod testing {
         &"foo".to_string(),
         &"0.0.1".to_string()
       ),
-      "https://crates-io.s3-us-west-1.amazonaws.com/crates/foo/foo-0.0.1.crate"
+      "https://crates.io/api/v1/crates/foo/0.0.1/download"
     );
 
     assert_eq!(

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -55,11 +55,6 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "autocfg"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "backtrace"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,12 +160,10 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "4.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -186,16 +179,16 @@ dependencies = [
 
 [[package]]
 name = "cargo-raze"
-version = "0.3.9"
+version = "0.5.0"
 dependencies = [
  "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "cargo-lock 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-lock 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo-platform 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cargo_metadata 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_metadata 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-expr 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "docopt 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -203,17 +196,16 @@ dependencies = [
  "spdx 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tera 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cargo_metadata"
-version = "0.9.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -415,14 +407,13 @@ dependencies = [
 
 [[package]]
 name = "docopt"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -476,11 +467,6 @@ dependencies = [
  "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flate2"
@@ -614,24 +600,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gumdrop"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "gumdrop_derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "gumdrop_derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "hex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,16 +664,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "itertools"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1013,15 +973,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fixedbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,6 +1245,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,6 +1360,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "strsim"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1550,8 +1515,8 @@ name = "tools"
 version = "0.0.0"
 dependencies = [
  "cargo 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cargo-raze 0.3.9",
- "docopt 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-raze 0.5.0",
+ "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "home 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1756,7 +1721,6 @@ dependencies = [
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
-"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
@@ -1765,9 +1729,9 @@ dependencies = [
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "716960a18f978640f25101b5cbf1c6f6b0d3192fab36a2d98ca96f0ecbe41010"
 "checksum cargo 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "399c966265f89b62ed12f662f51e7402c58820c86f9f1d3a9ee59a689c787d76"
-"checksum cargo-lock 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8504b63dd1249fd1745b7b4ef9b6f7b107ddeb3c95370043c7dbcc38653a2679"
+"checksum cargo-lock 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "415e72da563b29daa89e034bf4bc3cd9986b9c34dbc07b0d6ac542e48574ab25"
 "checksum cargo-platform 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7"
-"checksum cargo_metadata 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "46e3374c604fb39d1a2f35ed5e4a4e30e60d01fab49446e08f1b3e9a90aef202"
+"checksum cargo_metadata 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e708746e51dfaeff27c6c3979a4005a7faddabe40144204a0b1ce5ad34a1d0a5"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cfg-expr 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c2be76f06820200669a77ae59a8328c6b8fe4496e8fb7fed02f2806a442c5ff"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
@@ -1790,14 +1754,13 @@ dependencies = [
 "checksum curl-sys 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ca79238a79fb294be6173b4057c95b22a718c94c4e38475d5faa82b8383f3502"
 "checksum deunicode 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
-"checksum docopt 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "db2906c2579b5b7207fc1e328796a9a8835dc44e22dbe8e460b1d636f9a7b225"
+"checksum docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f525a586d310c87df72ebcd98009e57f1cc030c8c268305287a476beb653969"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum filetime 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a2df5c1a8c4be27e7707789dc42ae65976e60b394afd293d1419ab915833e646"
-"checksum fixedbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 "checksum flate2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2291c165c8e703ee54ef3055ad6188e3d51108e2ded18e9f2476e774fc5ad3d4"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
@@ -1813,8 +1776,6 @@ dependencies = [
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4743617a7464bbda3c8aec8558ff2f9429047e025771037df561d383337ff865"
 "checksum globwalk 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "178270263374052c40502e9f607134947de75302c1348d1a0e31db67c1691446"
-"checksum gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee50908bc1beeac1f2902e0b4e0cd0d844e716f5ebdc6f0cfc1163fe5e10bcde"
-"checksum gumdrop_derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90454ce4de40b7ca6a8968b5ef367bdab48413962588d0d2b1638d60090c35d7"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum home 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "29302b90cfa76231a757a887d1e3153331a63c7f80b6c75f86366334cbe70708"
 "checksum humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6cab2627acfc432780848602f3f558f7e9dd427352224b0d9324025796d2a5e"
@@ -1822,8 +1783,7 @@ dependencies = [
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum ignore 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ad03ca67dc12474ecd91fdb94d758cbd20cb4e7a78ebe831df26a9b7511e1162"
-"checksum indexmap 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
-"checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
+"checksum itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum jobserver 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "dd80e58f77e0cdea53ba96acc5e04479e5ffc5d869626a6beafe50fed867eace"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -1860,7 +1820,6 @@ dependencies = [
 "checksum pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
 "checksum pest_generator 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63120576c4efd69615b5537d3d052257328a4ca82876771d6944424ccfd9f646"
 "checksum pest_meta 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5a3492a4ed208ffc247adcdcc7ba2a95be3104f58877d0d02f0df39bf3efb5e"
-"checksum petgraph 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum ppv-lite86 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 "checksum proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "38fddd23d98b2144d197c0eca5705632d4fe2667d14a6be5df8934f8d74f1978"
@@ -1894,6 +1853,7 @@ dependencies = [
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum schannel 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "0e1a231dc10abf6749cfa5d7767f25888d484201accbd919b66ab5413c502d56"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum semver 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
@@ -1909,6 +1869,7 @@ dependencies = [
 "checksum spdx 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1a68f874c9aa7762aa10401e2ae004d977e7b6156074668eb4ce78dd0cb28255"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 "checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
 "checksum syn 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)" = "936cae2873c940d92e697597c5eee105fb570cd5689c695806f672883653349b"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"


### PR DESCRIPTION
This change is broken out of #227 and is necessary to be compatible with https://github.com/ehuss/cargo-clone-crate