### PR TITLE
build script was missing platform-specific deps

### DIFF
--- a/impl/src/templates/partials/build_script.template
+++ b/impl/src/templates/partials/build_script.template
@@ -18,7 +18,24 @@ cargo_build_script(
       {%- for dependency in crate.default_deps.build_dependencies %}
         "{{dependency.buildable_target}}",
       {%- endfor %}
-    ],
+    ]
+    {%- if crate.targeted_deps -%} 
+    {% for targeted_dep in crate.targeted_deps %} + selects.with_or({
+        # {{ targeted_dep.target }}
+        (
+    {%- for condition in targeted_dep.conditions %}
+            "{{ condition }}",
+    {%- endfor %}
+        ): [
+    {%- for dependency in targeted_dep.deps.build_dependencies %}
+            "{{ dependency.buildable_target }}",
+    {%- endfor %}
+        ],
+        "//conditions:default": [],
+    })
+    {%- endfor -%}
+    {%- else -%}
+    {%- endif %},
     {%- if crate.default_deps.build_proc_macro_dependencies %}
     proc_macro_deps = [
     {%- for dependency in crate.default_deps.build_proc_macro_dependencies %}


### PR DESCRIPTION
Prior to #212 being merged, the following in Cargo.toml was included the resulting BUILD file:

```
[target.'cfg(target_env = "msvc")'.build-dependencies]
vcpkg = { version = "0.2", optional = true }
```

This patch makes it work again, gated with a platform check, eg:

```
cargo_build_script(
    name = "libsqlite3_sys_build_script",
    srcs = glob(["**/*.rs"]),
    crate_root = "build.rs",
    edition = "2018",
    deps = [
        "@raze__cc__1_0_61//:cc",
        "@raze__pkg_config__0_3_18//:pkg_config",
    ] + selects.with_or({
        # cfg(target_env = "msvc")
        (
            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
        ): [
            "@raze__vcpkg__0_2_10//:vcpkg",
        ],
        "//conditions:default": [],
    }),
```