### PR TITLE
Fixed missing use of `rust_rules_workspace_name` setting in templates

### DIFF
--- a/impl/src/bin/cargo-raze.rs
+++ b/impl/src/bin/cargo-raze.rs
@@ -135,6 +135,7 @@ fn main() -> Result<()> {
     package_aliases_dir: settings.package_aliases_dir,
     vendored_buildfile_name: settings.output_buildfile_suffix,
     bazel_root: cargo_raze_working_dir,
+    rust_rules_workspace_name: settings.rust_rules_workspace_name,
     experimental_api: settings.experimental_api,
   };
   let bazel_file_outputs = match &settings.genmode {

--- a/impl/src/rendering.rs
+++ b/impl/src/rendering.rs
@@ -48,5 +48,6 @@ pub struct RenderDetails {
   pub package_aliases_dir: String,
   pub vendored_buildfile_name: String,
   pub bazel_root: PathBuf,
+  pub rust_rules_workspace_name: String,
   pub experimental_api: bool,
 }

--- a/impl/src/rendering/templates/crate.BUILD.template
+++ b/impl/src/rendering/templates/crate.BUILD.template
@@ -7,7 +7,7 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 
 # buildifier: disable=load
 load(
-    "@io_bazel_rules_rust//rust:rust.bzl",
+    "@{{ rust_rules_workspace_name }}//rust:rust.bzl",
     "rust_binary",
     "rust_library",
     "rust_test",

--- a/impl/src/rendering/templates/partials/build_script.template
+++ b/impl/src/rendering/templates/partials/build_script.template
@@ -1,6 +1,6 @@
 # buildifier: disable=load-on-top
 load(
-    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "@{{ rust_rules_workspace_name }}//cargo:cargo_build_script.bzl",
     "cargo_build_script",
 )
 


### PR DESCRIPTION
In working on https://github.com/bazelbuild/rules_rust/pull/500 I realized that not all the uses of the `rules_rust` workspace name were being templetized. This PR fixes this such that the `load` statements also use `rust_rules_workspace_name`. (Sorry about missing this).