### PR TITLE
Removed `dummy_injecting_metadata` in favor of a templated metadata dump

### DIFF
--- a/impl/src/checks.rs
+++ b/impl/src/checks.rs
@@ -241,7 +241,7 @@ mod tests {
     settings.genmode = GenMode::Vendored;
 
     let result = check_all_vendored(
-      &dummy_modified_metadata(),
+      &dummy_modified_metadata().metadata,
       &settings,
       &PathBuf::from("/tmp/some/path"),
     );

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -130,19 +130,10 @@ mod tests {
     assert!(planned_build_res.unwrap().crate_contexts.is_empty());
   }
 
-  fn dummy_injecting_metadata() -> RazeMetadata {
-    RazeMetadata {
-      metadata: dummy_modified_metadata(),
-      cargo_workspace_root: PathBuf::from("/some/crate"),
-      lockfile: None,
-      checksums: HashMap::new(),
-    }
-  }
-
   #[test]
   fn test_plan_build_minimum_workspace_dependency() {
     let planned_build_res =
-      BuildPlannerImpl::new(dummy_injecting_metadata(), dummy_raze_settings()).plan_build(Some(
+      BuildPlannerImpl::new(dummy_modified_metadata(), dummy_raze_settings()).plan_build(Some(
         PlatformDetails::new("some_target_triple".to_owned(), Vec::new() /* attrs */),
       ));
 

--- a/impl/src/testing/metadata_templates/dummy_modified_metadata.json.template
+++ b/impl/src/testing/metadata_templates/dummy_modified_metadata.json.template
@@ -1,0 +1,134 @@
+{# Cargo.toml
+[package]
+name = "test"
+version = "0.0.1"
+
+[lib]
+path = "not_a_file.rs"
+
+# Note: this does not resolve to anything. See note below
+[dependencies]
+test_dep = "0.0.1"
+#}
+{# 
+This Metadata has been hand crafted to represent a basic metadata dump where
+the package has one additional resolved dependency.
+#}
+{
+    "packages": [
+        {
+            "name": "test",
+            "version": "0.0.1",
+            "authors": [],
+            "id": "test 0.0.1 (path+file://{{ mock_workspace }})",
+            "source": null,
+            "description": null,
+            "dependencies": [
+                {
+                    "name": "test_dep",
+                    "source": null,
+                    "req": "0.0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "license": null,
+            "license_file": null,
+            "targets": [
+                {
+                    "name": "test",
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "required-features": [],
+                    "src_path": "{{ mock_workspace }}/not_a_file.rs",
+                    "edition": "2015",
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{{ mock_workspace }}/Cargo.toml",
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": null,
+            "homepage": null,
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "publish": null
+        },
+        {
+            "name": "test_dep",
+            "version": "0.0.1",
+            "authors": [],
+            "id": "test_dep_id",
+            "source": null,
+            "description": null,
+            "dependencies": [],
+            "license": null,
+            "license_file": null,
+            "targets": [
+                {
+                    "name": "test",
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "required-features": [],
+                    "src_path": "{{ mock_workspace }}/not_a_file.rs",
+                    "edition": "2015",
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{{ mock_workspace }}/Cargo.toml",
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": null,
+            "homepage": null,
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "publish": null
+        }
+    ],
+    "workspace_members": [
+        "test 0.0.1 (path+file://{{ mock_workspace }})"
+    ],
+    "resolve": {
+        "nodes": [
+            {
+                "id": "test 0.0.1 (path+file://{{ mock_workspace }})",
+                "deps": [],
+                "dependencies": [
+                    "test_dep_id"
+                ],
+                "features": []
+            },
+            {
+                "id": "test_dep_id",
+                "deps": [],
+                "dependencies": [],
+                "features": []
+            }
+        ],
+        "root": "test 0.0.1 (path+file://{{ mock_workspace }})"
+    },
+    "workspace_root": "{{ mock_workspace }}",
+    "target_directory": "{{ mock_workspace }}/target",
+    "version": 1
+}


### PR DESCRIPTION
This is a spinoff of https://github.com/google/cargo-raze/pull/319#discussion_r543835396 where I needed to update tests using the `dummy_injecting_metadata` and opted to replace that function with a templated dump of the metadata it's generating to cleanup how many ways metadata is created for tests. Ultimately, I think this metadata can be deleted since it's quite similar to one of the pacakges included in `dummy_workspace_members_metadata.json.template`. This PR should also be looked at when actioning #310 