### PR TITLE
Rework planning to be based off the resolve tree and not directly pkgs

### DIFF
--- a/impl/src/metadata.rs
+++ b/impl/src/metadata.rs
@@ -438,7 +438,7 @@ impl RazeMetadataFetcher {
           let version = info.req();
           let src_dir = self.fetch_crate_src(cargo_dir.as_ref(), &name, version)?;
           checksums.insert(
-            package_ident(name, version),
+            package_ident(name, &version),
             self.fetch_crate_checksum(name, version)?,
           );
           if let Some(dirname) = src_dir.file_name() {

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -20,7 +20,7 @@ use anyhow::Result;
 use cargo_lock::Lockfile;
 
 use crate::{
-  context::{CrateContext, WorkspaceContext},
+  context::{CrateContext, DependencyAlias, WorkspaceContext},
   metadata::RazeMetadata,
   settings::RazeSettings,
   util::PlatformDetails,
@@ -32,8 +32,13 @@ use subplanners::WorkspaceSubplanner;
 /// A ready-to-be-rendered build, containing renderable context for each crate.
 #[derive(Debug)]
 pub struct PlannedBuild {
+  /// The overall context for this workspace
   pub workspace_context: WorkspaceContext,
+  /// The creates to build for
   pub crate_contexts: Vec<CrateContext>,
+  /// And aliases that are defined at the workspace root
+  pub workspace_aliases: Vec<DependencyAlias>,
+  /// The version lock used if present
   pub lockfile: Option<Lockfile>,
 }
 
@@ -89,6 +94,7 @@ mod tests {
   use super::*;
   use cargo_metadata::PackageId;
   use indoc::indoc;
+  use itertools::Itertools;
   use semver::{Version, VersionReq};
 
   fn dummy_resolve_dropping_metadata() -> RazeMetadata {
@@ -245,22 +251,22 @@ mod tests {
     assert!(krate_position.is_some());
 
     // Get crate context using computed position
-    let krate_context = crates_with_aliased_deps[krate_position.unwrap()].clone();
+    let crate_ctx = crates_with_aliased_deps[krate_position.unwrap()].clone();
 
     // There are two default dependencies for cargo-raze-alias-test, log^0.4 and log^0.3
-    // However, log^0.3 is aliased to old_log_ while log^0.4 isn't aliased. Therefore, we
-    // should only see one aliased dependency (log^0.3 -> old_log_) which shows that the
+    // However, log^0.3 is aliased to old_log while log^0.4 isn't aliased. Therefore, we
+    // should only see one aliased dependency (log^0.3 -> old_log) which shows that the
     // name and semver matching for aliased dependencies is working correctly
-    assert!(krate_context.default_deps.aliased_dependencies.len() == 1);
-    assert_eq!(
-      krate_context.default_deps.aliased_dependencies[0].target,
-      "@raze_test__log__0_3_9//:log"
-    );
-    assert_eq!(
-      krate_context.default_deps.aliased_dependencies[0].alias,
-      "old_log_"
-    );
+    let dep = crate_ctx
+      .default_deps
+      .aliased_dependencies
+      .iter()
+      .exactly_one()
+      .unwrap();
+    assert_eq!(dep.target, "@raze_test__log__0_3_9//:log");
+    assert_eq!(dep.alias, "old_log");
   }
+
   #[test]
   fn test_plan_build_produces_proc_macro_dependencies() {
     let mut settings = dummy_raze_settings();
@@ -423,7 +429,6 @@ mod tests {
     let context = planned_build
       .crate_contexts
       .iter()
-      .inspect(|x| println!("{}{}", x.pkg_name, x.pkg_version))
       .find(|ctx| ctx.pkg_name == "some-binary-crate" && ctx.pkg_version == version)
       .unwrap();
 

--- a/impl/src/planning/subplanners.rs
+++ b/impl/src/planning/subplanners.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::{
-  collections::{HashMap, HashSet},
+  collections::{BTreeSet, HashMap, HashSet},
   io, iter,
   path::{Path, PathBuf},
   str::FromStr,
@@ -21,7 +21,7 @@ use std::{
 
 use anyhow::{anyhow, Context, Result};
 use cargo_lock::SourceId;
-use cargo_metadata::{DependencyKind, Node, Package};
+use cargo_metadata::{DepKindInfo, DependencyKind, Node, Package};
 use cargo_platform::Platform;
 use itertools::Itertools;
 
@@ -43,39 +43,11 @@ use super::{
   PlannedBuild,
 };
 
-/// A set of named dependencies (without version) derived from a package manifest.
-struct DependencyNames {
-  // Dependencies that are required for all buildable targets of this crate
-  normal_dep_names: Vec<String>,
-  // Dependencies that are required for build script only
-  build_dep_names: Vec<String>,
-  // Dependencies that are required for tests
-  dev_dep_names: Vec<String>,
-  // Dependencies that have been renamed and need to be aliased in the build rule
-  aliased_dep_names: HashMap<String, (semver::VersionReq, String)>,
-}
+/// Named type to reduce declaration noise for deducing the crate contexts
+type CrateContextProduction = (Vec<CrateContext>, Vec<DependencyAlias>);
 
-// TODO(acmcarther): Remove this struct -- move it into CrateContext.
-/// A set of dependencies that a crate has broken down by type.
-struct DependencySet {
-  // Dependencies that are required for all buildable targets of this crate
-  normal_deps: Vec<BuildableDependency>,
-  proc_macro_deps: Vec<BuildableDependency>,
-  // Dependencies that are required for build script only
-  build_deps: Vec<BuildableDependency>,
-  // Dependencies that proc macros and are required for the build script only
-  build_proc_macro_deps: Vec<BuildableDependency>,
-  // Dependencies that are required for tests
-  dev_deps: Vec<BuildableDependency>,
-  // Dependencies that have been renamed and need to be aliased in the build rule
-  aliased_deps: Vec<DependencyAlias>,
-}
-
-/// A set of dependencies that a crate has for a specific target/cfg
-struct TargetedDependencySet {
-  target: String,
-  dependencies: DependencySet,
-}
+/// Utility type alias to reduce declaration noise
+type DepProduction = HashMap<Option<String>, CrateDependencyContext>;
 
 /// An internal working planner for generating context for an individual crate.
 struct CrateSubplanner<'planner> {
@@ -103,11 +75,12 @@ impl<'planner> WorkspaceSubplanner<'planner> {
   /// Produces a planned build using internal state.
   pub fn produce_planned_build(&self) -> Result<PlannedBuild> {
     // Produce planned build
-    let crate_contexts = self.produce_crate_contexts()?;
+    let (crate_contexts, workspace_aliases) = self.produce_crate_contexts()?;
 
     Ok(PlannedBuild {
       workspace_context: self.produce_workspace_context(),
       crate_contexts,
+      workspace_aliases,
       lockfile: self.metadata.lockfile.clone(),
     })
   }
@@ -155,7 +128,7 @@ impl<'planner> WorkspaceSubplanner<'planner> {
     &self,
     node: &Node,
     catalog: &CrateCatalog,
-  ) -> Option<Result<CrateContext>> {
+  ) -> Option<Result<(CrateContext, bool)>> {
     let own_crate_catalog_entry = catalog.entry_for_package_id(&node.id)?;
     let own_package = own_crate_catalog_entry.package();
 
@@ -193,7 +166,11 @@ impl<'planner> WorkspaceSubplanner<'planner> {
       sha256: &checksum_opt.map(|c| c.to_owned()),
     };
 
-    Some(crate_subplanner.produce_context(&self.metadata.cargo_workspace_root))
+    let res = crate_subplanner
+      .produce_context(&self.metadata.cargo_workspace_root)
+      .map(|x| (x, own_crate_catalog_entry.is_workspace_crate()));
+
+    Some(res)
   }
 
   fn crate_settings(&self, package: &Package) -> Result<Option<&CrateSettings>> {
@@ -225,8 +202,8 @@ impl<'planner> WorkspaceSubplanner<'planner> {
   }
 
   /// Produces a crate context for each declared crate and dependency.
-  fn produce_crate_contexts(&self) -> Result<Vec<CrateContext>> {
-    self
+  fn produce_crate_contexts(&self) -> Result<CrateContextProduction> {
+    let contexts = self
       .crate_catalog
       .metadata
       .resolve
@@ -236,25 +213,64 @@ impl<'planner> WorkspaceSubplanner<'planner> {
       .iter()
       .sorted_by_key(|n| &n.id)
       .filter_map(|node| self.create_crate_context(node, &self.crate_catalog))
-      .collect::<Result<Vec<CrateContext>>>()
+      .collect::<Result<Vec<_>>>()?;
+
+    let root_ctxs = contexts
+      .iter()
+      .filter_map(|(ctx, is_workspace)| match is_workspace {
+        true => Some(ctx.default_deps.aliased_dependencies.clone()),
+        false => None,
+      })
+      .flatten()
+      .collect::<BTreeSet<_>>();
+
+    let contexts = contexts.into_iter().map(|(ctx, _)| ctx).collect_vec();
+    let aliases = self.produce_workspace_aliases(root_ctxs, &contexts);
+
+    Ok((contexts, aliases))
+  }
+
+  fn produce_workspace_aliases(
+    &self,
+    root_dep_aliases: BTreeSet<DependencyAlias>,
+    all_packages: &[CrateContext],
+  ) -> Vec<DependencyAlias> {
+    let renames = root_dep_aliases
+      .iter()
+      .map(|rename| (&rename.target, &rename.alias))
+      .collect::<HashMap<_, _>>();
+
+    all_packages
+      .iter()
+      .filter(|to_alias| to_alias.lib_target_name.is_some())
+      .filter(|to_alias| to_alias.is_workspace_member_dependency)
+      .flat_map(|to_alias| {
+        let pkg_name = to_alias.pkg_name.replace("-", "_");
+        let target = format!("{}:{}", &to_alias.workspace_path_to_crate, &pkg_name);
+        let alias = renames
+          .get(&target)
+          .map(|x| x.to_string())
+          .unwrap_or(pkg_name);
+        let dep_alias = DependencyAlias { alias, target };
+
+        to_alias
+          .raze_settings
+          .extra_aliased_targets
+          .iter()
+          .map(move |extra_alias| DependencyAlias {
+            alias: extra_alias.clone(),
+            target: format!("{}:{}", &to_alias.workspace_path_to_crate, extra_alias),
+          })
+          .chain(std::iter::once(dep_alias))
+      })
+      .sorted()
+      .collect_vec()
   }
 }
 
 impl<'planner> CrateSubplanner<'planner> {
   /// Builds a crate context from internal state.
   fn produce_context(&self, cargo_workspace_root: &Path) -> Result<CrateContext> {
-    let (
-      DependencySet {
-        build_deps,
-        build_proc_macro_deps,
-        proc_macro_deps,
-        dev_deps,
-        normal_deps,
-        aliased_deps,
-      },
-      targeted_deps,
-    ) = self.produce_deps()?;
-
     let package = self.crate_catalog_entry.package();
 
     let manifest_path = PathBuf::from(&package.manifest_path);
@@ -264,59 +280,40 @@ impl<'planner> CrateSubplanner<'planner> {
     let mut targets = self.produce_targets(&package_root)?;
     let build_script_target_opt = self.take_build_script_target(&mut targets);
 
-    let mut lib_target_name = None;
-    let mut is_proc_macro = false;
-    {
-      for target in &targets {
-        if target.kind == "lib" {
-          lib_target_name = Some(target.name.clone());
-          break;
-        }
-        if target.kind == "proc-macro" {
-          is_proc_macro = true;
-          lib_target_name = Some(target.name.clone());
-          break;
-        }
-      }
-    }
+    let lib_target_name = targets
+      .iter()
+      .find(|target| target.kind == "lib" || target.kind == "proc-macro")
+      .map(|target| target.name.clone());
 
-    // Build a list of dependencies while addression a potential whitelist of target triples
-    let mut filtered_deps = Vec::new();
-    for dep_set in targeted_deps.iter() {
-      let mut target_triples = util::get_matching_bazel_triples(&dep_set.target)?;
-      util::filter_bazel_triples(
-        &mut target_triples,
-        self
-          .settings
-          .targets
-          .as_ref()
-          .unwrap_or(&Vec::<String>::new()),
-      );
+    let is_proc_macro = targets.iter().any(|target| target.kind == "proc_macro");
 
-      if target_triples.is_empty() {
-        continue;
-      }
+    let mut deps = self.produce_deps()?;
 
-      filtered_deps.push(CrateTargetedDepContext {
-        target: dep_set.target.clone(),
-        deps: CrateDependencyContext {
-          dependencies: dep_set.dependencies.normal_deps.clone(),
-          proc_macro_dependencies: dep_set.dependencies.proc_macro_deps.clone(),
-          data_dependencies: vec![],
-          build_dependencies: dep_set.dependencies.build_deps.clone(),
-          build_proc_macro_dependencies: dep_set.dependencies.build_proc_macro_deps.clone(),
-          build_data_dependencies: vec![],
-          dev_dependencies: dep_set.dependencies.dev_deps.clone(),
-          aliased_dependencies: dep_set.dependencies.aliased_deps.clone(),
-        },
-        conditions: util::generate_bazel_conditions(
-          &self.settings.rust_rules_workspace_name,
-          &target_triples,
-        )?,
-      });
-    }
+    // Take the default deps that are not bound to platform targets
+    let default_deps = deps.remove(&None).unwrap_or_default();
 
-    filtered_deps.sort();
+    // Build a list of dependencies while addression a potential allowlist of target triples
+    let mut targeted_deps = deps
+      .into_iter()
+      .map(|(target, deps)| {
+        let target = target.unwrap();
+        let platform_targets = util::get_matching_bazel_triples(&target, &self.settings.targets)?
+          .map(|x| x.to_string())
+          .collect();
+
+        Ok(CrateTargetedDepContext {
+          deps,
+          target,
+          platform_targets,
+        })
+      })
+      .filter(|res| match res {
+        Ok(ctx) => !ctx.platform_targets.is_empty(),
+        Err(_) => true,
+      })
+      .collect::<Result<Vec<_>>>()?;
+
+    targeted_deps.sort();
 
     let mut workspace_member_dependents: Vec<PathBuf> = Vec::new();
     let mut workspace_member_dev_dependents: Vec<PathBuf> = Vec::new();
@@ -396,17 +393,8 @@ impl<'planner> CrateSubplanner<'planner> {
       is_workspace_member_dependency,
       is_binary_dependency,
       is_proc_macro,
-      default_deps: CrateDependencyContext {
-        dependencies: normal_deps,
-        proc_macro_dependencies: proc_macro_deps,
-        data_dependencies: vec![],
-        build_dependencies: build_deps,
-        build_proc_macro_dependencies: build_proc_macro_deps,
-        build_data_dependencies: vec![],
-        dev_dependencies: dev_deps,
-        aliased_dependencies: aliased_deps,
-      },
-      targeted_deps: filtered_deps,
+      default_deps,
+      targeted_deps,
       workspace_path_to_crate: self.crate_catalog_entry.workspace_path(&self.settings)?,
       build_script_target: build_script_target_opt,
       links: package.links.clone(),
@@ -439,20 +427,9 @@ impl<'planner> CrateSubplanner<'planner> {
     license::get_license_from_str(licenses_str)
   }
 
-  fn _produce_deps(&self, names: &DependencyNames) -> Result<DependencySet> {
-    let build_dep_names = &names.build_dep_names;
-    let dev_dep_names = &names.dev_dep_names;
-    let normal_dep_names = &names.normal_dep_names;
-    let aliased_dep_names = &names.aliased_dep_names;
-
-    let mut dep_set = DependencySet {
-      build_deps: Vec::new(),
-      build_proc_macro_deps: Vec::new(),
-      proc_macro_deps: Vec::new(),
-      dev_deps: Vec::new(),
-      normal_deps: Vec::new(),
-      aliased_deps: Vec::new(),
-    };
+  /// Generates the set of dependencies for the contained crate.
+  fn produce_deps(&self) -> Result<DepProduction> {
+    let mut dep_production = DepProduction::new();
 
     let all_skipped_deps = self
       .crate_settings
@@ -460,204 +437,195 @@ impl<'planner> CrateSubplanner<'planner> {
       .flat_map(|pkg| pkg.skipped_deps.iter())
       .collect::<HashSet<_>>();
 
-    for dep_id in &self.node.dependencies {
+    // This wonderful part of the metadata gives us both renames and targets.
+    //
+    // Irritatingly its still a little tricky to detect renames fully, we need this to finally
+    // deduce the aliases - see `is_renamed`.
+    //
+    // If https://github.com/rust-lang/cargo/issues/7289 gets solved then a lot of the left-over
+    // rename detection code can get removed.
+    for dep in &self.node.deps {
       // UNWRAP(s): Safe from verification of packages_by_id
       let dep_package = self
         .crate_catalog
-        .entry_for_package_id(&dep_id)
+        .entry_for_package_id(&dep.pkg)
         .unwrap()
         .package();
 
       // Skip settings-indicated deps to skip
-      if all_skipped_deps.contains(&util::package_ident(
-        &dep_package.name,
-        &dep_package.version.to_string(),
-      )) {
+      let pkg_id = util::package_ident(&dep_package.name, &dep_package.version.to_string());
+      if all_skipped_deps.contains(&pkg_id) {
         continue;
       }
 
-      // UNWRAP: Guaranteed to exist by checks in WorkspaceSubplanner#produce_build_plan
-      let buildable_target = self
-        .crate_catalog
-        .entry_for_package_id(dep_id)
-        .unwrap()
-        .workspace_path_and_default_target(&self.settings)?;
-
-      // Implicitly dependencies are on the [lib] target from Cargo.toml (of which there is
-      // guaranteed to be at most one).
-      // In this function, we don't explicitly narrow to be considering only the [lib] Target - we
-      // rely on the fact that only one [lib] is allowed in a Package, and so treat the Package
-      // synonymously with the [lib] Target therein.
-      // Only the [lib] target is allowed to be labelled as a proc-macro, so checking if "any"
-      // target is a proc-macro is equivalent to checking if the [lib] target is a proc-macro (and
-      // accordingly, whether we need to treat this dep like a proc-macro).
-      let is_proc_macro = dep_package
-        .targets
-        .iter()
-        .flat_map(|target| target.crate_types.iter())
-        .any(|crate_type| crate_type.as_str() == "proc-macro");
-
-      let buildable_dependency = BuildableDependency {
-        name: dep_package.name.clone(),
-        version: dep_package.version.clone(),
-        buildable_target: buildable_target.clone(),
-        is_proc_macro,
-      };
-
-      if build_dep_names.contains(&dep_package.name) {
-        if buildable_dependency.is_proc_macro {
-          dep_set
-            .build_proc_macro_deps
-            .push(buildable_dependency.clone());
-        } else {
-          dep_set.build_deps.push(buildable_dependency.clone());
-        }
-      }
-
-      if dev_dep_names.contains(&dep_package.name) {
-        dep_set.dev_deps.push(buildable_dependency.clone());
-      }
-
-      if normal_dep_names.contains(&dep_package.name) {
-        // sys crates build files may generate DEP_* environment variables that
-        // need to be visible in their direct dependency build files.
-        if dep_package.name.ends_with("-sys") {
-          dep_set.build_deps.push(buildable_dependency.clone());
-        }
-        if buildable_dependency.is_proc_macro {
-          dep_set.proc_macro_deps.push(buildable_dependency);
-        } else {
-          dep_set.normal_deps.push(buildable_dependency);
-        }
-        // Only add aliased normal deps to the Vec
-        if let Some(alias_pair) = aliased_dep_names.get(&dep_package.name) {
-          // Check whether the package's version matches the semver requirement
-          // of the package that had an alias
-          if alias_pair.0.matches(&dep_package.version) {
-            dep_set.aliased_deps.push(DependencyAlias {
-              target: buildable_target.clone(),
-              alias: (&alias_pair.1).replace("-", "_"),
-            })
-          }
-        }
-      }
-    }
-
-    dep_set.aliased_deps.sort();
-    dep_set.build_deps.sort();
-    dep_set.build_proc_macro_deps.sort();
-    dep_set.dev_deps.sort();
-    dep_set.normal_deps.sort();
-    dep_set.proc_macro_deps.sort();
-
-    Ok(dep_set)
-  }
-
-  /// Generates the set of dependencies for the contained crate.
-  fn produce_deps(&self) -> Result<(DependencySet, Vec<TargetedDependencySet>)> {
-    let (default_deps, targeted_deps) = self.identify_named_deps()?;
-
-    let targeted_set = targeted_deps
-      .iter()
-      .map(|(target, deps)| TargetedDependencySet {
-        target: target.clone(),
-        dependencies: self._produce_deps(deps).unwrap(),
-      })
-      .collect::<Vec<TargetedDependencySet>>();
-
-    Ok((self._produce_deps(&default_deps)?, targeted_set))
-  }
-
-  /// Yields the list of dependencies as described by the manifest (without version).
-  fn identify_named_deps(&self) -> Result<(DependencyNames, HashMap<String, DependencyNames>)> {
-    // Resolve dependencies into types
-    let mut default_dep_names = DependencyNames {
-      build_dep_names: Vec::new(),
-      dev_dep_names: Vec::new(),
-      normal_dep_names: Vec::new(),
-      aliased_dep_names: HashMap::new(),
-    };
-
-    let mut targeted_dep_names: HashMap<String, DependencyNames> = HashMap::new();
-
-    let package = self.crate_catalog_entry.package();
-    for dep in &package.dependencies {
-      // This shadow allow for dependencies with target restrictions to override where
-      // to write data about itself.
-      let mut dep_names = &mut default_dep_names;
-
-      if dep.target.is_some() {
-        // UNWRAP: Safe from above check
-        let target_str = format!("{}", dep.target.as_ref().unwrap());
-
-        // Legacy behavior
-        if let Some(platform_details) = &self.platform_details {
-          if let Some(settings_target) = &self.settings.target {
-            let platform = Platform::from_str(&target_str)?;
-
-            // Skip this dep if it doesn't match our platform attributes
-            if !platform.matches(settings_target, platform_details.attrs().as_ref()) {
-              continue;
-            }
-          }
-        }
-
-        let (is_bazel_platform, matches_all_platforms) =
-          util::is_bazel_supported_platform(&target_str);
-        // If the target is not supported by Bazel, we ignore it
-        if !is_bazel_platform {
+      // TODO(GregBowyer): Reimplement what cargo does to detect bad renames
+      //
+      // The problem manifests from this:
+      //
+      // ```toml
+      // [dependencies]
+      // bytes_new = { version = "0.3.0", package = "bytes" }
+      // bytes_old = { version = "0.3.0", package = "bytes" }
+      // ```
+      //
+      // Strictly this is an error. Right now cargo metadata will basically lose both bytes deps
+      // from the resolve graph :gruntle: but a cargo build will scream about having the same basic
+      // package with multiple names.
+      //
+      // Currently there is no good solution using metadata. Pull requests welcome!
+      for dep_kind in &dep.dep_kinds {
+        let platform_target = dep_kind.target.as_ref().map(|x| x.to_string());
+        // Skip deps that fall out of targetting
+        if !self.is_dep_targetted(platform_target.as_ref()) {
           continue;
         }
 
-        // In cases where the cfg target matches all platforms, we consider it a default dependency
-        if !matches_all_platforms {
-          // Ensure an entry is created for the 'conditional' dependency
-          dep_names = match targeted_dep_names.get_mut(&target_str) {
-            Some(targeted) => targeted,
-            None => {
-              // Create a new entry if one was not found
-              targeted_dep_names.insert(
-                target_str.clone(),
-                DependencyNames {
-                  normal_dep_names: Vec::new(),
-                  build_dep_names: Vec::new(),
-                  dev_dep_names: Vec::new(),
-                  aliased_dep_names: HashMap::new(),
-                },
-              );
-              // UNWRAP: This unwrap should be safe given the insert above
-              targeted_dep_names.get_mut(&target_str).unwrap()
-            }
-          };
-        }
-      }
-      match dep.kind {
-        DependencyKind::Normal => dep_names.normal_dep_names.push(dep.name.clone()),
-        DependencyKind::Development => dep_names.dev_dep_names.push(dep.name.clone()),
-        DependencyKind::Build => dep_names.build_dep_names.push(dep.name.clone()),
-        _ => {
-          return Err(
-            RazeError::Planning {
-              dependency_name_opt: Some(package.name.to_string()),
-              message: format!(
-                "Unhandlable dependency type {:?} on {} detected! {}",
-                dep.kind, dep.name, PLEASE_FILE_A_BUG
-              ),
-            }
-            .into(),
-          )
-        }
-      }
-
-      // Check if the dependency has been renamed
-      if let Some(alias) = dep.rename.as_ref() {
-        dep_names
-          .aliased_dep_names
-          .insert(dep.name.clone(), (dep.req.clone(), alias.clone()));
+        let mut dep_set = dep_production.entry(platform_target).or_default();
+        self.process_dep(&mut dep_set, &dep.name, dep_kind, &dep_package)?
       }
     }
 
-    Ok((default_dep_names, targeted_dep_names))
+    for set in dep_production.values_mut() {
+      set.build_proc_macro_dependencies.sort();
+      set.build_dependencies.sort();
+      set.dev_dependencies.sort();
+      set.proc_macro_dependencies.sort();
+      set.dependencies.sort();
+    }
+
+    Ok(dep_production)
+  }
+
+  fn process_dep(
+    &self,
+    dep_set: &mut CrateDependencyContext,
+    name: &str,
+    dep: &DepKindInfo,
+    pkg: &Package,
+  ) -> Result<()> {
+    let is_proc_macro = self.is_proc_macro(pkg);
+    let is_sys_crate = pkg.name.ends_with("-sys");
+
+    let build_dep = BuildableDependency {
+      name: pkg.name.clone(),
+      version: pkg.version.clone(),
+      buildable_target: self.buildable_target_for_dep(pkg)?,
+      is_proc_macro,
+    };
+
+    use DependencyKind::*;
+    match dep.kind {
+      Build if is_proc_macro => dep_set.build_proc_macro_dependencies.push(build_dep),
+      Build => dep_set.build_dependencies.push(build_dep),
+      Development => dep_set.dev_dependencies.push(build_dep),
+      Normal if is_proc_macro => dep_set.proc_macro_dependencies.push(build_dep),
+      Normal => {
+        // sys crates may generate DEP_* env vars that must be visible to direct dep builds
+        if is_sys_crate {
+          dep_set.build_dependencies.push(build_dep.clone());
+        }
+        dep_set.dependencies.push(build_dep)
+      }
+      kind => {
+        return Err(
+          RazeError::Planning {
+            dependency_name_opt: Some(pkg.name.to_string()),
+            message: format!(
+              "Unhandlable dependency type {:?} on {} detected! {}",
+              kind, &pkg.name, PLEASE_FILE_A_BUG
+            ),
+          }
+          .into(),
+        )
+      }
+    };
+
+    if self.is_renamed(pkg) {
+      let dep_alias = DependencyAlias {
+        target: self.buildable_target_for_dep(pkg)?,
+        alias: name.replace("-", "_"),
+      };
+
+      if !dep_set.aliased_dependencies.insert(dep_alias) {
+        return Err(
+          RazeError::Planning {
+            dependency_name_opt: Some(pkg.name.to_string()),
+            message: format!("Duplicated renamed package {}", name),
+          }
+          .into(),
+        );
+      }
+    }
+
+    Ok(())
+  }
+
+  /// Test to see if a dep has been renamed
+  ///
+  /// Currently cargo-metadata provides rename detection in a few places, we take the names
+  /// from the resolution of a package
+  fn is_renamed(&self, dep_package: &Package) -> bool {
+    self
+      .crate_catalog_entry
+      .package()
+      .dependencies
+      .iter()
+      .filter(|x| x.name == dep_package.name)
+      .filter(|x| x.req.matches(&dep_package.version))
+      .filter(|x| x.source == dep_package.source.as_ref().map(|src| src.to_string()))
+      .find(|x| x.rename.is_some())
+      .map_or(false, |x| x.rename.is_some())
+  }
+
+  fn is_dep_targetted(&self, target: Option<&String>) -> bool {
+    target
+      .map(|platform| {
+        let potential_targets = self
+          .platform_details
+          .as_ref()
+          .zip(self.settings.target.as_ref());
+
+        match potential_targets {
+          // Legacy behavior
+          Some((platform_details, settings_target)) => {
+            // Skip this dep if it doesn't match our platform attributes
+            // UNWRAP: It is reasonable to assume cargo is not giving us odd platform strings
+            let platform = Platform::from_str(platform).unwrap();
+            platform.matches(settings_target, platform_details.attrs())
+          }
+          None => {
+            util::is_bazel_supported_platform(platform) != util::BazelTargetSupport::Unsupported
+          }
+        }
+      })
+      .unwrap_or(true)
+  }
+
+  /// Test if the given dep details pertain to it being a proc-macro
+  ///
+  /// Implicitly dependencies are on the [lib] target from Cargo.toml (of which there is guaranteed
+  /// to be at most one).
+  ///
+  /// We don't explicitly narrow to be considering only the [lib] Target - we rely on the fact that
+  /// only one [lib] is allowed in a Package, and so treat the Package synonymously with the [lib]
+  /// Target therein. Only the [lib] target is allowed to be labelled as a proc-macro, so checking
+  /// if "any" target is a proc-macro is equivalent to checking if the [lib] target is a proc-macro
+  /// (and accordingly, whether we need to treat this dep like a proc-macro).
+  fn is_proc_macro(&self, dep_package: &Package) -> bool {
+    dep_package
+      .targets
+      .iter()
+      .flat_map(|target| target.crate_types.iter())
+      .any(|crate_type| crate_type.as_str() == "proc-macro")
+  }
+
+  fn buildable_target_for_dep(&self, dep_package: &Package) -> Result<String> {
+    // UNWRAP: Guaranteed to exist by checks in WorkspaceSubplanner#produce_build_plan
+    self
+      .crate_catalog
+      .entry_for_package_id(&dep_package.id)
+      .unwrap()
+      .workspace_path_and_default_target(&self.settings)
   }
 
   /// Generates source details for internal crate.

--- a/impl/src/rendering/templates/partials/build_script.template
+++ b/impl/src/rendering/templates/partials/build_script.template
@@ -73,8 +73,8 @@ cargo_build_script(
     {% for targeted_dep in crate.targeted_deps %} + selects.with_or({
         # {{ targeted_dep.target }}
         (
-    {%- for condition in targeted_dep.conditions %}
-            "{{ condition }}",
+    {%- for platform_target in targeted_dep.platform_targets %}
+          "@rules_rust//rust/platform:{{platform_target}}",
     {%- endfor %}
         ): [
     {%- for dependency in targeted_dep.deps.build_dependencies %}

--- a/impl/src/rendering/templates/partials/targeted_dependencies.template
+++ b/impl/src/rendering/templates/partials/targeted_dependencies.template
@@ -1,8 +1,8 @@
 {% for targeted_dep in crate.targeted_deps %} + selects.with_or({
         # {{ targeted_dep.target }}
         (
-{%- for condition in targeted_dep.conditions %}
-            "{{ condition }}",
+{%- for platform_target in targeted_dep.platform_targets %}
+          "@rules_rust//rust/platform:{{platform_target}}",
 {%- endfor %}
         ): [
 {%- for dependency in targeted_dep.deps.dependencies %}

--- a/impl/src/rendering/templates/workspace.BUILD.template
+++ b/impl/src/rendering/templates/workspace.BUILD.template
@@ -4,34 +4,19 @@ package(default_visibility = ["//visibility:public"])
 licenses([
     "notice",  # See individual crates for specific licenses
 ])
-{%- if crates %}
+{%- if aliases %}
 
 # Aliased targets
-{%- for crate in crates %}
-{%- if crate.is_workspace_member_dependency and crate.lib_target_name %}
-{%- set crate_name_sanitized = crate.pkg_name | replace(from="-", to="_") %}
+{%- for alias in aliases %}
 alias(
-    name = "{{crate_name_sanitized}}",
-    actual = "{{crate.workspace_path_to_crate}}:{{crate_name_sanitized}}",
+    name = "{{alias.alias}}",
+    actual = "{{alias.target}}",
     tags = [
         "cargo-raze",
         "manual",
     ],
 )
-{%  endif %}
-{%- for aliased_target in crate.raze_settings.extra_aliased_targets %}
-alias(
-    # Extra aliased target, from raze configuration
-    # N.B.: The exact form of this is subject to change.
-    name = "{{aliased_target}}",
-    actual = "{{crate.workspace_path_to_crate}}:{{aliased_target}}",
-    tags = [
-        "cargo-raze",
-        "manual",
-    ],
-)
-{%  endfor %}
-{%- endfor %}
+{% endfor %}
 {%- else %}
 
 # No targets defined

--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -22,7 +22,7 @@ use cargo_metadata::{Metadata, MetadataCommand, Package};
 use semver::VersionReq;
 use serde::{Deserialize, Serialize};
 use std::{
-  collections::HashMap,
+  collections::{HashMap, HashSet},
   hash::Hash,
   path::{Path, PathBuf},
 };
@@ -62,7 +62,7 @@ pub struct RazeSettings {
   ///
   /// Each item comes in the form of a "triple", such as "x86_64-unknown-linux-gnu"
   #[serde(default)]
-  pub targets: Option<Vec<String>>,
+  pub targets: Option<HashSet<String>>,
 
   /// A list of binary dependencies.
   #[serde(default)]

--- a/impl/src/testing.rs
+++ b/impl/src/testing.rs
@@ -225,7 +225,7 @@ pub fn mock_remote_crate<'server>(
     let enc = flate2::write::GzEncoder::new(tar_gz, Compression::default());
     let mut tar = tar::Builder::new(enc);
     tar
-      .append_dir_all(package_ident(name, version), dir.as_ref().join("archive"))
+      .append_dir_all(package_ident(name, &version), dir.as_ref().join("archive"))
       .unwrap();
   }
 


### PR DESCRIPTION
There are a range of subtle and irritating bugs that stem from
attempting to work with renames from the package set provided by cargo
metadata.

Fortunately, recent versions of cargo metadata provide a limited version
of the resolve nodes, both as the original node ids and as a newer set
providing both rename and targetting information.

As such we can (hopefully) simplify crate -> dep node resolution, remove
a bunch of subtle aliasing bugs.

Fixes #241, fixes #269, fixes #270, resolves #144, resolves #187