### PR TITLE
Cleaning up code owners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Code owners of cargo-raze
 
-* @acmcarther @damienmg @dfreese
+* @acmcarther


### PR DESCRIPTION
Based on the discussion https://github.com/google/cargo-raze/discussions/314 It makes sense to me to have @acmcarther be the only code owner represented for the repo.