### PR TITLE
Moved template header into it's own file

### DIFF
--- a/examples/remote/binary_dependencies/cargo/BUILD.bazel
+++ b/examples/remote/binary_dependencies/cargo/BUILD.bazel
@@ -1,6 +1,6 @@
 """
 @generated
-cargo-raze workspace build file.
+cargo-raze generated Bazel file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """

--- a/examples/remote/binary_dependencies/cargo/crates.bzl
+++ b/examples/remote/binary_dependencies/cargo/crates.bzl
@@ -1,6 +1,6 @@
 """
 @generated
-cargo-raze crate workspace functions
+cargo-raze generated Bazel file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """

--- a/examples/remote/complicated_cargo_library/cargo/BUILD.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/BUILD.bazel
@@ -1,6 +1,6 @@
 """
 @generated
-cargo-raze workspace build file.
+cargo-raze generated Bazel file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """

--- a/examples/remote/complicated_cargo_library/cargo/crates.bzl
+++ b/examples/remote/complicated_cargo_library/cargo/crates.bzl
@@ -1,6 +1,6 @@
 """
 @generated
-cargo-raze crate workspace functions
+cargo-raze generated Bazel file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """

--- a/examples/remote/no_deps/cargo/BUILD.bazel
+++ b/examples/remote/no_deps/cargo/BUILD.bazel
@@ -1,6 +1,6 @@
 """
 @generated
-cargo-raze workspace build file.
+cargo-raze generated Bazel file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """

--- a/examples/remote/no_deps/cargo/crates.bzl
+++ b/examples/remote/no_deps/cargo/crates.bzl
@@ -1,6 +1,6 @@
 """
 @generated
-cargo-raze crate workspace functions
+cargo-raze generated Bazel file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """

--- a/examples/remote/non_cratesio/cargo/BUILD.bazel
+++ b/examples/remote/non_cratesio/cargo/BUILD.bazel
@@ -1,6 +1,6 @@
 """
 @generated
-cargo-raze workspace build file.
+cargo-raze generated Bazel file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """

--- a/examples/remote/non_cratesio/cargo/crates.bzl
+++ b/examples/remote/non_cratesio/cargo/crates.bzl
@@ -1,6 +1,6 @@
 """
 @generated
-cargo-raze crate workspace functions
+cargo-raze generated Bazel file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """

--- a/examples/vendored/complicated_cargo_library/cargo/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/BUILD.bazel
@@ -1,6 +1,6 @@
 """
 @generated
-cargo-raze workspace build file.
+cargo-raze generated Bazel file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """

--- a/examples/vendored/hello_cargo_library/cargo/BUILD.bazel
+++ b/examples/vendored/hello_cargo_library/cargo/BUILD.bazel
@@ -1,6 +1,6 @@
 """
 @generated
-cargo-raze workspace build file.
+cargo-raze generated Bazel file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """

--- a/examples/vendored/non_cratesio_library/cargo/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/BUILD.bazel
@@ -1,6 +1,6 @@
 """
 @generated
-cargo-raze workspace build file.
+cargo-raze generated Bazel file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """

--- a/impl/src/rendering/bazel.rs
+++ b/impl/src/rendering/bazel.rs
@@ -37,8 +37,24 @@ impl BazelRenderer {
     internal_renderer
       .add_raw_templates(vec![
         (
+          "templates/crate.BUILD.template",
+          include_str!("templates/crate.BUILD.template"),
+        ),
+        (
           "templates/partials/build_script.template",
           include_str!("templates/partials/build_script.template"),
+        ),
+        (
+          "templates/partials/common_attrs.template",
+          include_str!("templates/partials/common_attrs.template"),
+        ),
+        (
+          "templates/partials/header.template",
+          include_str!("templates/partials/header.template"),
+        ),
+        (
+          "templates/partials/remote_crates_patch.template",
+          include_str!("templates/partials/remote_crates_patch.template"),
         ),
         (
           "templates/partials/rust_binary.template",
@@ -49,28 +65,16 @@ impl BazelRenderer {
           include_str!("templates/partials/rust_library.template"),
         ),
         (
-          "templates/partials/common_attrs.template",
-          include_str!("templates/partials/common_attrs.template"),
-        ),
-        (
-          "templates/workspace.BUILD.template",
-          include_str!("templates/workspace.BUILD.template"),
-        ),
-        (
-          "templates/crate.BUILD.template",
-          include_str!("templates/crate.BUILD.template"),
+          "templates/partials/targeted_dependencies.template",
+          include_str!("templates/partials/targeted_dependencies.template"),
         ),
         (
           "templates/remote_crates.bzl.template",
           include_str!("templates/remote_crates.bzl.template"),
         ),
         (
-          "templates/partials/remote_crates_patch.template",
-          include_str!("templates/partials/remote_crates_patch.template"),
-        ),
-        (
-          "templates/partials/targeted_dependencies.template",
-          include_str!("templates/partials/targeted_dependencies.template"),
+          "templates/workspace.BUILD.template",
+          include_str!("templates/workspace.BUILD.template"),
         ),
       ])
       .unwrap();

--- a/impl/src/rendering/templates/partials/header.template
+++ b/impl/src/rendering/templates/partials/header.template
@@ -1,0 +1,6 @@
+"""
+@generated
+cargo-raze generated Bazel file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""

--- a/impl/src/rendering/templates/remote_crates.bzl.template
+++ b/impl/src/rendering/templates/remote_crates.bzl.template
@@ -1,10 +1,4 @@
-"""
-@generated
-cargo-raze crate workspace functions
-
-DO NOT EDIT! Replaced on runs of cargo-raze
-"""
-
+{%- include "templates/partials/header.template" %}
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")  # buildifier: disable=load
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")  # buildifier: disable=load
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")  # buildifier: disable=load

--- a/impl/src/rendering/templates/workspace.BUILD.template
+++ b/impl/src/rendering/templates/workspace.BUILD.template
@@ -1,10 +1,4 @@
-"""
-@generated
-cargo-raze workspace build file.
-
-DO NOT EDIT! Replaced on runs of cargo-raze
-"""
-
+{%- include "templates/partials/header.template" %}
 package(default_visibility = ["//visibility:public"])
 
 licenses([


### PR DESCRIPTION
Since there is a nearly identical header for two types of files, I thought it'd make sense to create a single source of truth for this.

This is more work that's been broken out of https://github.com/google/cargo-raze/pull/276