### PR TITLE
Fixed verbose output

### DIFF
--- a/impl/src/bin/cargo-raze.rs
+++ b/impl/src/bin/cargo-raze.rs
@@ -35,7 +35,7 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize)]
 struct Options {
   arg_buildprefix: Option<String>,
-  flag_verbose: u32,
+  flag_verbose: Option<bool>,
   flag_quiet: Option<bool>,
   flag_host: Option<String>,
   flag_color: Option<String>,
@@ -70,7 +70,7 @@ fn main() -> Result<()> {
     .unwrap_or_else(|e| e.exit());
 
   let settings = load_settings("Cargo.toml")?;
-  if options.flag_verbose > 0 {
+  if options.flag_verbose.unwrap_or(false) {
     println!("Loaded override settings: {:#?}", settings);
   }
   
@@ -158,7 +158,7 @@ fn main() -> Result<()> {
     if dry_run {
       println!("{}:\n{}", path.display(), contents);
     } else {
-      write_to_file(&path, &contents, options.flag_verbose > 0)?;
+      write_to_file(&path, &contents, options.flag_verbose.unwrap_or(false))?;
     }
   }
 


### PR DESCRIPTION
The numeric flags didn't appear to be working. Verbose is now a boolean

```command
no_deps % /Users/user/Code/cargo-raze/impl/target/debug/cargo-raze raze -v
```
```output
Loaded override settings: RazeSettings {
    workspace_path: "//remote/no_deps/cargo",
    incompatible_relative_workspace_path: true,
    target: None,
    targets: None,
    binary_deps: {},
    crates: {},
    gen_workspace_prefix: "remote_no_deps",
    genmode: Remote,
    output_buildfile_suffix: "BUILD.bazel",
    default_gen_buildrs: false,
    registry: "https://crates.io/api/v1/crates/{crate}/{version}/download",
    index_url: "https://github.com/rust-lang/crates.io-index",
}
Generated /Users/user/Code/cargo-raze/examples/remote/no_deps/cargo/remote/BUILD.bazel successfully
Generated /Users/user/Code/cargo-raze/examples/remote/no_deps/cargo/BUILD.bazel successfully
Generated /Users/user/Code/cargo-raze/examples/remote/no_deps/cargo/crates.bzl successfully
```
```command
no_deps % /Users/user/Code/cargo-raze/impl/target/debug/cargo-raze raze --verbose
```
```output
Loaded override settings: RazeSettings {
    workspace_path: "//remote/no_deps/cargo",
    incompatible_relative_workspace_path: true,
    target: None,
    targets: None,
    binary_deps: {},
    crates: {},
    gen_workspace_prefix: "remote_no_deps",
    genmode: Remote,
    output_buildfile_suffix: "BUILD.bazel",
    default_gen_buildrs: false,
    registry: "https://crates.io/api/v1/crates/{crate}/{version}/download",
    index_url: "https://github.com/rust-lang/crates.io-index",
}
Generated /Users/user/Code/cargo-raze/examples/remote/no_deps/cargo/remote/BUILD.bazel successfully
Generated /Users/user/Code/cargo-raze/examples/remote/no_deps/cargo/BUILD.bazel successfully
Generated /Users/user/Code/cargo-raze/examples/remote/no_deps/cargo/crates.bzl successfully
```
```command
no_deps % /Users/user/Code/cargo-raze/impl/target/debug/cargo-raze raze
```
```output
```
