### PR TITLE
cli: implement `--version`

### DIFF
--- a/impl/src/bin/cargo-raze.rs
+++ b/impl/src/bin/cargo-raze.rs
@@ -53,9 +53,11 @@ Usage:
     cargo raze [--verbose] [--quiet] [--color=<WHEN>] [--dryrun] [--cargo-bin-path=<PATH>] [--output=<PATH>]
     cargo raze <buildprefix> [--verbose] [--quiet] [--color=<WHEN>] [--dryrun] [--cargo-bin-path=<PATH>]
                              [--output=<PATH>]
+    cargo raze --version
 
 Options:
     -h, --help                         Print this message
+    --version                          Print version info and exit
     -v, --verbose                      Use verbose output
     -q, --quiet                        No output printed to stdout
     --color=<WHEN>                     Coloring: auto, always, never
@@ -66,6 +68,11 @@ Options:
 
 fn main() -> Result<()> {
   let options: Options = Docopt::new(USAGE)
+    .map(|d| {
+      d.version(Some(
+        concat!("cargo-raze ", env!("CARGO_PKG_VERSION")).to_string(),
+      ))
+    })
     .and_then(|d| d.deserialize())
     .unwrap_or_else(|e| e.exit());
 

--- a/impl/src/bin/cargo-raze.rs
+++ b/impl/src/bin/cargo-raze.rs
@@ -53,11 +53,11 @@ Usage:
     cargo raze [--verbose] [--quiet] [--color=<WHEN>] [--dryrun] [--cargo-bin-path=<PATH>] [--output=<PATH>]
     cargo raze <buildprefix> [--verbose] [--quiet] [--color=<WHEN>] [--dryrun] [--cargo-bin-path=<PATH>]
                              [--output=<PATH>]
-    cargo raze --version
+    cargo raze (-V | --version)
 
 Options:
     -h, --help                         Print this message
-    --version                          Print version info and exit
+    -V, --version                      Print version info and exit
     -v, --verbose                      Use verbose output
     -q, --quiet                        No output printed to stdout
     --color=<WHEN>                     Coloring: auto, always, never


### PR DESCRIPTION
This patch adds a `--version` flag that causes `cargo-raze` to print
version info and exit. The functionality is built into Docopt, so it’s
just a matter of hooking it up to the `CARGO_PKG_VERSION` env var.

Test Plan:
When invoking the binary to test, make sure to pass an extra `raze` arg
so that docopt matches the `cargo raze` (not `cargo-raze`) pattern:

```
cargo run -- raze --version  # or...
cargo install --path . && cargo raze --version
```

Either invocation prints “cargo-raze 0.7.0” and a newline before exiting
successfully. This format is consistent with the `--version` behavior of
`cargo` and `rustc` themselves.

wchargin-branch: cli-version
