### PR TITLE
Added setting `rust_rules_workspace_name`

### DIFF
--- a/impl/src/planning/subplanners.rs
+++ b/impl/src/planning/subplanners.rs
@@ -307,7 +307,10 @@ impl<'planner> CrateSubplanner<'planner> {
           dev_dependencies: dep_set.dependencies.dev_deps.clone(),
           aliased_dependencies: dep_set.dependencies.aliased_deps.clone(),
         },
-        conditions: generate_bazel_conditions(&target_triples)?,
+        conditions: generate_bazel_conditions(
+          &self.settings.rust_rules_workspace_name,
+          &target_triples,
+        )?,
       });
     }
 

--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -141,6 +141,13 @@ pub struct RazeSettings {
    */
   #[serde(default = "default_raze_settings_index_url")]
   pub index_url: String,
+
+  /**
+   * The name of the [rules_rust](https://github.com/bazelbuild/rules_rust) repository
+   * used in the generated workspace.
+   */
+  #[serde(default = "default_raze_settings_rust_rules_workspace_name")]
+  pub rust_rules_workspace_name: String,
 }
 
 /** Override settings for individual crates (as part of `RazeSettings`). */
@@ -333,6 +340,10 @@ fn default_raze_settings_index_url() -> String {
   DEFAULT_CRATE_INDEX_URL.to_string()
 }
 
+fn default_raze_settings_rust_rules_workspace_name() -> String {
+  "io_bazel_rules_rust".to_owned()
+}
+
 fn default_crate_settings_field_gen_buildrs() -> Option<bool> {
   None
 }
@@ -484,6 +495,7 @@ pub mod tests {
       binary_deps: HashMap::new(),
       registry: default_raze_settings_registry(),
       index_url: default_raze_settings_index_url(),
+      rust_rules_workspace_name: default_raze_settings_rust_rules_workspace_name(),
     }
   }
 


### PR DESCRIPTION
A new setting `rust_rules_workspace_name` has been added which allows users to specify the name of the `rules_rust` repository they wish to generate files with.

This is blocked by https://github.com/google/cargo-raze/pull/296
This blocks https://github.com/bazelbuild/rules_rust/pull/500