### PR TITLE
Unknown fields will now cause failures

### DIFF
--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -467,6 +467,7 @@ fn validate_settings(
  * [`RazeSettings`](crate::settings::RazeSettings)
  */
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawRazeSettings {
   #[serde(default)]
   pub workspace_path: Option<String>,


### PR DESCRIPTION
This causes raze to generate an error when unexpected fields are in the `[*.metadata.raze]` section of a `Cargo.toml`
With the following diff:
```diff
diff --git a/examples/remote/cargo_workspace/Cargo.toml b/examples/remote/cargo_workspace/Cargo.toml
index 097d943c..047f39c7 100644
--- a/examples/remote/cargo_workspace/Cargo.toml
+++ b/examples/remote/cargo_workspace/Cargo.toml
@@ -11,3 +11,4 @@ gen_workspace_prefix = "remote_cargo_workspace"
 genmode = "Remote"
 default_gen_buildrs = true
 package_aliases_dir = "cargo"
+oops = "yup"
\ No newline at end of file
```

The following error is generated when running `cargo raze --manifest-path=./examples/cargo_workspace/Cargo.toml` 
```output
Error: Raze failed with cause: "unknown field `oops`, expected one of `workspace_path`, `package_aliases_dir`, `target`, `targets`, `binary_deps`, `crates`, `gen_workspace_prefix`, `genmode`, `output_buildfile_suffix`, `default_gen_buildrs`, `registry`, `index_url`, `rust_rules_workspace_name`, `vendor_dir`"
```