### PR TITLE
Updated windows platforms from `gnu` to `msvc`

### DIFF
--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -4,11 +4,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_rust",
-    sha256 = "1c7da8ca29382c44b4431790983b4070d66278df7498c0ffe9390214b31a9d9f",
-    strip_prefix = "rules_rust-51b6a6d65cf609d10bd3b9cfe0a847a3bc7b0588",
+    sha256 = "50a772198877e21a61823fa292d28539f8bc99d72463e55b5b09942394ec370e",
+    strip_prefix = "rules_rust-9a8ef691b8e8f682d767189c38339cbee16d0a16",
     urls = [
-        # Master branch as of 2020-09-24
-        "https://github.com/bazelbuild/rules_rust/archive/51b6a6d65cf609d10bd3b9cfe0a847a3bc7b0588.tar.gz",
+        # Master branch as of 2020-10-16
+        "https://github.com/bazelbuild/rules_rust/archive/9a8ef691b8e8f682d767189c38339cbee16d0a16.tar.gz",
     ],
 )
 

--- a/examples/remote/binary_dependencies/cargo/remote/ansi_term-0.11.0.BUILD.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/ansi_term-0.11.0.BUILD.bazel
@@ -38,8 +38,8 @@ rust_library(
     ] + selects.with_or({
         # cfg(target_os = "windows")
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@remote_binary_dependencies__winapi__0_3_8//:winapi",
         ],

--- a/examples/remote/binary_dependencies/cargo/remote/atty-0.2.14.BUILD.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/atty-0.2.14.BUILD.bazel
@@ -61,8 +61,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@remote_binary_dependencies__winapi__0_3_8//:winapi",
         ],

--- a/examples/remote/binary_dependencies/cargo/remote/backtrace-0.3.50.BUILD.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/backtrace-0.3.50.BUILD.bazel
@@ -46,8 +46,8 @@ rust_library(
     ] + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
         ],
         "//conditions:default": [],

--- a/examples/remote/binary_dependencies/cargo/remote/clicolors-control-1.0.1.BUILD.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/clicolors-control-1.0.1.BUILD.bazel
@@ -61,8 +61,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@remote_binary_dependencies__atty__0_2_14//:atty",
             "@remote_binary_dependencies__winapi__0_3_8//:winapi",

--- a/examples/remote/binary_dependencies/cargo/remote/console-0.9.2.BUILD.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/console-0.9.2.BUILD.bazel
@@ -66,8 +66,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@remote_binary_dependencies__encode_unicode__0_3_6//:encode_unicode",
             "@remote_binary_dependencies__winapi__0_3_8//:winapi",

--- a/examples/remote/binary_dependencies/cargo/remote/texture-synthesis-0.8.0.BUILD.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/texture-synthesis-0.8.0.BUILD.bazel
@@ -60,7 +60,7 @@ rust_library(
             "@io_bazel_rules_rust//rust/platform:arm-unknown-linux-gnueabi",
             "@io_bazel_rules_rust//rust/platform:i686-apple-darwin",
             "@io_bazel_rules_rust//rust/platform:i686-linux-android",
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
             "@io_bazel_rules_rust//rust/platform:i686-unknown-freebsd",
             "@io_bazel_rules_rust//rust/platform:i686-unknown-linux-gnu",
             "@io_bazel_rules_rust//rust/platform:powerpc-unknown-linux-gnu",
@@ -68,7 +68,7 @@ rust_library(
             "@io_bazel_rules_rust//rust/platform:x86_64-apple-darwin",
             "@io_bazel_rules_rust//rust/platform:x86_64-apple-ios",
             "@io_bazel_rules_rust//rust/platform:x86_64-linux-android",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
             "@io_bazel_rules_rust//rust/platform:x86_64-unknown-freebsd",
             "@io_bazel_rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [

--- a/examples/remote/binary_dependencies/cargo/remote/texture-synthesis-cli-0.8.0.BUILD.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/texture-synthesis-cli-0.8.0.BUILD.bazel
@@ -47,7 +47,7 @@ rust_binary(
             "@io_bazel_rules_rust//rust/platform:arm-unknown-linux-gnueabi",
             "@io_bazel_rules_rust//rust/platform:i686-apple-darwin",
             "@io_bazel_rules_rust//rust/platform:i686-linux-android",
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
             "@io_bazel_rules_rust//rust/platform:i686-unknown-freebsd",
             "@io_bazel_rules_rust//rust/platform:i686-unknown-linux-gnu",
             "@io_bazel_rules_rust//rust/platform:powerpc-unknown-linux-gnu",
@@ -55,7 +55,7 @@ rust_binary(
             "@io_bazel_rules_rust//rust/platform:x86_64-apple-darwin",
             "@io_bazel_rules_rust//rust/platform:x86_64-apple-ios",
             "@io_bazel_rules_rust//rust/platform:x86_64-linux-android",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
             "@io_bazel_rules_rust//rust/platform:x86_64-unknown-freebsd",
             "@io_bazel_rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [

--- a/examples/remote/binary_dependencies/cargo/remote/winapi-0.3.8.BUILD.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/winapi-0.3.8.BUILD.bazel
@@ -42,21 +42,7 @@ cargo_build_script(
     crate_root = "build.rs",
     edition = "2015",
     deps = [
-    ] + selects.with_or({
-        # i686-pc-windows-gnu
-        (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-        ): [
-        ],
-        "//conditions:default": [],
-    }) + selects.with_or({
-        # x86_64-pc-windows-gnu
-        (
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
-        ): [
-        ],
-        "//conditions:default": [],
-    }),
+    ],
     rustc_flags = [
         "--cap-lints=allow",
     ],
@@ -89,23 +75,7 @@ rust_library(
     crate_type = "lib",
     deps = [
         ":winapi_build_script",
-    ] + selects.with_or({
-        # i686-pc-windows-gnu
-        (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-        ): [
-            "@remote_binary_dependencies__winapi_i686_pc_windows_gnu__0_4_0//:winapi_i686_pc_windows_gnu",
-        ],
-        "//conditions:default": [],
-    }) + selects.with_or({
-        # x86_64-pc-windows-gnu
-        (
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
-        ): [
-            "@remote_binary_dependencies__winapi_x86_64_pc_windows_gnu__0_4_0//:winapi_x86_64_pc_windows_gnu",
-        ],
-        "//conditions:default": [],
-    }),
+    ],
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
     edition = "2015",
@@ -128,6 +98,4 @@ rust_library(
         "wincon",
         "winuser",
     ],
-    aliases = {
-    },
 )

--- a/examples/remote/binary_dependencies/cargo/remote/winapi-0.3.9.BUILD.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/winapi-0.3.9.BUILD.bazel
@@ -42,21 +42,7 @@ cargo_build_script(
     crate_root = "build.rs",
     edition = "2015",
     deps = [
-    ] + selects.with_or({
-        # i686-pc-windows-gnu
-        (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-        ): [
-        ],
-        "//conditions:default": [],
-    }) + selects.with_or({
-        # x86_64-pc-windows-gnu
-        (
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
-        ): [
-        ],
-        "//conditions:default": [],
-    }),
+    ],
     rustc_flags = [
         "--cap-lints=allow",
     ],
@@ -86,23 +72,7 @@ rust_library(
     crate_type = "lib",
     deps = [
         ":winapi_build_script",
-    ] + selects.with_or({
-        # i686-pc-windows-gnu
-        (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-        ): [
-            "@remote_binary_dependencies__winapi_i686_pc_windows_gnu__0_4_0//:winapi_i686_pc_windows_gnu",
-        ],
-        "//conditions:default": [],
-    }) + selects.with_or({
-        # x86_64-pc-windows-gnu
-        (
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
-        ): [
-            "@remote_binary_dependencies__winapi_x86_64_pc_windows_gnu__0_4_0//:winapi_x86_64_pc_windows_gnu",
-        ],
-        "//conditions:default": [],
-    }),
+    ],
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
     edition = "2015",
@@ -122,6 +92,4 @@ rust_library(
         "processenv",
         "winbase",
     ],
-    aliases = {
-    },
 )

--- a/examples/remote/complicated_cargo_library/cargo/remote/libloading-0.5.2.BUILD.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/libloading-0.5.2.BUILD.bazel
@@ -41,8 +41,8 @@ rust_library(
     ] + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@remote_complicated_cargo_library__winapi__0_3_9//:winapi",
         ],

--- a/examples/remote/complicated_cargo_library/cargo/remote/time-0.1.44.BUILD.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/time-0.1.44.BUILD.bazel
@@ -39,8 +39,8 @@ rust_library(
     ] + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@remote_complicated_cargo_library__winapi__0_3_9//:winapi",
         ],

--- a/examples/remote/complicated_cargo_library/cargo/remote/winapi-0.3.9.BUILD.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/winapi-0.3.9.BUILD.bazel
@@ -36,23 +36,7 @@ rust_library(
     name = "winapi",
     crate_type = "lib",
     deps = [
-    ] + selects.with_or({
-        # i686-pc-windows-gnu
-        (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-        ): [
-            "@remote_complicated_cargo_library__winapi_i686_pc_windows_gnu__0_4_0//:winapi_i686_pc_windows_gnu",
-        ],
-        "//conditions:default": [],
-    }) + selects.with_or({
-        # x86_64-pc-windows-gnu
-        (
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
-        ): [
-            "@remote_complicated_cargo_library__winapi_x86_64_pc_windows_gnu__0_4_0//:winapi_x86_64_pc_windows_gnu",
-        ],
-        "//conditions:default": [],
-    }),
+    ],
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
     edition = "2015",
@@ -76,6 +60,4 @@ rust_library(
         "timezoneapi",
         "winerror",
     ],
-    aliases = {
-    },
 )

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/time-0.1.44/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/time-0.1.44/BUILD.bazel
@@ -39,8 +39,8 @@ rust_library(
     ] + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "//vendored/complicated_cargo_library/cargo/vendor/winapi-0.3.9:winapi",
         ],

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-0.3.9/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-0.3.9/BUILD.bazel
@@ -36,23 +36,7 @@ rust_library(
     name = "winapi",
     crate_type = "lib",
     deps = [
-    ] + selects.with_or({
-        # i686-pc-windows-gnu
-        (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-        ): [
-            "//vendored/complicated_cargo_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0:winapi_i686_pc_windows_gnu",
-        ],
-        "//conditions:default": [],
-    }) + selects.with_or({
-        # x86_64-pc-windows-gnu
-        (
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
-        ): [
-            "//vendored/complicated_cargo_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0:winapi_x86_64_pc_windows_gnu",
-        ],
-        "//conditions:default": [],
-    }),
+    ],
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
     edition = "2015",
@@ -73,6 +57,4 @@ rust_library(
         "sysinfoapi",
         "timezoneapi",
     ],
-    aliases = {
-    },
 )

--- a/impl/src/util.rs
+++ b/impl/src/util.rs
@@ -29,10 +29,10 @@ use cfg_expr::{targets::get_builtin_target_by_triple, Expression, Predicate};
 static SUPPORTED_PLATFORM_TRIPLES: &'static [&'static str] = &[
   // SUPPORTED_T1_PLATFORM_TRIPLES
   "i686-apple-darwin",
-  "i686-pc-windows-gnu",
+  "i686-pc-windows-msvc",
   "i686-unknown-linux-gnu",
   "x86_64-apple-darwin",
-  "x86_64-pc-windows-gnu",
+  "x86_64-pc-windows-msvc",
   "x86_64-unknown-linux-gnu",
   // SUPPORTED_T2_PLATFORM_TRIPLES
   "aarch64-apple-ios",

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -40,11 +40,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_rust",
-    sha256 = "1c7da8ca29382c44b4431790983b4070d66278df7498c0ffe9390214b31a9d9f",
-    strip_prefix = "rules_rust-51b6a6d65cf609d10bd3b9cfe0a847a3bc7b0588",
+    sha256 = "50a772198877e21a61823fa292d28539f8bc99d72463e55b5b09942394ec370e",
+    strip_prefix = "rules_rust-9a8ef691b8e8f682d767189c38339cbee16d0a16",
     urls = [
-        # Master branch as of 2020-09-24
-        "https://github.com/bazelbuild/rules_rust/archive/51b6a6d65cf609d10bd3b9cfe0a847a3bc7b0588.tar.gz",
+        # Master branch as of 2020-10-16
+        "https://github.com/bazelbuild/rules_rust/archive/9a8ef691b8e8f682d767189c38339cbee16d0a16.tar.gz",
     ],
 )
 


### PR DESCRIPTION
Not trying to steal the thunder from @dae but there is currently an incompatibility between `cargo-raze` and head of `rules_rust` This PR is the same change as #245 but with updated smoke-tests (the only thing broken about the PR). I'd love to see this get merged (or #245 get updated and merged) and then a release be made.