### PR TITLE
Add links to CargoContext

### DIFF
--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -112,6 +112,7 @@ pub struct CrateContext {
   pub is_root_dependency: bool,
   pub targets: Vec<BuildableTarget>,
   pub build_script_target: Option<BuildableTarget>,
+  pub links: Option<String>,
   pub source_details: SourceDetails,
   pub sha256: Option<String>,
   pub registry_url: String,

--- a/impl/src/planning/subplanners.rs
+++ b/impl/src/planning/subplanners.rs
@@ -384,6 +384,7 @@ impl<'planner> CrateSubplanner<'planner> {
       targeted_deps: filtered_deps,
       workspace_path_to_crate: self.crate_catalog_entry.workspace_path(&self.settings)?,
       build_script_target: build_script_target_opt,
+      links: package.links.clone(),
       raze_settings: self.crate_settings.cloned().unwrap_or_default(),
       source_details: self.produce_source_details(&package, &package_root),
       expected_build_path: self.crate_catalog_entry.local_build_path(&self.settings)?,

--- a/impl/src/rendering/bazel.rs
+++ b/impl/src/rendering/bazel.rs
@@ -383,6 +383,7 @@ mod tests {
         edition: "2015".to_owned(),
       }],
       build_script_target: None,
+      links: None,
       source_details: SourceDetails {
         git_data: None,
       },
@@ -423,6 +424,7 @@ mod tests {
         edition: "2015".to_owned(),
       }],
       build_script_target: None,
+      links: Some("ssh2".to_owned()),
       source_details: SourceDetails {
         git_data: None,
       },


### PR DESCRIPTION
The links attribute is needed to infer the name of environment variables to pass to sys crate dependencies.

Fixes #288