### PR TITLE
Cargo raze can now be run from anywhere within a cargo workspace

### DIFF
--- a/impl/src/bin/cargo-raze.rs
+++ b/impl/src/bin/cargo-raze.rs
@@ -138,7 +138,7 @@ fn fetch_local_metadata(options: &Options) -> Result<Metadata> {
   let working_directory = if let Some(manifest_path) = &options.flag_manifest_path {
     let manifest_path = PathBuf::from(manifest_path).canonicalize()?;
     if !manifest_path.is_file() {
-      return Err(anyhow!("{} is not a file.", manifest_path.display()));
+      return Err(anyhow!("manifest path `{}` is not a file.", manifest_path.display()));
     }
     // UNWRAP: Unwrap safe due to check above.
     PathBuf::from(manifest_path.parent().unwrap())

--- a/impl/src/bin/cargo-raze.rs
+++ b/impl/src/bin/cargo-raze.rs
@@ -14,22 +14,25 @@
 
 use std::{
   collections::HashMap,
+  env,
   fs::{self, File},
   io::Write,
   path::{Path, PathBuf},
 };
 
-use anyhow::Result;
+use anyhow::{anyhow, Context, Result};
 
+use cargo_metadata::Metadata;
 use docopt::Docopt;
 
 use cargo_raze::{
   checks,
-  metadata::{CargoWorkspaceFiles, RazeMetadataFetcher},
-  planning::{BuildPlanner, BuildPlannerImpl},
+  metadata::{CargoWorkspaceFiles, MetadataFetcher, RazeMetadata, RazeMetadataFetcher},
+  planning::{BuildPlanner, BuildPlannerImpl, PlannedBuild},
+  rendering::FileOutputs,
   rendering::{bazel::BazelRenderer, BuildRenderer, RenderDetails},
   settings::RazeSettings,
-  settings::{load_settings, GenMode},
+  settings::{load_settings, GenMode, SettingsMetadataFetcher},
   util::{find_bazel_workspace_root, PlatformDetails},
 };
 
@@ -72,6 +75,28 @@ Options:
 
 fn main() -> Result<()> {
   // Parse options
+  let options = parse_options();
+
+  // Load settings
+  let (local_metadata, settings) = load_raze_settings(&options)?;
+
+  // Fetch metadata
+  let raze_metadata = fetch_raze_metadata(&options, &settings, &local_metadata)?;
+
+  // Do Planning
+  let planned_build = do_planning(&settings, &raze_metadata)?;
+
+  // Render BUILD files
+  let (render_details, bazel_file_outputs) =
+    render_files(&settings, &raze_metadata, &planned_build, &local_metadata)?;
+
+  // Write BUILD files
+  write_files(&bazel_file_outputs, &render_details, &settings, &options)?;
+
+  Ok(())
+}
+
+fn parse_options() -> Options {
   let options: Options = Docopt::new(USAGE)
     .map(|d| {
       d.version(Some(
@@ -81,16 +106,61 @@ fn main() -> Result<()> {
     .and_then(|d| d.deserialize())
     .unwrap_or_else(|e| e.exit());
 
-  // Load settings
-  let manifest_path = PathBuf::from(options
-    .flag_manifest_path
-    .unwrap_or("./Cargo.toml".to_owned())).canonicalize()?;
-  let settings = load_settings(&manifest_path, options.flag_cargo_bin_path.clone())?;
+  options
+}
+
+fn load_raze_settings(options: &Options) -> Result<(Metadata, RazeSettings)> {
+  let metadata = fetch_local_metadata(options)?;
+
+  // Parse settings with that metadata
+  let settings = match load_settings(&metadata) {
+    Ok(settings) => settings,
+    Err(err) => return Err(anyhow!(err.to_string())),
+  };
+
   if options.flag_verbose.unwrap_or(false) {
     println!("Loaded override settings: {:#?}", settings);
   }
 
-  // Fetch metadata
+  Ok((metadata, settings))
+}
+
+fn fetch_local_metadata(options: &Options) -> Result<Metadata> {
+  // Gather basic, offline metadata to parse settings from
+  let fetcher = if let Some(cargo_bin_path) = &options.flag_cargo_bin_path {
+    SettingsMetadataFetcher {
+      cargo_bin_path: PathBuf::from(cargo_bin_path),
+    }
+  } else {
+    SettingsMetadataFetcher::default()
+  };
+
+  let working_directory = if let Some(manifest_path) = &options.flag_manifest_path {
+    let manifest_path = PathBuf::from(manifest_path).canonicalize()?;
+    if !manifest_path.is_file() {
+      return Err(anyhow!("{} is not a file.", manifest_path.display()));
+    }
+    // UNWRAP: Unwrap safe due to check above.
+    PathBuf::from(manifest_path.parent().unwrap())
+  } else {
+    env::current_dir()?
+  };
+
+  fetcher
+    .fetch_metadata(&working_directory, false)
+    .with_context(|| {
+      format!(
+        "Failed to fetch metadata for {}",
+        working_directory.display()
+      )
+    })
+}
+
+fn fetch_raze_metadata(
+  options: &Options,
+  settings: &RazeSettings,
+  local_metadata: &Metadata,
+) -> Result<RazeMetadata> {
   let metadata_fetcher: RazeMetadataFetcher = match options.flag_cargo_bin_path {
     Some(ref cargo_bin_path) => RazeMetadataFetcher::new(
       cargo_bin_path,
@@ -99,41 +169,61 @@ fn main() -> Result<()> {
     ),
     None => RazeMetadataFetcher::default(),
   };
+
   let cargo_raze_working_dir =
-    find_bazel_workspace_root(&manifest_path).unwrap_or(std::env::current_dir()?);
-  let lock_path_opt = if let Some(parent) = manifest_path.parent() {
-    let lock_path = parent.join("Cargo.lock");
+    find_bazel_workspace_root(&local_metadata.workspace_root).unwrap_or(env::current_dir()?);
+
+  let toml_path = local_metadata.workspace_root.join("Cargo.toml");
+  let lock_path_opt = {
+    let lock_path = local_metadata.workspace_root.join("Cargo.lock");
     fs::metadata(&lock_path).ok().map(|_| lock_path)
-  } else {
-    None
   };
+
   let files = CargoWorkspaceFiles {
-    toml_path: manifest_path,
+    toml_path,
     lock_path_opt,
   };
+
   let remote_genmode_inputs = gather_remote_genmode_inputs(&cargo_raze_working_dir, &settings);
-  let metadata = metadata_fetcher.fetch_metadata(
+
+  let raze_metadata = metadata_fetcher.fetch_metadata(
     &files,
     remote_genmode_inputs.binary_deps,
     remote_genmode_inputs.override_lockfile,
   )?;
-  checks::check_metadata(&metadata.metadata, &settings, &cargo_raze_working_dir)?;
 
-  // Do Planning
+  checks::check_metadata(&raze_metadata.metadata, &settings, &cargo_raze_working_dir)?;
+  Ok(raze_metadata)
+}
+
+fn do_planning(
+  settings: &RazeSettings,
+  metadata: &RazeMetadata,
+) -> Result<PlannedBuild> {
   let platform_details = match &settings.target {
     Some(target) => Some(PlatformDetails::new_using_rustc(target)?),
     None => None,
   };
-  let planned_build =
-    BuildPlannerImpl::new(metadata.clone(), settings.clone()).plan_build(platform_details)?;
 
-  // Render BUILD files
+  BuildPlannerImpl::new(metadata.clone(), settings.clone())
+    .plan_build(platform_details)
+}
+
+fn render_files(
+  settings: &RazeSettings,
+  metadata: &RazeMetadata,
+  planned_build: &PlannedBuild,
+  local_metadata: &Metadata,
+) -> Result<(RenderDetails, Vec<FileOutputs>)> {
+  let cargo_raze_working_dir =
+    find_bazel_workspace_root(&local_metadata.workspace_root).unwrap_or(env::current_dir()?);
+
   let mut bazel_renderer = BazelRenderer::new();
   let render_details = RenderDetails {
-    cargo_root: metadata.cargo_workspace_root,
+    cargo_root: metadata.cargo_workspace_root.clone(),
     path_prefix: PathBuf::from(&settings.workspace_path.trim_start_matches("/")),
-    package_aliases_dir: settings.package_aliases_dir,
-    vendored_buildfile_name: settings.output_buildfile_suffix,
+    package_aliases_dir: settings.package_aliases_dir.clone(),
+    vendored_buildfile_name: settings.output_buildfile_suffix.clone(),
     bazel_root: cargo_raze_working_dir,
   };
   let bazel_file_outputs = match &settings.genmode {
@@ -145,11 +235,19 @@ fn main() -> Result<()> {
     GenMode::Unspecified => Vec::new(),
   };
 
-  // Write BUILD files
+  Ok((render_details, bazel_file_outputs))
+}
+
+fn write_files(
+  bazel_file_outputs: &Vec<FileOutputs>,
+  render_details: &RenderDetails,
+  settings: &RazeSettings,
+  options: &Options,
+) -> Result<()> {
   if &settings.genmode == &GenMode::Remote {
     let remote_dir = render_details
       .bazel_root
-      .join(render_details.path_prefix)
+      .join(&render_details.path_prefix)
       .join("remote");
     // Clean out the "remote" directory so users can easily see what build files are relevant
     if remote_dir.exists() {
@@ -161,6 +259,7 @@ fn main() -> Result<()> {
       }
     }
   }
+
   for output in bazel_file_outputs.iter() {
     if options.flag_dryrun.unwrap_or(false) {
       println!("{}:\n{}", output.path.display(), output.contents);

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -590,7 +590,7 @@ mod tests {
 
     let settings = {
       let (_temp_dir, files) = make_workspace(toml_file, None);
-      crate::settings::load_settings(&files.toml_path, None).unwrap()
+      crate::settings::load_settings_from_manifest(&files.toml_path, None).unwrap()
     };
 
     let planner = BuildPlannerImpl::new(


### PR DESCRIPTION
This allows `cargo raze` to be run anywhere within a cargo workspace. This means when iterating on a target, one can simply call `cargo raze && bazel build //my:target` from anywhere within a cargo workspace to generate new BUILD files and have them immediately used in the next run of Bazel.

To accomplish this, a restructuring was done to the `cargo-raze.rs` file. An overview of what the binary is doing can more easily be seen in the `main` function where the logic that was all once in that single function has been split into smaller functions to group the steps `cargo-raze` does to generate BUILD files.

`settings::load_settings_from_workspace` was add to be able to fetch metadata from an arbitrary location in a cargo workspace. This will use the new `SettingsMetadataFetcher` struct to gather metadata from the current cargo workspace without requiring any network connectivity or gathering any information about non workspace member dependencies.

`git status` shows:
```output
On branch raze-anywhere
Your branch is ahead of 'origin/raze-anywhere' by 1 commit.
  (use "git push" to publish your local commits)

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	deleted:    cargo/remote/BUILD.MacTypes-sys-1.3.0.bazel
	deleted:    cargo/remote/BUILD.aho-corasick-0.6.10.bazel
	deleted:    cargo/remote/BUILD.arrayvec-0.3.25.bazel
	deleted:    cargo/remote/BUILD.atom-0.3.5.bazel
	deleted:    cargo/remote/BUILD.autocfg-1.0.1.bazel
	deleted:    cargo/remote/BUILD.bazel
	deleted:    cargo/remote/BUILD.cc-1.0.60.bazel
	...
    ...
```

And when I run `cargo raze && bazel build ...` from within `examples/remote/complicated_cargo_library` I can successfully generate build files and build the target
```output
WARNING: The default of `[*.raze.rust_rules_workspace_name]` will soon be set to `"rules_rust"`. Please explicitly set this flag to prevent a change in behavior or upgrade your code to use the latest version of `rules_rust` and change references of `io_bazel_rules_rust` to `rules_rust` in your project.
Starting local Bazel server and connecting to it...
INFO: Invocation ID: bff80552-f156-42e6-a6f2-0b04f19a3de7
INFO: Analyzed target //remote/complicated_cargo_library:complicated_cargo_library (76 packages loaded, 1270 targets configured).
INFO: Found 1 target...
Target //remote/complicated_cargo_library:complicated_cargo_library up-to-date:
  bazel-bin/remote/complicated_cargo_library/complicated_cargo_library
INFO: Elapsed time: 9.105s, Critical Path: 1.59s
INFO: 12 processes: 5 internal, 7 darwin-sandbox.
INFO: Build completed successfully, 12 total actions
```