### PR TITLE
Add data deps attrs to CrateDependencyContext

### DIFF
--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.addr2line-0.14.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.addr2line-0.14.0.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.adler-0.2.3.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.adler-0.2.3.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.adler32-1.2.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.adler32-1.2.0.bazel
@@ -43,6 +43,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.ansi_term-0.11.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.ansi_term-0.11.0.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.atty-0.2.14.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.atty-0.2.14.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.autocfg-1.0.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.autocfg-1.0.1.bazel
@@ -45,6 +45,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.backtrace-0.3.54.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.backtrace-0.3.54.bazel
@@ -51,6 +51,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.bitflags-1.2.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.bitflags-1.2.1.bazel
@@ -67,6 +67,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.bytemuck-1.4.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.bytemuck-1.4.1.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.byteorder-1.3.4.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.byteorder-1.3.4.bazel
@@ -71,6 +71,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.cfg-if-0.1.10.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.cfg-if-0.1.10.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.cfg-if-1.0.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.cfg-if-1.0.0.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.clap-2.33.3.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.clap-2.33.3.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.console-0.13.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.console-0.13.0.bazel
@@ -53,6 +53,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.crc32fast-1.2.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.crc32fast-1.2.1.bazel
@@ -71,6 +71,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.crossbeam-utils-0.7.2.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.crossbeam-utils-0.7.2.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.deflate-0.8.6.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.deflate-0.8.6.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.encode_unicode-0.3.6.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.encode_unicode-0.3.6.bazel
@@ -43,6 +43,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.error-chain-0.10.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.error-chain-0.10.0.bazel
@@ -48,6 +48,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.ferris-says-0.2.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.ferris-says-0.2.0.bazel
@@ -38,6 +38,7 @@ rust_binary(
     crate_features = [
     ],
     crate_root = "src/bin/main.rs",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
@@ -66,6 +67,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.gimli-0.23.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.gimli-0.23.0.bazel
@@ -48,6 +48,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.heck-0.3.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.heck-0.3.1.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.hermit-abi-0.1.17.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.hermit-abi-0.1.17.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.image-0.23.10.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.image-0.23.10.bazel
@@ -47,7 +47,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
-    data = ["README.md"],
+    data = [] + ["README.md"],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.indicatif-0.14.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.indicatif-0.14.0.bazel
@@ -66,6 +66,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.jpeg-decoder-0.1.20.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.jpeg-decoder-0.1.20.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.lazy_static-1.4.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.lazy_static-1.4.0.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.libc-0.2.80.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.libc-0.2.80.bazel
@@ -69,6 +69,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.miniz_oxide-0.3.7.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.miniz_oxide-0.3.7.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
@@ -66,6 +66,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num-integer-0.1.44.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num-integer-0.1.44.bazel
@@ -76,6 +76,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num-iter-0.1.42.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num-iter-0.1.42.bazel
@@ -70,6 +70,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num-rational-0.3.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num-rational-0.3.1.bazel
@@ -66,6 +66,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num-traits-0.2.14.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num-traits-0.2.14.bazel
@@ -72,6 +72,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num_cpus-1.13.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num_cpus-1.13.0.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.number_prefix-0.3.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.number_prefix-0.3.0.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.object-0.22.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.object-0.22.0.bazel
@@ -54,6 +54,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.pdqselect-0.1.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.pdqselect-0.1.0.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.png-0.16.7.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.png-0.16.7.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.ppv-lite86-0.2.9.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.ppv-lite86-0.2.9.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro-error-1.0.4.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro-error-1.0.4.bazel
@@ -72,6 +72,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     proc_macro_deps = [
         "@remote_binary_dependencies__proc_macro_error_attr__1_0_4//:proc_macro_error_attr",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro-error-attr-1.0.4.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro-error-attr-1.0.4.bazel
@@ -66,6 +66,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "proc-macro",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro2-1.0.24.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro2-1.0.24.bazel
@@ -69,6 +69,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.quote-1.0.7.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.quote-1.0.7.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rand-0.7.3.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rand-0.7.3.bazel
@@ -51,6 +51,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_chacha-0.2.2.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_chacha-0.2.2.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_core-0.5.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_core-0.5.1.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_hc-0.2.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_hc-0.2.0.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_pcg-0.2.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_pcg-0.2.1.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.regex-1.4.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.regex-1.4.1.bazel
@@ -50,6 +50,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.regex-syntax-0.6.20.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.regex-syntax-0.6.20.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rstar-0.7.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rstar-0.7.1.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rustc-demangle-0.1.18.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rustc-demangle-0.1.18.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.smallvec-0.4.5.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.smallvec-0.4.5.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.strsim-0.8.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.strsim-0.8.0.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.structopt-0.3.20.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.structopt-0.3.20.bazel
@@ -80,6 +80,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     proc_macro_deps = [
         "@remote_binary_dependencies__structopt_derive__0_4_13//:structopt_derive",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.structopt-derive-0.4.13.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.structopt-derive-0.4.13.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "proc-macro",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.syn-1.0.48.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.syn-1.0.48.bazel
@@ -85,6 +85,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.terminal_size-0.1.13.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.terminal_size-0.1.13.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.texture-synthesis-0.8.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.texture-synthesis-0.8.0.bazel
@@ -59,6 +59,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.texture-synthesis-cli-0.8.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.texture-synthesis-cli-0.8.0.bazel
@@ -41,6 +41,7 @@ rust_binary(
         "default",
     ],
     crate_root = "src/main.rs",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.textwrap-0.11.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.textwrap-0.11.0.bazel
@@ -43,6 +43,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.unicode-segmentation-1.6.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.unicode-segmentation-1.6.0.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.unicode-width-0.1.8.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.unicode-width-0.1.8.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.unicode-xid-0.2.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.unicode-xid-0.2.1.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.vec_map-0.8.2.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.vec_map-0.8.2.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.version_check-0.9.2.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.version_check-0.9.2.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -91,6 +91,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -65,6 +65,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-util-0.1.5.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-util-0.1.5.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -65,6 +65,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.addr2line-0.13.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.addr2line-0.13.0.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.adler-0.2.3.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.adler-0.2.3.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.ansi_term-0.11.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.ansi_term-0.11.0.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.atty-0.2.14.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.atty-0.2.14.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.autocfg-1.0.1.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.autocfg-1.0.1.bazel
@@ -45,6 +45,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.backtrace-0.3.53.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.backtrace-0.3.53.bazel
@@ -51,6 +51,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.bitflags-1.2.1.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.bitflags-1.2.1.bazel
@@ -67,6 +67,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.cfg-if-0.1.10.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.cfg-if-0.1.10.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.cfg-if-1.0.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.cfg-if-1.0.0.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.clap-2.33.3.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.clap-2.33.3.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.error-chain-0.10.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.error-chain-0.10.0.bazel
@@ -48,6 +48,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.ferris-says-0.2.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.ferris-says-0.2.0.bazel
@@ -38,6 +38,7 @@ rust_binary(
     crate_features = [
     ],
     crate_root = "src/bin/main.rs",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
@@ -66,6 +67,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.getrandom-0.1.15.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.getrandom-0.1.15.bazel
@@ -107,6 +107,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.gimli-0.22.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.gimli-0.22.0.bazel
@@ -48,6 +48,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.hermit-abi-0.1.17.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.hermit-abi-0.1.17.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.libc-0.2.79.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.libc-0.2.79.bazel
@@ -65,6 +65,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
@@ -66,6 +66,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.object-0.21.1.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.object-0.21.1.bazel
@@ -49,6 +49,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.ppv-lite86-0.2.9.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.ppv-lite86-0.2.9.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.rand-0.7.3.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.rand-0.7.3.bazel
@@ -58,6 +58,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.rand_chacha-0.2.2.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.rand_chacha-0.2.2.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.rand_core-0.5.1.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.rand_core-0.5.1.bazel
@@ -40,6 +40,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.rand_hc-0.2.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.rand_hc-0.2.0.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.rustc-demangle-0.1.17.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.rustc-demangle-0.1.17.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.smallvec-0.4.5.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.smallvec-0.4.5.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.strsim-0.8.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.strsim-0.8.0.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.textwrap-0.11.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.textwrap-0.11.0.bazel
@@ -43,6 +43,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.unicode-width-0.1.8.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.unicode-width-0.1.8.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.vec_map-0.8.2.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.vec_map-0.8.2.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.wasi-0.9.0+wasi-snapshot-preview1.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.wasi-0.9.0+wasi-snapshot-preview1.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -77,6 +77,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -65,6 +65,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -65,6 +65,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.MacTypes-sys-1.3.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.MacTypes-sys-1.3.0.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.aho-corasick-0.6.10.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.aho-corasick-0.6.10.bazel
@@ -40,6 +40,7 @@ rust_binary(
     crate_features = [
     ],
     crate_root = "src/main.rs",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
@@ -66,6 +67,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.arrayvec-0.3.25.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.arrayvec-0.3.25.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.atom-0.3.5.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.atom-0.3.5.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.autocfg-1.0.1.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.autocfg-1.0.1.bazel
@@ -45,6 +45,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.cc-1.0.60.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.cc-1.0.60.bazel
@@ -38,6 +38,7 @@ rust_binary(
     crate_features = [
     ],
     crate_root = "src/bin/gcc-shim.rs",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
@@ -61,6 +62,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.cfg-if-0.1.10.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.cfg-if-0.1.10.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.core-foundation-sys-0.5.1.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.core-foundation-sys-0.5.1.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-0.3.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-0.3.2.bazel
@@ -38,6 +38,7 @@ rust_binary(
     crate_features = [
     ],
     crate_root = "src/bin/bench.rs",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
@@ -62,6 +63,7 @@ rust_binary(
     crate_features = [
     ],
     crate_root = "src/bin/stress-msq.rs",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
@@ -85,6 +87,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-channel-0.4.4.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-channel-0.4.4.bazel
@@ -45,6 +45,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-deque-0.7.3.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-deque-0.7.3.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-epoch-0.8.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-epoch-0.8.2.bazel
@@ -52,6 +52,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-utils-0.7.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-utils-0.7.2.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.derivative-1.0.4.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.derivative-1.0.4.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "proc-macro",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.fnv-1.0.7.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.fnv-1.0.7.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.hermit-abi-0.1.15.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.hermit-abi-0.1.15.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.hibitset-0.3.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.hibitset-0.3.2.bazel
@@ -42,6 +42,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.lazy_static-1.4.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.lazy_static-1.4.0.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.libc-0.2.77.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.libc-0.2.77.bazel
@@ -42,6 +42,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.libloading-0.5.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.libloading-0.5.2.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.maybe-uninit-2.0.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.maybe-uninit-2.0.0.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.memchr-2.3.3.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.memchr-2.3.3.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.memoffset-0.5.5.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.memoffset-0.5.5.bazel
@@ -40,6 +40,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.mopa-0.2.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.mopa-0.2.2.bazel
@@ -43,6 +43,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.nodrop-0.1.14.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.nodrop-0.1.14.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.num_cpus-1.13.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.num_cpus-1.13.0.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.odds-0.2.26.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.odds-0.2.26.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.proc-macro2-0.4.30.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.proc-macro2-0.4.30.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.pulse-0.5.3.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.pulse-0.5.3.bazel
@@ -40,6 +40,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.quote-0.3.15.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.quote-0.3.15.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.quote-0.6.13.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.quote-0.6.13.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.rayon-0.8.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.rayon-0.8.2.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.rayon-core-1.8.1.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.rayon-core-1.8.1.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.regex-0.2.5.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.regex-0.2.5.bazel
@@ -49,6 +49,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_env = {
         "NOT_USED_KEY": "not_used_value",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.regex-syntax-0.4.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.regex-syntax-0.4.2.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.scopeguard-1.1.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.scopeguard-1.1.0.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.security-framework-sys-0.2.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.security-framework-sys-0.2.2.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.shred-0.5.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.shred-0.5.2.bazel
@@ -55,6 +55,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     proc_macro_deps = [
         "@remote_complicated_cargo_library__shred_derive__0_3_0//:shred_derive",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.shred-derive-0.3.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.shred-derive-0.3.0.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "proc-macro",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.smallvec-0.4.5.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.smallvec-0.4.5.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.specs-0.10.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.specs-0.10.0.bazel
@@ -57,6 +57,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     proc_macro_deps = [
         "@remote_complicated_cargo_library__derivative__1_0_4//:derivative",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.syn-0.11.11.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.syn-0.11.11.bazel
@@ -43,6 +43,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.syn-0.15.44.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.syn-0.15.44.bazel
@@ -83,6 +83,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.synom-0.11.3.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.synom-0.11.3.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.thread_local-0.3.6.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.thread_local-0.3.6.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.time-0.1.44.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.time-0.1.44.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.tuple_utils-0.2.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.tuple_utils-0.2.0.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.unicode-xid-0.0.4.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.unicode-xid-0.0.4.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.unicode-xid-0.1.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.unicode-xid-0.1.0.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.utf8-ranges-1.0.4.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.utf8-ranges-1.0.4.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.wasi-0.10.0+wasi-snapshot-preview1.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.wasi-0.10.0+wasi-snapshot-preview1.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -49,6 +49,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.aho-corasick-0.6.10.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.aho-corasick-0.6.10.bazel
@@ -40,6 +40,7 @@ rust_binary(
     crate_features = [
     ],
     crate_root = "src/main.rs",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
@@ -66,6 +67,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.atty-0.2.14.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.atty-0.2.14.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.bitflags-1.2.1.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.bitflags-1.2.1.bazel
@@ -40,6 +40,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.cfg-if-0.1.10.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.cfg-if-0.1.10.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.env_logger-0.5.5.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.env_logger-0.5.5.bazel
@@ -49,6 +49,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.fuchsia-zircon-0.3.3.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.fuchsia-zircon-0.3.3.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.fuchsia-zircon-sys-0.3.3.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.fuchsia-zircon-sys-0.3.3.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.hermit-abi-0.1.15.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.hermit-abi-0.1.15.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.humantime-1.3.0.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.humantime-1.3.0.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.lazy_static-1.4.0.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.lazy_static-1.4.0.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.libc-0.2.77.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.libc-0.2.77.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.log-0.4.0.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.log-0.4.0.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.log-0.4.11.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.log-0.4.11.bazel
@@ -40,6 +40,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.memchr-2.3.3.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.memchr-2.3.3.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.quick-error-1.2.3.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.quick-error-1.2.3.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.rand-0.4.1.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.rand-0.4.1.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.regex-0.2.11.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.regex-0.2.11.bazel
@@ -52,6 +52,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.regex-syntax-0.5.6.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.regex-syntax-0.5.6.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.termcolor-0.3.6.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.termcolor-0.3.6.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.thread_local-0.3.6.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.thread_local-0.3.6.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.ucd-util-0.1.8.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.ucd-util-0.1.8.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.utf8-ranges-1.0.4.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.utf8-ranges-1.0.4.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -45,6 +45,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.wincolor-0.1.6.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.wincolor-0.1.6.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/addr2line-0.13.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/addr2line-0.13.0/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/adler-0.2.3/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/adler-0.2.3/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/ansi_term-0.11.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/ansi_term-0.11.0/BUILD.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/atty-0.2.14/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/atty-0.2.14/BUILD.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/autocfg-1.0.1/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/autocfg-1.0.1/BUILD.bazel
@@ -45,6 +45,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/backtrace-0.3.53/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/backtrace-0.3.53/BUILD.bazel
@@ -51,6 +51,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/bitflags-1.2.1/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/bitflags-1.2.1/BUILD.bazel
@@ -67,6 +67,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/cfg-if-0.1.10/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/cfg-if-0.1.10/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/cfg-if-1.0.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/cfg-if-1.0.0/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/clap-2.33.3/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/clap-2.33.3/BUILD.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/error-chain-0.10.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/error-chain-0.10.0/BUILD.bazel
@@ -48,6 +48,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/ferris-says-0.2.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/ferris-says-0.2.0/BUILD.bazel
@@ -38,6 +38,7 @@ rust_binary(
     crate_features = [
     ],
     crate_root = "src/bin/main.rs",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
@@ -66,6 +67,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/getrandom-0.1.15/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/getrandom-0.1.15/BUILD.bazel
@@ -107,6 +107,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/gimli-0.22.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/gimli-0.22.0/BUILD.bazel
@@ -48,6 +48,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/hermit-abi-0.1.17/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/hermit-abi-0.1.17/BUILD.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/libc-0.2.79/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/libc-0.2.79/BUILD.bazel
@@ -65,6 +65,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/miniz_oxide-0.4.3/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/miniz_oxide-0.4.3/BUILD.bazel
@@ -66,6 +66,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/object-0.21.1/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/object-0.21.1/BUILD.bazel
@@ -49,6 +49,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/ppv-lite86-0.2.9/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/ppv-lite86-0.2.9/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/rand-0.7.3/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/rand-0.7.3/BUILD.bazel
@@ -58,6 +58,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/rand_chacha-0.2.2/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/rand_chacha-0.2.2/BUILD.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/rand_core-0.5.1/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/rand_core-0.5.1/BUILD.bazel
@@ -40,6 +40,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/rand_hc-0.2.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/rand_hc-0.2.0/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/rustc-demangle-0.1.17/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/rustc-demangle-0.1.17/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/smallvec-0.4.5/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/smallvec-0.4.5/BUILD.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/strsim-0.8.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/strsim-0.8.0/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/textwrap-0.11.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/textwrap-0.11.0/BUILD.bazel
@@ -43,6 +43,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/unicode-width-0.1.8/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/unicode-width-0.1.8/BUILD.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/vec_map-0.8.2/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/vec_map-0.8.2/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/wasi-0.9.0+wasi-snapshot-preview1/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/wasi-0.9.0+wasi-snapshot-preview1/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/winapi-0.3.9/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/winapi-0.3.9/BUILD.bazel
@@ -77,6 +77,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -65,6 +65,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/cargo_workspace/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -65,6 +65,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/MacTypes-sys-2.1.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/MacTypes-sys-2.1.0/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
@@ -40,6 +40,7 @@ rust_binary(
     crate_features = [
     ],
     crate_root = "src/main.rs",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
@@ -66,6 +67,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/arrayvec-0.3.25/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/arrayvec-0.3.25/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/atom-0.3.5/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/atom-0.3.5/BUILD.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/autocfg-1.0.1/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/autocfg-1.0.1/BUILD.bazel
@@ -45,6 +45,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/cfg-if-0.1.10/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/cfg-if-0.1.10/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/conduit-mime-types-0.7.3/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/conduit-mime-types-0.7.3/BUILD.bazel
@@ -37,7 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
-    data = glob(["data/**"]),
+    data = [] + glob(["data/**"]),
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/core-foundation-sys-0.5.1/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/core-foundation-sys-0.5.1/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-0.3.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-0.3.2/BUILD.bazel
@@ -38,6 +38,7 @@ rust_binary(
     crate_features = [
     ],
     crate_root = "src/bin/bench.rs",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
@@ -62,6 +63,7 @@ rust_binary(
     crate_features = [
     ],
     crate_root = "src/bin/stress-msq.rs",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
@@ -85,6 +87,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-channel-0.4.4/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-channel-0.4.4/BUILD.bazel
@@ -45,6 +45,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-deque-0.7.3/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-deque-0.7.3/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-epoch-0.8.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-epoch-0.8.2/BUILD.bazel
@@ -52,6 +52,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-utils-0.7.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-utils-0.7.2/BUILD.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/derivative-1.0.4/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/derivative-1.0.4/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "proc-macro",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/fnv-1.0.7/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/fnv-1.0.7/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/hermit-abi-0.1.15/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/hermit-abi-0.1.15/BUILD.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/hibitset-0.3.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/hibitset-0.3.2/BUILD.bazel
@@ -42,6 +42,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/lazy_static-1.4.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/lazy_static-1.4.0/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/libc-0.2.77/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/libc-0.2.77/BUILD.bazel
@@ -42,6 +42,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/maybe-uninit-2.0.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/maybe-uninit-2.0.0/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/memchr-2.3.3/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/memchr-2.3.3/BUILD.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/memoffset-0.5.5/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/memoffset-0.5.5/BUILD.bazel
@@ -40,6 +40,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/mopa-0.2.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/mopa-0.2.2/BUILD.bazel
@@ -43,6 +43,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/nodrop-0.1.14/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/nodrop-0.1.14/BUILD.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/num_cpus-1.13.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/num_cpus-1.13.0/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/odds-0.2.26/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/odds-0.2.26/BUILD.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/proc-macro2-0.4.30/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/proc-macro2-0.4.30/BUILD.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/pulse-0.5.3/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/pulse-0.5.3/BUILD.bazel
@@ -40,6 +40,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/quote-0.3.15/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/quote-0.3.15/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/quote-0.6.13/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/quote-0.6.13/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-0.8.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-0.8.2/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-core-1.8.1/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-core-1.8.1/BUILD.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/regex-0.2.11/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/regex-0.2.11/BUILD.bazel
@@ -52,6 +52,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_env = {
         "NOT_USED_KEY": "not_used_value",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/regex-syntax-0.5.6/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/regex-syntax-0.5.6/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/rustc-serialize-0.3.24/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/rustc-serialize-0.3.24/BUILD.bazel
@@ -43,6 +43,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/scopeguard-1.1.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/scopeguard-1.1.0/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/security-framework-sys-0.2.3/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/security-framework-sys-0.2.3/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/shred-0.5.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/shred-0.5.2/BUILD.bazel
@@ -55,6 +55,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     proc_macro_deps = [
         "//vendored/complicated_cargo_library/cargo/vendor/shred-derive-0.3.0:shred_derive",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/shred-derive-0.3.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/shred-derive-0.3.0/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "proc-macro",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/smallvec-0.4.5/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/smallvec-0.4.5/BUILD.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/specs-0.10.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/specs-0.10.0/BUILD.bazel
@@ -57,6 +57,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     proc_macro_deps = [
         "//vendored/complicated_cargo_library/cargo/vendor/derivative-1.0.4:derivative",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.11.11/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.11.11/BUILD.bazel
@@ -43,6 +43,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.15.44/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.15.44/BUILD.bazel
@@ -48,6 +48,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/synom-0.11.3/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/synom-0.11.3/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/thread_local-0.3.6/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/thread_local-0.3.6/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/time-0.1.44/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/time-0.1.44/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/tuple_utils-0.2.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/tuple_utils-0.2.0/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/ucd-util-0.1.8/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/ucd-util-0.1.8/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.0.4/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.0.4/BUILD.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.1.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.1.0/BUILD.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/utf8-ranges-1.0.4/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/utf8-ranges-1.0.4/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/wasi-0.10.0+wasi-snapshot-preview1/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/wasi-0.10.0+wasi-snapshot-preview1/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-0.3.9/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-0.3.9/BUILD.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/hello_cargo_library/cargo/vendor/fern-0.3.5/BUILD.bazel
+++ b/examples/vendored/hello_cargo_library/cargo/vendor/fern-0.3.5/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/hello_cargo_library/cargo/vendor/log-0.3.6/BUILD.bazel
+++ b/examples/vendored/hello_cargo_library/cargo/vendor/log-0.3.6/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
@@ -40,6 +40,7 @@ rust_binary(
     crate_features = [
     ],
     crate_root = "src/main.rs",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
@@ -66,6 +67,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/atty-0.2.14/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/atty-0.2.14/BUILD.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/cfg-if-0.1.10/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/cfg-if-0.1.10/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/either-1.6.1/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/either-1.6.1/BUILD.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/env_logger-0.5.5/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/env_logger-0.5.5/BUILD.bazel
@@ -49,6 +49,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-0.2.0/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-channel-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-channel-0.2.0/BUILD.bazel
@@ -40,6 +40,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-core-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-core-0.2.0/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-executor-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-executor-0.2.0/BUILD.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-io-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-io-0.2.0/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-sink-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-sink-0.2.0/BUILD.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-stable-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-stable-0.2.0/BUILD.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-util-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-util-0.2.0/BUILD.bazel
@@ -42,6 +42,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/hermit-abi-0.1.15/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/hermit-abi-0.1.15/BUILD.bazel
@@ -38,6 +38,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/humantime-1.3.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/humantime-1.3.0/BUILD.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/iovec-0.1.4/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/iovec-0.1.4/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/lazy_static-1.4.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/lazy_static-1.4.0/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/libc-0.2.77/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/libc-0.2.77/BUILD.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.0/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.11/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.11/BUILD.bazel
@@ -40,6 +40,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/memchr-2.3.3/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/memchr-2.3.3/BUILD.bazel
@@ -41,6 +41,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/num_cpus-1.13.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/num_cpus-1.13.0/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/quick-error-1.2.3/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/quick-error-1.2.3/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/regex-0.2.11/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/regex-0.2.11/BUILD.bazel
@@ -52,6 +52,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/regex-syntax-0.5.6/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/regex-syntax-0.5.6/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/termcolor-0.3.6/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/termcolor-0.3.6/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/thread_local-0.3.6/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/thread_local-0.3.6/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/ucd-util-0.1.8/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/ucd-util-0.1.8/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/utf8-ranges-1.0.4/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/utf8-ranges-1.0.4/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/winapi-0.3.9/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/winapi-0.3.9/BUILD.bazel
@@ -45,6 +45,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -39,6 +39,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/examples/vendored/non_cratesio_library/cargo/vendor/wincolor-0.1.6/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/wincolor-0.1.6/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     crate_type = "lib",
+    data = [],
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -87,8 +87,12 @@ pub struct SourceDetails {
 pub struct CrateDependencyContext {
   pub dependencies: Vec<BuildableDependency>,
   pub proc_macro_dependencies: Vec<BuildableDependency>,
+  // data_dependencies can only be set when using cargo-raze as a library at the moment.
+  pub data_dependencies: Vec<BuildableDependency>,
   pub build_dependencies: Vec<BuildableDependency>,
   pub build_proc_macro_dependencies: Vec<BuildableDependency>,
+  // build_data_dependencies can only be set when using cargo-raze as a library at the moment.
+  pub build_data_dependencies: Vec<BuildableDependency>,
   pub dev_dependencies: Vec<BuildableDependency>,
   pub aliased_dependencies: Vec<DependencyAlias>,
 }

--- a/impl/src/planning/subplanners.rs
+++ b/impl/src/planning/subplanners.rs
@@ -302,8 +302,10 @@ impl<'planner> CrateSubplanner<'planner> {
         deps: CrateDependencyContext {
           dependencies: dep_set.dependencies.normal_deps.clone(),
           proc_macro_dependencies: dep_set.dependencies.proc_macro_deps.clone(),
+          data_dependencies: vec![],
           build_dependencies: dep_set.dependencies.build_deps.clone(),
           build_proc_macro_dependencies: dep_set.dependencies.build_proc_macro_deps.clone(),
+          build_data_dependencies: vec![],
           dev_dependencies: dep_set.dependencies.dev_deps.clone(),
           aliased_dependencies: dep_set.dependencies.aliased_deps.clone(),
         },
@@ -353,8 +355,10 @@ impl<'planner> CrateSubplanner<'planner> {
       default_deps: CrateDependencyContext {
         dependencies: normal_deps,
         proc_macro_dependencies: proc_macro_deps,
+        data_dependencies: vec![],
         build_dependencies: build_deps,
         build_proc_macro_dependencies: build_proc_macro_deps,
+        build_data_dependencies: vec![],
         dev_dependencies: dev_deps,
         aliased_dependencies: aliased_deps,
       },

--- a/impl/src/rendering/bazel.rs
+++ b/impl/src/rendering/bazel.rs
@@ -407,8 +407,10 @@ mod tests {
       default_deps: CrateDependencyContext {
         dependencies: Vec::new(),
         proc_macro_dependencies: Vec::new(),
+        data_dependencies: Vec::new(),
         build_dependencies: Vec::new(),
         build_proc_macro_dependencies: Vec::new(),
+        build_data_dependencies: Vec::new(),
         dev_dependencies: Vec::new(),
         aliased_dependencies: Vec::new(),
       },
@@ -450,8 +452,10 @@ mod tests {
       default_deps: CrateDependencyContext {
         dependencies: Vec::new(),
         proc_macro_dependencies: Vec::new(),
+        data_dependencies: Vec::new(),
         build_dependencies: Vec::new(),
         build_proc_macro_dependencies: Vec::new(),
+        build_data_dependencies: Vec::new(),
         dev_dependencies: Vec::new(),
         aliased_dependencies: Vec::new(),
       },

--- a/impl/src/rendering/templates/partials/build_script.template
+++ b/impl/src/rendering/templates/partials/build_script.template
@@ -21,8 +21,15 @@ cargo_build_script(
     crate_root = "{{ crate.build_script_target.path }}",
     {%- else %}
     crate_root = "build.rs",
+    {%- endif -%}
+    {# Note: build_data_dependencies can only be set when using cargo-raze as a library at the moment #}
+    data = {%- if crate.default_deps.build_data_dependencies %} glob(["**"]) + [
+    {%- for dependency in crate.default_deps.build_data_dependencies %}
+        "{{dependency.buildable_target}}",
+    {%- endfor %}
+    ],
+    {%- else %} glob(["**"]),
     {%- endif %}
-    data = glob(["**"]),
     edition = "{{ crate.edition }}",
     {%- if crate.default_deps.build_proc_macro_dependencies %}
     proc_macro_deps = [

--- a/impl/src/rendering/templates/partials/common_attrs.template
+++ b/impl/src/rendering/templates/partials/common_attrs.template
@@ -20,9 +20,16 @@
     {%- if target.kind != "bin" %}
     crate_type = "{{ target.kind }}",
     {%- endif %}
-    {%- if crate.raze_settings.data_attr %}
-    data = {{crate.raze_settings.data_attr}},
-    {%- endif %}
+    data = []
+    {%- if crate.raze_settings.data_attr %} + {{crate.raze_settings.data_attr}}
+    {%- endif -%}
+    {# Note: data_dependencies can only be set when using cargo-raze as a library at the moment #}
+    {%- if crate.default_deps.data_dependencies %} + [
+    {%- for dependency in crate.default_deps.data_dependencies %}
+        "{{dependency.buildable_target}}",
+    {%- endfor %}
+    ]
+    {%- endif %},
     edition = "{{ target.edition }}",
     {%- if crate.default_deps.proc_macro_dependencies %}
     proc_macro_deps = [


### PR DESCRIPTION
Specifying data dependencies is needed for some projects.

This PR only adds the corresponding attributes to the data structures, allowing dependencies of cargo-raze to use them.

This is needed for an upcoming contribution that @illicitonion is working on.