### PR TITLE
`default_gen_buildrs` now defaults to `true`

### DIFF
--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -334,7 +334,7 @@ fn default_raze_settings_field_output_buildfile_suffix() -> String {
 }
 
 fn default_raze_settings_field_gen_buildrs() -> bool {
-  false
+  true
 }
 
 fn default_raze_settings_registry() -> String {
@@ -533,12 +533,6 @@ impl RawRazeSettings {
   }
 
   fn print_notices_and_warnings(&self) {
-    if self.default_gen_buildrs.is_none() {
-      eprintln!(
-        "NOTICE: The default of `[*.raze.default_gen_buildrs]` will soon be set to `true`. Please \
-         explicitly set this flag to prevent a change in behavior."
-      );
-    }
 
     if self.incompatible_relative_workspace_path.unwrap_or(false) {
       eprintln!(


### PR DESCRIPTION
Closes https://github.com/bazelbuild/rules_rust/issues/490

In the common case, running `build.rs` is fine and doesn't break determinism or violate any sandboxing. For the cases that do, users can set `gen_buildrs = false` in the `CrateSetting` of the crate that has a complex `build.rs` file to avoid undesirable behavior. There are enough settings to work around most cases users would run into.