### PR TITLE
Fixed regression in rendered templates

### DIFF
--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.bitflags-1.2.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.bitflags-1.2.1.bazel
@@ -28,7 +28,8 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.byteorder-1.3.4.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.byteorder-1.3.4.bazel
@@ -28,7 +28,8 @@ licenses([
     "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.crc32fast-1.2.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.crc32fast-1.2.0.bazel
@@ -28,7 +28,8 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.libc-0.2.67.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.libc-0.2.67.bazel
@@ -28,7 +28,8 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.libc-0.2.77.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.libc-0.2.77.bazel
@@ -28,7 +28,8 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.miniz_oxide-0.4.2.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.miniz_oxide-0.4.2.bazel
@@ -28,7 +28,8 @@ licenses([
     "notice",  # MIT from expression "MIT"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num-integer-0.1.42.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num-integer-0.1.42.bazel
@@ -28,7 +28,8 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num-iter-0.1.40.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num-iter-0.1.40.bazel
@@ -28,7 +28,8 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num-rational-0.2.3.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num-rational-0.2.3.bazel
@@ -28,7 +28,8 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num-traits-0.2.11.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num-traits-0.2.11.bazel
@@ -28,7 +28,8 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro-error-0.4.9.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro-error-0.4.9.bazel
@@ -28,7 +28,8 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro2-1.0.9.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro2-1.0.9.bazel
@@ -28,7 +28,8 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rustversion-1.0.2.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rustversion-1.0.2.bazel
@@ -28,7 +28,8 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.syn-1.0.16.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.syn-1.0.16.bazel
@@ -28,7 +28,8 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-0.3.8.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-0.3.8.bazel
@@ -28,7 +28,8 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -28,7 +28,8 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -28,7 +28,8 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -28,7 +28,8 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.syn-0.15.44.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.syn-0.15.44.bazel
@@ -28,7 +28,8 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated Targets# buildifier: disable=load-on-top
+# Generated Targets
+# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",

--- a/impl/src/rendering/templates/crate.BUILD.template
+++ b/impl/src/rendering/templates/crate.BUILD.template
@@ -30,7 +30,7 @@ licenses([
 
 # Generated Targets
 {%- set crate_name_sanitized = crate.pkg_name | replace(from="-", to="_") -%}
-{%- if crate.build_script_target -%}
+{%- if crate.build_script_target %}
 {%      include "templates/partials/build_script.template" %}
 {%- endif -%}
 {%- for target in crate.targets -%}


### PR DESCRIPTION
This fixes a regression where a newline had been removed from outputs resulting in lines like
```python
# Generated Targets# buildifier: disable=load-on-top
```

This corrects that so the same template renders correctly:
```python
# Generated Targets
# buildifier: disable=load-on-top
```