### PR TITLE
Added deprecation warnings

### DIFF
--- a/examples/remote/complicated_cargo_library/Cargo.toml
+++ b/examples/remote/complicated_cargo_library/Cargo.toml
@@ -19,6 +19,7 @@ workspace_path = "//remote/complicated_cargo_library/cargo"
 gen_workspace_prefix = "remote_complicated_cargo_library"
 genmode = "Remote"
 package_aliases_dir = "cargo"
+default_gen_buildrs = false
 
 [package.metadata.raze.crates.proc-macro2.'0.4.30']
 additional_flags = [

--- a/examples/remote/no_deps/Cargo.toml
+++ b/examples/remote/no_deps/Cargo.toml
@@ -12,3 +12,4 @@ workspace_path = "//remote/no_deps/cargo"
 genmode = "Remote"
 gen_workspace_prefix = "remote_no_deps"
 package_aliases_dir = "cargo"
+default_gen_buildrs = true

--- a/examples/remote/non_cratesio/Cargo.toml
+++ b/examples/remote/non_cratesio/Cargo.toml
@@ -17,10 +17,17 @@ path = "src/main.rs"
 
 [package.metadata.raze]
 workspace_path = "//remote/non_cratesio/cargo"
-target = "x86_64-unknown-linux-gnu"
+targets = [
+    "aarch64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+]
 genmode = "Remote"
 gen_workspace_prefix = "remote_non_cratesio"
 package_aliases_dir = "cargo"
+default_gen_buildrs = false
 
 [package.metadata.raze.crates.log.'0.4.11']
 additional_flags = [

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.atty-0.2.14.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.atty-0.2.14.bazel
@@ -57,23 +57,19 @@ rust_library(
         # cfg(unix)
         (
             "@io_bazel_rules_rust//rust/platform:aarch64-apple-darwin",
-            "@io_bazel_rules_rust//rust/platform:aarch64-apple-ios",
-            "@io_bazel_rules_rust//rust/platform:aarch64-linux-android",
             "@io_bazel_rules_rust//rust/platform:aarch64-unknown-linux-gnu",
-            "@io_bazel_rules_rust//rust/platform:arm-unknown-linux-gnueabi",
-            "@io_bazel_rules_rust//rust/platform:i686-apple-darwin",
-            "@io_bazel_rules_rust//rust/platform:i686-linux-android",
-            "@io_bazel_rules_rust//rust/platform:i686-unknown-freebsd",
-            "@io_bazel_rules_rust//rust/platform:i686-unknown-linux-gnu",
-            "@io_bazel_rules_rust//rust/platform:powerpc-unknown-linux-gnu",
-            "@io_bazel_rules_rust//rust/platform:s390x-unknown-linux-gnu",
             "@io_bazel_rules_rust//rust/platform:x86_64-apple-darwin",
-            "@io_bazel_rules_rust//rust/platform:x86_64-apple-ios",
-            "@io_bazel_rules_rust//rust/platform:x86_64-linux-android",
-            "@io_bazel_rules_rust//rust/platform:x86_64-unknown-freebsd",
             "@io_bazel_rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
             "@remote_non_cratesio__libc__0_2_77//:libc",
+        ],
+        "//conditions:default": [],
+    }) + selects.with_or({
+        # cfg(windows)
+        (
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+            "@remote_non_cratesio__winapi__0_3_9//:winapi",
         ],
         "//conditions:default": [],
     }),

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.termcolor-0.3.6.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.termcolor-0.3.6.bazel
@@ -33,6 +33,8 @@ licenses([
 rust_library(
     name = "termcolor",
     srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
     crate_features = [
     ],
     crate_root = "src/lib.rs",
@@ -49,5 +51,13 @@ rust_library(
     version = "0.3.6",
     # buildifier: leave-alone
     deps = [
-    ],
+    ] + selects.with_or({
+        # cfg(windows)
+        (
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+            "@remote_non_cratesio__wincolor__0_1_6//:wincolor",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/examples/vendored/complicated_cargo_library/Cargo.toml
+++ b/examples/vendored/complicated_cargo_library/Cargo.toml
@@ -17,6 +17,7 @@ workspace_path = "//vendored/complicated_cargo_library/cargo"
 gen_workspace_prefix = "vendored_complicated_cargo_library"
 genmode = "Vendored"
 package_aliases_dir = "cargo"
+default_gen_buildrs = false
 
 [package.metadata.raze.crates.proc-macro2.'0.4.30']
 additional_flags = [

--- a/examples/vendored/hello_cargo_library/Cargo.toml
+++ b/examples/vendored/hello_cargo_library/Cargo.toml
@@ -13,8 +13,15 @@ path = "src/main.rs"
 
 [package.metadata.raze]
 workspace_path = "//vendored/hello_cargo_library/cargo"
-target = "x86_64-unknown-linux-gnu"
+targets = [
+    "aarch64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+]
 output_buildfile_suffix = "BUILD.bazel"
 gen_workspace_prefix = "vendored_hello_cargo_library"
 genmode = "Vendored"
 package_aliases_dir = "cargo"
+default_gen_buildrs = false

--- a/examples/vendored/non_cratesio_library/Cargo.toml
+++ b/examples/vendored/non_cratesio_library/Cargo.toml
@@ -18,10 +18,17 @@ path = "src/main.rs"
 
 [package.metadata.raze]
 workspace_path = "//vendored/non_cratesio_library/cargo"
-target = "x86_64-unknown-linux-gnu"
+targets = [
+    "aarch64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+]
 gen_workspace_prefix = "vendored_non_cratesio_library"
 genmode = "Vendored"
 package_aliases_dir = "cargo"
+default_gen_buildrs = false
 
 [package.metadata.raze.crates.log.'0.4.11']
 additional_flags = [

--- a/examples/vendored/non_cratesio_library/cargo/vendor/atty-0.2.14/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/atty-0.2.14/BUILD.bazel
@@ -57,23 +57,19 @@ rust_library(
         # cfg(unix)
         (
             "@io_bazel_rules_rust//rust/platform:aarch64-apple-darwin",
-            "@io_bazel_rules_rust//rust/platform:aarch64-apple-ios",
-            "@io_bazel_rules_rust//rust/platform:aarch64-linux-android",
             "@io_bazel_rules_rust//rust/platform:aarch64-unknown-linux-gnu",
-            "@io_bazel_rules_rust//rust/platform:arm-unknown-linux-gnueabi",
-            "@io_bazel_rules_rust//rust/platform:i686-apple-darwin",
-            "@io_bazel_rules_rust//rust/platform:i686-linux-android",
-            "@io_bazel_rules_rust//rust/platform:i686-unknown-freebsd",
-            "@io_bazel_rules_rust//rust/platform:i686-unknown-linux-gnu",
-            "@io_bazel_rules_rust//rust/platform:powerpc-unknown-linux-gnu",
-            "@io_bazel_rules_rust//rust/platform:s390x-unknown-linux-gnu",
             "@io_bazel_rules_rust//rust/platform:x86_64-apple-darwin",
-            "@io_bazel_rules_rust//rust/platform:x86_64-apple-ios",
-            "@io_bazel_rules_rust//rust/platform:x86_64-linux-android",
-            "@io_bazel_rules_rust//rust/platform:x86_64-unknown-freebsd",
             "@io_bazel_rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
             "//vendored/non_cratesio_library/cargo/vendor/libc-0.2.77:libc",
+        ],
+        "//conditions:default": [],
+    }) + selects.with_or({
+        # cfg(windows)
+        (
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+            "//vendored/non_cratesio_library/cargo/vendor/winapi-0.3.9:winapi",
         ],
         "//conditions:default": [],
     }),

--- a/examples/vendored/non_cratesio_library/cargo/vendor/iovec-0.1.4/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/iovec-0.1.4/BUILD.bazel
@@ -55,20 +55,8 @@ rust_library(
         # cfg(unix)
         (
             "@io_bazel_rules_rust//rust/platform:aarch64-apple-darwin",
-            "@io_bazel_rules_rust//rust/platform:aarch64-apple-ios",
-            "@io_bazel_rules_rust//rust/platform:aarch64-linux-android",
             "@io_bazel_rules_rust//rust/platform:aarch64-unknown-linux-gnu",
-            "@io_bazel_rules_rust//rust/platform:arm-unknown-linux-gnueabi",
-            "@io_bazel_rules_rust//rust/platform:i686-apple-darwin",
-            "@io_bazel_rules_rust//rust/platform:i686-linux-android",
-            "@io_bazel_rules_rust//rust/platform:i686-unknown-freebsd",
-            "@io_bazel_rules_rust//rust/platform:i686-unknown-linux-gnu",
-            "@io_bazel_rules_rust//rust/platform:powerpc-unknown-linux-gnu",
-            "@io_bazel_rules_rust//rust/platform:s390x-unknown-linux-gnu",
             "@io_bazel_rules_rust//rust/platform:x86_64-apple-darwin",
-            "@io_bazel_rules_rust//rust/platform:x86_64-apple-ios",
-            "@io_bazel_rules_rust//rust/platform:x86_64-linux-android",
-            "@io_bazel_rules_rust//rust/platform:x86_64-unknown-freebsd",
             "@io_bazel_rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
             "//vendored/non_cratesio_library/cargo/vendor/libc-0.2.77:libc",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/termcolor-0.3.6/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/termcolor-0.3.6/BUILD.bazel
@@ -33,6 +33,8 @@ licenses([
 rust_library(
     name = "termcolor",
     srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
     crate_features = [
     ],
     crate_root = "src/lib.rs",
@@ -49,5 +51,13 @@ rust_library(
     version = "0.3.6",
     # buildifier: leave-alone
     deps = [
-    ],
+    ] + selects.with_or({
+        # cfg(windows)
+        (
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+            "//vendored/non_cratesio_library/cargo/vendor/wincolor-0.1.6:wincolor",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -542,7 +542,7 @@ impl RawRazeSettings {
 
     if self.incompatible_relative_workspace_path.unwrap_or(false) {
       eprintln!(
-        "WARNING: `[*.raze.incompatible_relative_workspace_path]` will is deprecated. Please set \
+        "WARNING: `[*.raze.incompatible_relative_workspace_path]` is deprecated. Please set \
          this flag to true and make sure `workspace_path` is the label where the Cargo-raze is \
          expected to write it's output."
       );
@@ -550,7 +550,7 @@ impl RawRazeSettings {
 
     if self.target.is_some() {
       eprintln!(
-        "WARNING: `[*.raze.target]` will soon be deprecated. Please update your project to use \
+        "WARNING: `[*.raze.target]` is deprecated. Please update your project to use \
          `[*.raze.targets]`."
       );
     }

--- a/smoke_test/remote/complicated_cargo_library/Cargo.toml
+++ b/smoke_test/remote/complicated_cargo_library/Cargo.toml
@@ -19,6 +19,7 @@ workspace_path = "//remote/complicated_cargo_library/cargo"
 gen_workspace_prefix = "remote_complicated_cargo_library"
 genmode = "Remote"
 package_aliases_dir = "cargo"
+default_gen_buildrs = false
 
 [package.metadata.raze.crates.proc-macro2.'0.4.30']
 additional_flags = [

--- a/smoke_test/remote/no_deps/Cargo.toml
+++ b/smoke_test/remote/no_deps/Cargo.toml
@@ -12,3 +12,4 @@ workspace_path = "//remote/no_deps/cargo"
 genmode = "Remote"
 gen_workspace_prefix = "remote_no_deps"
 package_aliases_dir = "cargo"
+default_gen_buildrs = true

--- a/smoke_test/remote/non_cratesio/Cargo.toml
+++ b/smoke_test/remote/non_cratesio/Cargo.toml
@@ -17,10 +17,17 @@ path = "src/main.rs"
 
 [package.metadata.raze]
 workspace_path = "//remote/non_cratesio/cargo"
-target = "x86_64-unknown-linux-gnu"
+targets = [
+    "aarch64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+]
 genmode = "Remote"
 gen_workspace_prefix = "remote_non_cratesio"
 package_aliases_dir = "cargo"
+default_gen_buildrs = false
 
 [package.metadata.raze.crates.log.'0.4.11']
 additional_flags = [

--- a/smoke_test/vendored/complicated_cargo_library/Cargo.toml
+++ b/smoke_test/vendored/complicated_cargo_library/Cargo.toml
@@ -17,6 +17,7 @@ workspace_path = "//vendored/complicated_cargo_library/cargo"
 gen_workspace_prefix = "vendored_complicated_cargo_library"
 genmode = "Vendored"
 package_aliases_dir = "cargo"
+default_gen_buildrs = false
 
 [package.metadata.raze.crates.proc-macro2.'0.4.30']
 additional_flags = [

--- a/smoke_test/vendored/hello_cargo_library/Cargo.toml
+++ b/smoke_test/vendored/hello_cargo_library/Cargo.toml
@@ -13,8 +13,15 @@ path = "src/main.rs"
 
 [package.metadata.raze]
 workspace_path = "//vendored/hello_cargo_library/cargo"
-target = "x86_64-unknown-linux-gnu"
+targets = [
+    "aarch64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+]
 output_buildfile_suffix = "BUILD.bazel"
 gen_workspace_prefix = "vendored_hello_cargo_library"
 genmode = "Vendored"
 package_aliases_dir = "cargo"
+default_gen_buildrs = false

--- a/smoke_test/vendored/non_cratesio_library/Cargo.toml
+++ b/smoke_test/vendored/non_cratesio_library/Cargo.toml
@@ -18,10 +18,17 @@ path = "src/main.rs"
 
 [package.metadata.raze]
 workspace_path = "//vendored/non_cratesio_library/cargo"
-target = "x86_64-unknown-linux-gnu"
+targets = [
+    "aarch64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+]
 gen_workspace_prefix = "vendored_non_cratesio_library"
 genmode = "Vendored"
 package_aliases_dir = "cargo"
+default_gen_buildrs = false
 
 [package.metadata.raze.crates.log.'0.4.11']
 additional_flags = [


### PR DESCRIPTION
This flags certain settings as deprecated. Namely:
- `incompatible_relative_workspace_path` is planned to be removed
- `target` can be replaced by `targets`
- `default_gen_buildrs` is expected to change it's default settings per https://github.com/bazelbuild/rules_rust/issues/490

Blocked by https://github.com/google/cargo-raze/pull/302