### PR TITLE
Changed comment block style to be compatible with rustdoc

### DIFF
--- a/impl/src/bin/cargo-raze.rs
+++ b/impl/src/bin/cargo-raze.rs
@@ -196,17 +196,13 @@ fn fetch_raze_metadata(
   Ok(raze_metadata)
 }
 
-fn do_planning(
-  settings: &RazeSettings,
-  metadata: &RazeMetadata,
-) -> Result<PlannedBuild> {
+fn do_planning(settings: &RazeSettings, metadata: &RazeMetadata) -> Result<PlannedBuild> {
   let platform_details = match &settings.target {
     Some(target) => Some(PlatformDetails::new_using_rustc(target)?),
     None => None,
   };
 
-  BuildPlannerImpl::new(metadata.clone(), settings.clone())
-    .plan_build(platform_details)
+  BuildPlannerImpl::new(metadata.clone(), settings.clone()).plan_build(platform_details)
 }
 
 fn render_files(
@@ -282,7 +278,7 @@ fn write_files(
   Ok(())
 }
 
-/** Writes rendered files to filesystem. */
+/// Writes rendered files to filesystem.
 fn write_to_file(path: &Path, contents: &str, verbose: bool) -> Result<()> {
   File::create(&path).and_then(|mut f| f.write_all(contents.as_bytes()))?;
   if verbose {
@@ -297,7 +293,7 @@ struct RemoteGenModeInputs<'settings> {
   pub binary_deps: Option<&'settings HashMap<String, cargo_toml::Dependency>>,
 }
 
-/** Gathers inputs for the `genmode = "Remote"` builds. */
+/// Gathers inputs for the `genmode = "Remote"` builds.
 fn gather_remote_genmode_inputs<'settings>(
   bazel_root: &Path,
   settings: &'settings RazeSettings,

--- a/impl/src/checks.rs
+++ b/impl/src/checks.rs
@@ -35,7 +35,7 @@ use cargo_metadata::{Metadata, Package, PackageId};
 const MAX_DISPLAYED_MISSING_VENDORED_CRATES: usize = 5;
 const MAX_DISPLAYED_MISSING_RESOLVE_PACKAGES: usize = 5;
 
-/** Ensure that the given Metadata is valid and ready to use for planning. */
+/// Ensure that the given Metadata is valid and ready to use for planning.
 pub fn check_metadata(
   metadata: &Metadata,
   settings: &RazeSettings,
@@ -54,7 +54,7 @@ pub fn check_metadata(
   Ok(())
 }
 
-/** Verifies that all provided packages are vendored (in settings.vendor_dir relative to CWD) */
+/// Verifies that all provided packages are vendored (in settings.vendor_dir relative to CWD)
 fn check_all_vendored(
   metadata: &Metadata,
   settings: &RazeSettings,
@@ -116,7 +116,7 @@ fn vendor_path(bazel_workspace_root: &Path, workspace_path: &str, vendor_dir: &s
     .join(vendor_dir)
 }
 
-/** Returns the packages expected path during current execution. */
+/// Returns the packages expected path during current execution.
 fn expected_vendored_path(
   package: &Package,
   bazel_workspace_root: &Path,
@@ -124,10 +124,7 @@ fn expected_vendored_path(
   vendor_dir: &str,
 ) -> String {
   vendor_path(bazel_workspace_root, workspace_path, vendor_dir)
-    .join(package_ident(
-      &package.name,
-      &package.version.to_string(),
-    ))
+    .join(package_ident(&package.name, &package.version.to_string()))
     .display()
     .to_string()
 }

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -18,13 +18,11 @@ use crate::settings::CrateSettings;
 use semver::Version;
 use serde::Serialize;
 
-/** A struct containing information about a crate's dependency that's buildable in Bazel
- *
- * Note: BUILDifier-compliant BUILD file generation depends on correct sorting of collections
- * of this struct by `buildable_target`. Do not add fields preceeding that field.
- */
+/// A struct containing information about a crate's dependency that's buildable in Bazel
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct BuildableDependency {
+  // Note: Buildifier-compliant BUILD file generation depends on correct sorting of collections
+  // of this struct by `buildable_target`. Do not add fields preceeding this field.
   pub buildable_target: String,
   pub name: String,
   pub version: Version,
@@ -42,7 +40,7 @@ pub struct BuildableTarget {
   pub kind: String,
   pub name: String,
 
-  /** The path in Bazel's format (i.e. with forward slashes) to the target's entry point. */
+  /// The path in Bazel's format (i.e. with forward slashes) to the target's entry point.
   pub path: String,
   pub edition: String,
 }

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -14,7 +14,7 @@
 
 use std::fmt;
 
-pub const PLEASE_FILE_A_BUG: &str =
+pub(crate) const PLEASE_FILE_A_BUG: &str =
   "Please file an issue at github.com/google/cargo-raze with details.";
 
 #[derive(Debug)]

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -29,7 +29,7 @@ use crate::{
 use crate_catalog::CrateCatalog;
 use subplanners::WorkspaceSubplanner;
 
-/** A ready-to-be-rendered build, containing renderable context for each crate. */
+/// A ready-to-be-rendered build, containing renderable context for each crate.
 #[derive(Debug)]
 pub struct PlannedBuild {
   pub workspace_context: WorkspaceContext,
@@ -37,23 +37,21 @@ pub struct PlannedBuild {
   pub lockfile: Option<Lockfile>,
 }
 
-/** An entity that can produce an organized, planned build ready to be rendered. */
+/// An entity that can produce an organized, planned build ready to be rendered.
 pub trait BuildPlanner {
-  /**
-   * A function that returns a completely planned build using internally generated metadata, along
-   * with settings, platform specifications, and critical file locations.
-   */
+  /// A function that returns a completely planned build using internally generated metadata, along
+  /// with settings, platform specifications, and critical file locations.
   fn plan_build(&self, platform_details: Option<PlatformDetails>) -> Result<PlannedBuild>;
 }
 
-/** The default implementation of a `BuildPlanner`. */
+/// The default implementation of a `BuildPlanner`.
 pub struct BuildPlannerImpl {
   metadata: RazeMetadata,
   settings: RazeSettings,
 }
 
 impl BuildPlanner for BuildPlannerImpl {
-  /** Retrieves metadata for local workspace and produces a build plan. */
+  /// Retrieves metadata for local workspace and produces a build plan.
   fn plan_build(&self, platform_details: Option<PlatformDetails>) -> Result<PlannedBuild> {
     // Create one combined metadata object which includes all dependencies and binaries
     let crate_catalog = CrateCatalog::new(&self.metadata.metadata)?;

--- a/impl/src/planning/crate_catalog.rs
+++ b/impl/src/planning/crate_catalog.rs
@@ -27,7 +27,7 @@ use crate::{
   util::package_ident,
 };
 
-/** An entry in the Crate catalog for a single crate. */
+/// An entry in the Crate catalog for a single crate.
 pub struct CrateCatalogEntry {
   // The package metadata for the crate
   pub package: Package,
@@ -62,23 +62,23 @@ impl CrateCatalogEntry {
     }
   }
 
-  /** Yields the name of the default target for this crate (sanitized). */
+  /// Yields the name of the default target for this crate (sanitized).
   #[allow(dead_code)]
   pub fn default_build_target_name(&self) -> &str {
     &self.sanitized_name
   }
 
-  /** Returns a reference to the contained package. */
+  /// Returns a reference to the contained package.
   pub fn package(&self) -> &Package {
     &self.package
   }
 
-  /** Returns whether or not this is a member of the root workspace. */
+  /// Returns whether or not this is a member of the root workspace.
   pub fn is_workspace_crate(&self) -> bool {
     self.is_workspace_crate
   }
 
-  /** Yields the expected location of the build file (relative to execution path). */
+  /// Yields the expected location of the build file (relative to execution path).
   pub fn local_build_path(&self, settings: &RazeSettings) -> Result<String> {
     match settings.genmode {
       GenMode::Remote => Ok(format!("remote/BUILD.{}.bazel", &self.package_ident,)),
@@ -93,7 +93,7 @@ impl CrateCatalogEntry {
     }
   }
 
-  /** Yields the precise path to this dependency for the provided settings. */
+  /// Yields the precise path to this dependency for the provided settings.
   pub fn workspace_path(&self, settings: &RazeSettings) -> Result<String> {
     match settings.genmode {
       GenMode::Remote => Ok(format!(
@@ -120,7 +120,7 @@ impl CrateCatalogEntry {
     }
   }
 
-  /** Emits a complete path to this dependency and default target using the given settings. */
+  /// Emits a complete path to this dependency and default target using the given settings.
   pub fn workspace_path_and_default_target(&self, settings: &RazeSettings) -> Result<String> {
     match settings.genmode {
       GenMode::Remote => Ok(format!(
@@ -151,7 +151,7 @@ impl CrateCatalogEntry {
   }
 }
 
-/** An intermediate structure that contains details about all crates in the workspace. */
+/// An intermediate structure that contains details about all crates in the workspace.
 pub struct CrateCatalog {
   pub metadata: Metadata,
   pub entries: Vec<CrateCatalogEntry>,
@@ -159,7 +159,7 @@ pub struct CrateCatalog {
 }
 
 impl CrateCatalog {
-  /** Produces a CrateCatalog using the package entries from a metadata blob.*/
+  /// Produces a CrateCatalog using the package entries from a metadata blob.
   pub fn new(metadata: &Metadata) -> Result<Self> {
     let resolve = metadata
       .resolve
@@ -208,7 +208,7 @@ impl CrateCatalog {
     })
   }
 
-  /** Finds and returns the catalog entry with the given package id if present. */
+  /// Finds and returns the catalog entry with the given package id if present.
   pub fn entry_for_package_id(&self, package_id: &PackageId) -> Option<&CrateCatalogEntry> {
     self
       .package_id_to_entries_idx

--- a/impl/src/planning/license.rs
+++ b/impl/src/planning/license.rs
@@ -19,11 +19,8 @@ use spdx::{
   Expression,
 };
 
-/**
- * The list of Bazel-known license types
- *
- * KEEP ORDERED: The order dictates the preference.
- */
+// KEEP ORDERED: The order dictates the preference.
+/// The list of Bazel-known license types
 #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Hash, Clone)]
 pub enum BazelLicenseType {
   Unencumbered,
@@ -47,9 +44,7 @@ impl BazelLicenseType {
   }
 }
 
-/**
- * A data structure for calculating a crate's license restrictions
- */
+/// A data structure for calculating a crate's license restrictions
 #[derive(Debug)]
 struct BazelSpdxLicense {
   // The name of the license this struct represents
@@ -81,11 +76,9 @@ impl BazelSpdxLicense {
     format!("{} {} {}", expr_str1, operator, expr_str2)
   }
 
-  /**
-   * Takes a BazelSpdxLicense as an argument, and returns a new BazelSpdxLicense based on the more
-   * restrictive license. If both licenses are equally restrictive, self's license is used. The
-   * new BazelSpdxLicense's expression will represent the "AND" of the two expressions.
-   */
+  /// Takes a BazelSpdxLicense as an argument, and returns a new BazelSpdxLicense based on the more
+  /// restrictive license. If both licenses are equally restrictive, self's license is used. The
+  /// new BazelSpdxLicense's expression will represent the "AND" of the two expressions.
   pub fn and(&self, other_license: Self) -> Self {
     let combined_expr = Self::combine_license_expr(self, &other_license, "AND");
     if self.license >= other_license.license {
@@ -103,11 +96,9 @@ impl BazelSpdxLicense {
     }
   }
 
-  /**
-   * Takes a BazelSpdxLicense as an argument, and returns a new BazelSpdxLicense based on the less
-   * restrictive license. If both licenses are equally restrictive, self's license is used. The
-   * new BazelSpdxLicense's expression will represent the "OR" of the two expressions.
-   */
+  /// Takes a BazelSpdxLicense as an argument, and returns a new BazelSpdxLicense based on the less
+  /// restrictive license. If both licenses are equally restrictive, self's license is used. The
+  /// new BazelSpdxLicense's expression will represent the "OR" of the two expressions.
   pub fn or(&self, other_license: Self) -> Self {
     let combined_expr = Self::combine_license_expr(&self, &other_license, "OR");
     if self.license <= other_license.license {
@@ -126,7 +117,7 @@ impl BazelSpdxLicense {
   }
 }
 
-/** Breaks apart a cargo license string and yields the available license types. */
+/// Breaks apart a cargo license string and yields the available license types.
 pub fn get_license_from_str(cargo_license_str: &str) -> LicenseData {
   if cargo_license_str.len() == 0 {
     return LicenseData::default();

--- a/impl/src/planning/subplanners.rs
+++ b/impl/src/planning/subplanners.rs
@@ -43,7 +43,7 @@ use super::{
   PlannedBuild,
 };
 
-/** A set of named dependencies (without version) derived from a package manifest. */
+/// A set of named dependencies (without version) derived from a package manifest.
 struct DependencyNames {
   // Dependencies that are required for all buildable targets of this crate
   normal_dep_names: Vec<String>,
@@ -56,7 +56,7 @@ struct DependencyNames {
 }
 
 // TODO(acmcarther): Remove this struct -- move it into CrateContext.
-/** A set of dependencies that a crate has broken down by type. */
+/// A set of dependencies that a crate has broken down by type.
 struct DependencySet {
   // Dependencies that are required for all buildable targets of this crate
   normal_deps: Vec<BuildableDependency>,
@@ -71,13 +71,13 @@ struct DependencySet {
   aliased_deps: Vec<DependencyAlias>,
 }
 
-/** A set of dependencies that a crate has for a specific target/cfg */
+/// A set of dependencies that a crate has for a specific target/cfg
 struct TargetedDependencySet {
   target: String,
   dependencies: DependencySet,
 }
 
-/** An internal working planner for generating context for an individual crate. */
+/// An internal working planner for generating context for an individual crate.
 struct CrateSubplanner<'planner> {
   // Workspace-Wide details
   settings: &'planner RazeSettings,
@@ -91,7 +91,7 @@ struct CrateSubplanner<'planner> {
   sha256: &'planner Option<String>,
 }
 
-/** An internal working planner for generating context for a whole workspace. */
+/// An internal working planner for generating context for a whole workspace.
 pub struct WorkspaceSubplanner<'planner> {
   pub(super) settings: &'planner RazeSettings,
   pub(super) platform_details: &'planner Option<util::PlatformDetails>,
@@ -100,7 +100,7 @@ pub struct WorkspaceSubplanner<'planner> {
 }
 
 impl<'planner> WorkspaceSubplanner<'planner> {
-  /** Produces a planned build using internal state. */
+  /// Produces a planned build using internal state.
   pub fn produce_planned_build(&self) -> Result<PlannedBuild> {
     // Produce planned build
     let crate_contexts = self.produce_crate_contexts()?;
@@ -112,7 +112,7 @@ impl<'planner> WorkspaceSubplanner<'planner> {
     })
   }
 
-  /** Constructs a workspace context from settings. */
+  /// Constructs a workspace context from settings.
   fn produce_workspace_context(&self) -> WorkspaceContext {
     // Gather the workspace member paths for all workspace members
     let workspace_members = self
@@ -224,7 +224,7 @@ impl<'planner> WorkspaceSubplanner<'planner> {
       .map_err(|e| e.into())
   }
 
-  /** Produces a crate context for each declared crate and dependency. */
+  /// Produces a crate context for each declared crate and dependency.
   fn produce_crate_contexts(&self) -> Result<Vec<CrateContext>> {
     self
       .crate_catalog
@@ -241,7 +241,7 @@ impl<'planner> WorkspaceSubplanner<'planner> {
 }
 
 impl<'planner> CrateSubplanner<'planner> {
-  /** Builds a crate context from internal state. */
+  /// Builds a crate context from internal state.
   fn produce_context(&self, cargo_workspace_root: &Path) -> Result<CrateContext> {
     let (
       DependencySet {
@@ -422,7 +422,7 @@ impl<'planner> CrateSubplanner<'planner> {
     Ok(context)
   }
 
-  /** Generates license data from internal crate details. */
+  /// Generates license data from internal crate details.
   fn produce_license(&self) -> LicenseData {
     let licenses_str = self
       .crate_catalog_entry
@@ -544,7 +544,7 @@ impl<'planner> CrateSubplanner<'planner> {
     Ok(dep_set)
   }
 
-  /** Generates the set of dependencies for the contained crate. */
+  /// Generates the set of dependencies for the contained crate.
   fn produce_deps(&self) -> Result<(DependencySet, Vec<TargetedDependencySet>)> {
     let (default_deps, targeted_deps) = self.identify_named_deps()?;
 
@@ -559,7 +559,7 @@ impl<'planner> CrateSubplanner<'planner> {
     Ok((self._produce_deps(&default_deps)?, targeted_set))
   }
 
-  /** Yields the list of dependencies as described by the manifest (without version). */
+  /// Yields the list of dependencies as described by the manifest (without version).
   fn identify_named_deps(&self) -> Result<(DependencyNames, HashMap<String, DependencyNames>)> {
     // Resolve dependencies into types
     let mut default_dep_names = DependencyNames {
@@ -651,7 +651,7 @@ impl<'planner> CrateSubplanner<'planner> {
     Ok((default_dep_names, targeted_dep_names))
   }
 
-  /** Generates source details for internal crate. */
+  /// Generates source details for internal crate.
   fn produce_source_details(&self, package: &Package, package_root: &Path) -> SourceDetails {
     SourceDetails {
       git_data: self.source_id.as_ref().filter(|id| id.is_git()).map(|id| {
@@ -671,12 +671,10 @@ impl<'planner> CrateSubplanner<'planner> {
     }
   }
 
-  /**
-   * Extracts the (one and only) build script target from the provided set of build targets.
-   *
-   * This function mutates the provided list of build arguments. It removes the first (and usually,
-   * only) found build script target.
-   */
+  /// Extracts the (one and only) build script target from the provided set of build targets.
+  ///
+  /// This function mutates the provided list of build arguments. It removes the first (and usually,
+  /// only) found build script target.
   fn take_build_script_target(
     &self,
     all_targets: &mut Vec<BuildableTarget>,
@@ -695,12 +693,9 @@ impl<'planner> CrateSubplanner<'planner> {
       .map(|idx| all_targets.remove(idx))
   }
 
-  /**
-   * Produces the complete set of build targets specified by this crate.
-   *
-   * This function may access the file system. See #find_package_root_for_manifest for more
-   * details.
-   */
+  /// Produces the complete set of build targets specified by this crate.
+  /// This function may access the file system. See #find_package_root_for_manifest for more
+  /// details.
   fn produce_targets(&self, package_root_path: &Path) -> Result<Vec<BuildableTarget>> {
     let mut targets = Vec::new();
     let package = self.crate_catalog_entry.package();
@@ -740,14 +735,11 @@ impl<'planner> CrateSubplanner<'planner> {
     Ok(targets)
   }
 
-  /**
-   * Finds the root of a contained git package.
-   *
-   * This function needs to access the file system if the dependency is a git dependency in order
-   * to find the true filesystem root of the dependency. The root cause is that git dependencies
-   * often aren't solely the crate of interest, but rather a repository that contains the crate of
-   * interest among others.
-   */
+  /// Finds the root of a contained git package.
+  /// This function needs to access the file system if the dependency is a git dependency in order
+  /// to find the true filesystem root of the dependency. The root cause is that git dependencies
+  /// often aren't solely the crate of interest, but rather a repository that contains the crate of
+  /// interest among others.
   fn find_package_root_for_manifest(&self, manifest_path: &PathBuf) -> Result<PathBuf> {
     let has_git_repo_root = {
       let is_git = self.source_id.as_ref().map_or(false, SourceId::is_git);

--- a/impl/src/rendering.rs
+++ b/impl/src/rendering.rs
@@ -18,10 +18,6 @@ use crate::planning::PlannedBuild;
 use anyhow::Result;
 use std::path::PathBuf;
 
-/**
- * An object that can convert a prepared build plan into a series of files for a Bazel-like build
- * system.
- */
 pub trait BuildRenderer {
   fn render_planned_build(
     &mut self,

--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -30,116 +30,90 @@ use std::{
 
 pub type CrateSettingsPerVersion = HashMap<VersionReq, CrateSettings>;
 
-/** The configuration settings for `cargo-raze`, included in a projects Cargo metadata */
+/// The configuration settings for `cargo-raze`, included in a projects Cargo metadata
 #[derive(Debug, Clone, Deserialize)]
 pub struct RazeSettings {
-  /**
-   * The path to the Cargo.toml working directory.
-   */
+  /// The path to the Cargo.toml working directory.
   pub workspace_path: String,
 
-  /**
-   * The relative path within each workspace member directory where aliases the member's dependencies should be rendered.
-   *
-   * By default, a new directory will be created next to the `Cargo.toml` file named `cargo` for users to refer to them
-   * as. For example, the toml file `//my/package:Cargo.toml`  will have aliases rendered as something like
-   * `//my/package/cargo:dependency`. Note that setting this value to `"."` will cause the BUILD file in the same package
-   * as the Cargo.toml file to be overwritten.
-   */
+  /// The relative path within each workspace member directory where aliases the member's dependencies should be rendered.
+  ///
+  /// By default, a new directory will be created next to the `Cargo.toml` file named `cargo` for users to refer to them
+  /// as. For example, the toml file `//my/package:Cargo.toml`  will have aliases rendered as something like
+  /// `//my/package/cargo:dependency`. Note that setting this value to `"."` will cause the BUILD file in the same package
+  /// as the Cargo.toml file to be overwritten.
   #[serde(default = "default_package_aliases_dir")]
   pub package_aliases_dir: String,
-
-  /**
-   * If true, package alises will be rendered based on the functionality described by `package_aliases_dir`. 
-   */
+  
+  /// If true, package alises will be rendered based on the functionality described by `package_aliases_dir`.
   #[serde(default = "default_render_package_aliases")]
   pub render_package_aliases: bool,
 
-  /**
-   * The platform target to generate BUILD rules for.
-   *
-   * This comes in the form of a "triple", such as "x86_64-unknown-linux-gnu"
-   */
+  /// The platform target to generate BUILD rules for.
+  ///
+  /// This comes in the form of a "triple", such as "x86_64-unknown-linux-gnu"
   #[serde(default)]
   pub target: Option<String>,
 
-  /**
-   * A list of targets to generate BUILD rules for.
-   *
-   * Each item comes in the form of a "triple", such as "x86_64-unknown-linux-gnu"
-   */
+  /// A list of targets to generate BUILD rules for.
+  ///
+  /// Each item comes in the form of a "triple", such as "x86_64-unknown-linux-gnu"
   #[serde(default)]
   pub targets: Option<Vec<String>>,
 
-  /**
-   * A list of binary dependencies.
-   */
+  /// A list of binary dependencies.
   #[serde(default)]
   pub binary_deps: HashMap<String, cargo_toml::Dependency>,
 
-  /** Any crate-specific configuration. See CrateSettings for details. */
+  /// Any crate-specific configuration. See CrateSettings for details.
   #[serde(default)]
   pub crates: HashMap<String, CrateSettingsPerVersion>,
 
-  /**
-   * Prefix for generated Bazel workspaces (from workspace_rules)
-   *
-   * This is only useful with remote genmode. It prefixes the names of the workspaces for
-   * dependencies (@PREFIX_crateName_crateVersion) as well as the name of the repository function
-   * generated in crates.bzl (PREFIX_fetch_remote_crates()).
-   *
-   * TODO(acmcarther): Does this have a non-bazel analogue?
-   */
+  // TODO(acmcarther): Does this have a non-bazel analogue?
+  /// Prefix for generated Bazel workspaces (from workspace_rules)
+  ///
+  /// This is only useful with remote genmode. It prefixes the names of the workspaces for
+  /// dependencies (@PREFIX_crateName_crateVersion) as well as the name of the repository function
+  /// generated in crates.bzl (PREFIX_fetch_remote_crates()).
   #[serde(default = "default_raze_settings_field_gen_workspace_prefix")]
   pub gen_workspace_prefix: String,
 
-  /** How to generate the dependencies. See GenMode for details. */
+  /// How to generate the dependencies. See GenMode for details.
   #[serde(default = "default_raze_settings_field_genmode")]
   pub genmode: GenMode,
 
-  /**
-   * The name of the output BUILD files when `genmode == "Vendored"`
-   * Default: BUILD.bazel
-   */
+  /// The name of the output BUILD files when `genmode == "Vendored"`
+  ///
+  /// Default: BUILD.bazel
   #[serde(default = "default_raze_settings_field_output_buildfile_suffix")]
   pub output_buildfile_suffix: String,
 
-  /**
-   * Default value for per-crate gen_buildrs setting if it's not explicitly for a crate.
-   *
-   * See that setting for more information.
-   */
+  /// Default value for per-crate gen_buildrs setting if it's not explicitly for a crate.
+  ///
+  /// See [crate::settings::CrateSettings::gen_buildrs] for more information.
   #[serde(default = "default_raze_settings_field_gen_buildrs")]
   pub default_gen_buildrs: bool,
 
-  /**
-   * The default crates registry.
-   *
-   * The patterns `{crate}` and `{version}` will be used to fill
-   * in the package's name (eg: rand) and version (eg: 0.7.1).
-   * See https://doc.rust-lang.org/cargo/reference/registries.html#index-format
-   */
+  /// The default crates registry.
+  ///
+  /// The patterns `{crate}` and `{version}` will be used to fill
+  /// in the package's name (eg: rand) and version (eg: 0.7.1).
+  /// See https://doc.rust-lang.org/cargo/reference/registries.html#index-format
   #[serde(default = "default_raze_settings_registry")]
   pub registry: String,
 
-  /**
-   * The index url to use for Binary dependencies
-   */
+  /// The index url to use for Binary dependencies
   #[serde(default = "default_raze_settings_index_url")]
   pub index_url: String,
 
-  /**
-   * The name of the [rules_rust](https://github.com/bazelbuild/rules_rust) repository
-   * used in the generated workspace.
-   */
+  /// The name of the [rules_rust](https://github.com/bazelbuild/rules_rust) repository
+  /// used in the generated workspace.
   #[serde(default = "default_raze_settings_rust_rules_workspace_name")]
   pub rust_rules_workspace_name: String,
 
-  /**
-   * The expected path relative to the `Cargo.toml` file where vendored sources can
-   * be found. This should match the path passed to the `cargo vendor` command. eg:
-   * `cargo vendor -q --versioned-dirs "cargo/vendor"
-   */
+  /// The expected path relative to the `Cargo.toml` file where vendored sources can
+  /// be found. This should match the path passed to the `cargo vendor` command. eg:
+  /// `cargo vendor -q --versioned-dirs "cargo/vendor"
   #[serde(default = "default_raze_settings_vendor_dir")]
   pub vendor_dir: String,
 
@@ -151,154 +125,122 @@ pub struct RazeSettings {
   pub experimental_api: bool,
 }
 
-/** Override settings for individual crates (as part of `RazeSettings`). */
+/// Override settings for individual crates (as part of `RazeSettings`).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CrateSettings {
-  /**
-   * Dependencies to be added to a crate.
-   *
-   * Importantly, the format of dependency references depends on the genmode.
-   * Remote: @{gen_workspace_prefix}__{dep_name}__{dep_version_sanitized}/:{dep_name}
-   * Vendored: //{workspace_path}/vendor/{dep_name}-{dep_version}:{dep_name}
-   *
-   * In addition, the added deps must be accessible from a remote workspace under Remote GenMode.
-   * Usually, this means they _also_ need to be remote, but a "local" build path prefixed with
-   * "@", in the form "@//something_local" may work.
-   */
+  /// Dependencies to be added to a crate.
+  ///
+  /// Importantly, the format of dependency references depends on the genmode.
+  /// Remote: @{gen_workspace_prefix}__{dep_name}__{dep_version_sanitized}/:{dep_name}
+  /// Vendored: //{workspace_path}/vendor/{dep_name}-{dep_version}:{dep_name}
+  ///
+  /// In addition, the added deps must be accessible from a remote workspace under Remote GenMode.
+  /// Usually, this means they _also_ need to be remote, but a "local" build path prefixed with
+  /// "@", in the form "@//something_local" may work.
   #[serde(default)]
   pub additional_deps: Vec<String>,
 
-  /**
-   * Dependencies to be removed from a crate, in the form "{dep-name}-{dep-version}"
-   *
-   * This is applied during Cargo analysis, so it uses Cargo-style labeling
-   */
+  /// Dependencies to be removed from a crate, in the form "{dep-name}-{dep-version}"
+  ///
+  /// This is applied during Cargo analysis, so it uses Cargo-style labeling
   #[serde(default)]
   pub skipped_deps: Vec<String>,
 
-  /**
-   * Library targets that should be aliased in the root BUILD file.
-   *
-   * This is useful to facilitate using binary utility crates, such as bindgen, as part of genrules.
-   */
+  /// Library targets that should be aliased in the root BUILD file.
+  ///
+  /// This is useful to facilitate using binary utility crates, such as bindgen, as part of genrules.
   #[serde(default)]
   pub extra_aliased_targets: Vec<String>,
 
-  /** Flags to be added to the crate compilation process, in the form "--flag". */
+  /// Flags to be added to the crate compilation process, in the form "--flag".
   #[serde(default)]
   pub additional_flags: Vec<String>,
 
-  /** Environment variables to be added to the crate compilation process. */
+  /// Environment variables to be added to the crate compilation process.
   #[serde(default)]
   pub additional_env: HashMap<String, String>,
 
-  /**
-   * Whether or not to generate the build script that goes with this crate.
-   *
-   * Many build scripts will not function, as they will still be built hermetically. However, build
-   * scripts that merely generate files into OUT_DIR may be fully functional.
-   */
+  /// Whether or not to generate the build script that goes with this crate.
+  ///
+  /// Many build scripts will not function, as they will still be built hermetically. However, build
+  /// scripts that merely generate files into OUT_DIR may be fully functional.
   #[serde(default = "default_crate_settings_field_gen_buildrs")]
   pub gen_buildrs: Option<bool>,
 
-  /**
-   * The verbatim `data` clause to be included for the generated build targets.
-   *
-   * N.B. Build scripts are always provided all crate files for their `data` attr.
-   */
+  // N.B. Build scripts are always provided all crate files for their `data` attr.
+  /// The verbatim `data` clause to be included for the generated build targets.
   #[serde(default = "default_crate_settings_field_data_attr")]
   pub data_attr: Option<String>,
 
-  /**
-   * The verbatim `compile_data` clause to be included for the generated build targets.
-   */
+  /// The verbatim `compile_data` clause to be included for the generated build targets.
   #[serde(default)]
   pub compile_data_attr: Option<String>,
 
-  /**
-   * Additional environment variables to add when running the build script.
-   */
+  /// Additional environment variables to add when running the build script.
   #[serde(default)]
   pub buildrs_additional_environment_variables: HashMap<String, String>,
 
-  /**
-   * The arguments given to the patch tool.
-   *
-   * Defaults to `-p0`, however `-p1` will usually be needed for patches generated by git.
-   *
-   * If multiple `-p` arguments are specified, the last one will take effect.
-   * If arguments other than `-p` are specified, Bazel will fall back to use patch command line
-   * tool instead of the Bazel-native patch implementation.
-   *
-   * When falling back to `patch` command line tool and `patch_tool` attribute is not specified,
-   * `patch` will be used.
-   */
+  /// The arguments given to the patch tool.
+  ///
+  /// Defaults to `-p0`, however `-p1` will usually be needed for patches generated by git.
+  ///
+  /// If multiple `-p` arguments are specified, the last one will take effect.
+  /// If arguments other than `-p` are specified, Bazel will fall back to use patch command line
+  /// tool instead of the Bazel-native patch implementation.
+  ///
+  /// When falling back to `patch` command line tool and `patch_tool` attribute is not specified,
+  /// `patch` will be used.
   #[serde(default)]
   pub patch_args: Vec<String>,
 
-  /**
-   * Sequence of Bash commands to be applied on Linux/Macos after patches are applied.
-   */
+  /// Sequence of Bash commands to be applied on Linux/Macos after patches are applied.
   #[serde(default)]
   pub patch_cmds: Vec<String>,
 
-  /**
-   * Sequence of Powershell commands to be applied on Windows after patches are applied.
-   *
-   * If this attribute is not set, patch_cmds will be executed on Windows, which requires Bash
-   * binary to exist.
-   */
+  /// Sequence of Powershell commands to be applied on Windows after patches are applied.
+  ///
+  /// If this attribute is not set, patch_cmds will be executed on Windows, which requires Bash
+  /// binary to exist.
   #[serde(default)]
   pub patch_cmds_win: Vec<String>,
 
-  /**
-   * The `patch(1)` utility to use.
-   *
-   * If this is specified, Bazel will use the specifed patch tool instead of the Bazel-native patch
-   * implementation.
-   */
+  /// The `patch(1)` utility to use.
+  ///
+  /// If this is specified, Bazel will use the specifed patch tool instead of the Bazel-native patch
+  /// implementation.
   #[serde(default)]
   pub patch_tool: Option<String>,
 
-  /**
-   * A list of files that are to be applied as patches after extracting the archive.
-   *
-   * By default, it uses the Bazel-native patch implementation which doesn't support fuzz match and
-   * binary patch, but Bazel will fall back to use patch command line tool if `patch_tool`
-   * attribute is specified or there are arguments other than `-p` in `patch_args` attribute.
-   */
+  /// A list of files that are to be applied as patches after extracting the archive.
+  ///
+  /// By default, it uses the Bazel-native patch implementation which doesn't support fuzz match and
+  /// binary patch, but Bazel will fall back to use patch command line tool if `patch_tool`
+  /// attribute is specified or there are arguments other than `-p` in `patch_args` attribute.
   #[serde(default)]
   pub patches: Vec<String>,
 
-  /**
-   * Path to a file to be included as part of the generated BUILD file.
-   *
-   * For example, some crates include non-Rust code typically built through a build.rs script. They
-   * can be made compatible by manually writing appropriate Bazel targets, and including them into
-   * the crate through a combination of additional_build_file and additional_deps.
-   *
-   * Note: This field should be a path to a file relative to the Cargo workspace root. For more
-   * context, see https://doc.rust-lang.org/cargo/reference/workspaces.html#root-package
-   */
+  /// Path to a file to be included as part of the generated BUILD file.
+  ///
+  /// For example, some crates include non-Rust code typically built through a build.rs script. They
+  /// can be made compatible by manually writing appropriate Bazel targets, and including them into
+  /// the crate through a combination of additional_build_file and additional_deps.
+  ///
+  /// Note: This field should be a path to a file relative to the Cargo workspace root. For more
+  /// context, see https://doc.rust-lang.org/cargo/reference/workspaces.html#root-package
   #[serde(default)]
   pub additional_build_file: Option<PathBuf>,
 }
 
-/**
- * Describes how dependencies should be managed in tree. Options are {Remote, Vendored}.
- *
- * Remote:
- * This mode assumes that files are not locally vendored, and generates a workspace-level
- * function that can bring them in.
- *
- * Vendored:
- * This mode assumes that files are vendored (into vendor/), and generates BUILD files
- * accordingly
- */
+/// Describes how dependencies should be managed in tree.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub enum GenMode {
+  /// This mode assumes that files are vendored (into vendor/), and generates BUILD files
+  /// accordingly
   Vendored,
+  /// This mode assumes that files are not locally vendored, and generates a workspace-level
+  /// function that can bring them in.
   Remote,
+  /// A representation of a GenMode that has not yet been specified
   Unspecified,
 }
 
@@ -379,14 +321,14 @@ fn default_render_package_aliases() -> bool {
   true
 }
 
-/** Formats a registry url to include the name and version fo the target package */
+/// Formats a registry url to include the name and version fo the target package
 pub fn format_registry_url(registry_url: &str, name: &str, version: &str) -> String {
   registry_url
     .replace("{crate}", name)
     .replace("{version}", version)
 }
 
-/** Check that the the `additional_build_file` represents a path to a file from the cargo workspace root */
+/// Check that the the `additional_build_file` represents a path to a file from the cargo workspace root
 fn validate_crate_setting_additional_build_file(
   additional_build_file: &Path,
   cargo_workspace_root: &Path,
@@ -403,7 +345,7 @@ fn validate_crate_setting_additional_build_file(
   Ok(())
 }
 
-/** Ensures crate settings associatd with the parsed [RazeSettings](crate::settings::RazeSettings) have valid crate settings */
+/// Ensures crate settings associatd with the parsed [RazeSettings](crate::settings::RazeSettings) have valid crate settings
 fn validate_crate_settings(
   settings: &RazeSettings,
   cargo_workspace_root: &Path,
@@ -446,7 +388,7 @@ fn validate_crate_settings(
   Ok(())
 }
 
-/** Verifies that the provided settings make sense. */
+/// Verifies that the provided settings make sense.
 fn validate_settings(
   settings: &mut RazeSettings,
   cargo_workspace_path: &Path,
@@ -482,11 +424,10 @@ fn validate_settings(
   Ok(())
 }
 
-/** The intermediate configuration settings for `cargo-raze`, included in a project's Cargo metadata
- *
- * Note that this struct should contain only `Option` and match all public fields of
- * [`RazeSettings`](crate::settings::RazeSettings)
- */
+/// The intermediate configuration settings for `cargo-raze`, included in a project's Cargo metadata
+///
+/// Note that this struct should contain only `Option` and match all public fields of
+/// [RazeSettings](crate::settings::RazeSettings)
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawRazeSettings {
@@ -525,7 +466,7 @@ struct RawRazeSettings {
 }
 
 impl RawRazeSettings {
-  /** Checks whether or not the settings have non-package specific settings specified */
+  /// Checks whether or not the settings have non-package specific settings specified
   fn contains_primary_options(&self) -> bool {
     self.workspace_path.is_some()
       || self.package_aliases_dir.is_some()
@@ -571,7 +512,7 @@ impl RawRazeSettings {
   }
 }
 
-/** Grows a list with duplicate keys between two maps */
+/// Grows a list with duplicate keys between two maps
 fn extend_duplicates<K: Hash + Eq + Clone, V>(
   extended_list: &mut Vec<K>,
   main_map: &HashMap<K, V>,
@@ -593,7 +534,7 @@ fn extend_duplicates<K: Hash + Eq + Clone, V>(
   );
 }
 
-/** Parse [`RazeSettings`](crate::settings::RazeSettings) from workspace metadata */
+/// Parse [RazeSettings](crate::settings::RazeSettings) from workspace metadata
 fn parse_raze_settings_workspace(
   metadata_value: &serde_json::value::Value,
   metadata: &Metadata,
@@ -660,7 +601,7 @@ fn parse_raze_settings_workspace(
   Ok(settings)
 }
 
-/** Parse [`RazeSettings`](crate::settings::RazeSettings) from a project's root package's metadata */
+/// Parse [RazeSettings](crate::settings::RazeSettings) from a project's root package's metadata
 fn parse_raze_settings_root_package(
   metadata_value: &serde_json::value::Value,
   root_package: &Package,
@@ -674,7 +615,7 @@ fn parse_raze_settings_root_package(
   });
 }
 
-/** Parse [`RazeSettings`](crate::settings::RazeSettings) from any workspace member's metadata */
+/// Parse [RazeSettings](crate::settings::RazeSettings) from any workspace member's metadata
 fn parse_raze_settings_any_package(metadata: &Metadata) -> Result<RazeSettings> {
   let mut settings_packages = Vec::new();
 
@@ -705,13 +646,13 @@ fn parse_raze_settings_any_package(metadata: &Metadata) -> Result<RazeSettings> 
     .with_context(|| format!("Failed to deserialize raze settings: {:?}", settings_value))
 }
 
-/** A struct only to deserialize a Cargo.toml to in search of the legacy syntax for [`RazeSettings`](crate::settings::RazeSettings) */
+/// A struct only to deserialize a Cargo.toml to in search of the legacy syntax for [RazeSettings](crate::settings::RazeSettings)
 #[derive(Debug, Clone, Deserialize)]
 pub struct LegacyCargoToml {
   pub raze: RazeSettings,
 }
 
-/** Parse [`RazeSettings`](crate::settings::RazeSettings) from a Cargo.toml file using the legacy syntax `[raze]` */
+/// Parse [RazeSettings](crate::settings::RazeSettings) from a Cargo.toml file using the legacy syntax `[raze]`
 fn parse_raze_settings_legacy(metadata: &Metadata) -> Result<RazeSettings> {
   let root_toml = metadata.workspace_root.join("Cargo.toml");
   let toml_contents = std::fs::read_to_string(&root_toml)?;
@@ -724,7 +665,7 @@ fn parse_raze_settings_legacy(metadata: &Metadata) -> Result<RazeSettings> {
   Ok(data.raze)
 }
 
-/** Parses raze settings from the contents of a `Cargo.toml` file */
+/// Parses raze settings from the contents of a `Cargo.toml` file
 fn parse_raze_settings(metadata: &Metadata) -> Result<RazeSettings> {
   // Workspace takes precedence
   let workspace_level_settigns = metadata.workspace_metadata.get("raze");
@@ -752,7 +693,7 @@ fn parse_raze_settings(metadata: &Metadata) -> Result<RazeSettings> {
   parse_raze_settings_any_package(&metadata)
 }
 
-/** A cargo command wrapper for gathering cargo metadata used to parse [RazeSettings](crate::settings::RazeSettings) */
+/// A cargo command wrapper for gathering cargo metadata used to parse [RazeSettings](crate::settings::RazeSettings)
 pub struct SettingsMetadataFetcher {
   pub cargo_bin_path: PathBuf,
 }
@@ -784,7 +725,7 @@ impl MetadataFetcher for SettingsMetadataFetcher {
   }
 }
 
-/** Load settings from a given Cargo manifest */
+/// Load settings from a given Cargo manifest
 pub fn load_settings_from_manifest<T: AsRef<Path>>(
   cargo_toml_path: T,
   cargo_bin_path: Option<String>,
@@ -816,7 +757,7 @@ pub fn load_settings_from_manifest<T: AsRef<Path>>(
   load_settings(&metadata)
 }
 
-/** Load settings used to configure the functionality of Cargo Raze */
+/// Load settings used to configure the functionality of Cargo Raze
 pub fn load_settings(metadata: &Metadata) -> Result<RazeSettings, RazeError> {
   let mut settings = {
     let result = parse_raze_settings(metadata);

--- a/impl/src/testing.rs
+++ b/impl/src/testing.rs
@@ -154,7 +154,7 @@ pub fn make_workspace_with_dependency() -> (TempDir, CargoWorkspaceFiles) {
   make_workspace(advanced_toml_contents(), Some(advanced_lock_contents()))
 }
 
-/** A helper stuct for mocking a crates.io remote crate endpoint */
+/// A helper stuct for mocking a crates.io remote crate endpoint
 pub struct MockRemoteCrateInfo<'http_mock_server> {
   // A directory of mock data to pull via a mocked endpoint
   pub data_dir: TempDir,
@@ -162,10 +162,8 @@ pub struct MockRemoteCrateInfo<'http_mock_server> {
   pub endpoints: Vec<MockRef<'http_mock_server>>,
 }
 
-/**
- * Configures the given mock_server (representing a crates.io remote) to return
- * mock responses for the given crate and version .
- */
+/// Configures the given mock_server (representing a crates.io remote) to return
+/// mock responses for the given crate and version .
 pub fn mock_remote_crate<'server>(
   name: &str,
   version: &str,
@@ -236,7 +234,7 @@ pub fn mock_remote_crate<'server>(
   }
 }
 
-/** A helper macro for passing a `crates` to  `mock_crate_index` */
+/// A helper macro for passing a `crates` to  `mock_crate_index`
 pub fn to_index_crates_map(list: Vec<(&str, &str)>) -> HashMap<String, String> {
   list
     .iter()
@@ -244,7 +242,7 @@ pub fn to_index_crates_map(list: Vec<(&str, &str)>) -> HashMap<String, String> {
     .collect()
 }
 
-/** Create a mock cache in a temporary direcotry that contains a set of given crates */
+/// Create a mock cache in a temporary direcotry that contains a set of given crates
 pub fn mock_crate_index(
   crates: &HashMap<String, String>,
   mock_dir: Option<&Path>,
@@ -292,7 +290,7 @@ pub fn mock_crate_index(
   }
 }
 
-/** Generate some basic metadata with an injected mock dependency */
+/// Generate some basic metadata with an injected mock dependency
 pub fn dummy_modified_metadata() -> RazeMetadata {
   let (_dir, files) = make_basic_workspace();
   let (mut fetcher, _server, _index_dir) = dummy_raze_metadata_fetcher();

--- a/impl/src/util.rs
+++ b/impl/src/util.rs
@@ -46,30 +46,19 @@ static SUPPORTED_PLATFORM_TRIPLES: &'static [&'static str] = &[
   "x86_64-unknown-freebsd",
 ];
 
-/** Determines if the target matches those supported by and defined in rules_rust
- *
- * Examples can be seen below:
- *
- * | target                                | returns          | reason                                           |
- * | ------------------------------------- | ---------------- | ------------------------------------------------ |
- * | `cfg(not(fuchsia))`                   | `(true, true)`   | `fuchsia` would be considered a 'default'        |
- * |                                       |                  | dependency since no supported target maps to it. |
- * |                                       |                  |                                                  |
- * | `cfg(unix)`                           | `(true, false)`  | There are supported platforms from the `unix`    |
- * |                                       |                  | `target_family` but not all platforms are of     |
- * |                                       |                  | the `unix` family.                               |
- * |                                       |                  |                                                  |
- * | `cfg(not(windows))`                   | `(true, false)`  | There are supported platforms in addition to     |
- * |                                       |                  | those in the `windows` `target_family`           |
- * |                                       |                  |                                                  |
- * | `x86_64-apple-darwin`                 | `(true, false)`  | This is a supported target triple but obviously  |
- * |                                       |                  | won't match with other triples.                  |
- * |                                       |                  |                                                  |
- * | `unknown-unknown-unknown`             | `(false, false)` | This will not match any triple.                  |
- * |                                       |                  |                                                  |
- * | `cfg(foo)`                            | `(false, false)` | `foo` is not a strongly defined cfg value.       |
- * | `cfg(target_os = "redox")`            | `(false, false)` | `redox` is not a supported platform.             |
- */
+/// Determines if the target matches those supported by and defined in rules_rust
+///
+/// Examples can be seen below:
+///
+/// | target                                | returns          | reason                                           |
+/// | ------------------------------------- | ---------------- | ------------------------------------------------ |
+/// | `cfg(not(fuchsia))`                   | `(true, true)`   | `fuchsia` would be considered a 'default' dependency since no supported target maps to it. |
+/// | `cfg(unix)`                           | `(true, false)`  | There are supported platforms from the `unix` `target_family` but not all platforms are of the `unix` family. |
+/// | `cfg(not(windows))`                   | `(true, false)`  | There are supported platforms in addition to those in the `windows` `target_family` |
+/// | `x86_64-apple-darwin`                 | `(true, false)`  | This is a supported target triple but obviously won't match with other triples. |
+/// | `unknown-unknown-unknown`             | `(false, false)` | This will not match any triple.                  |
+/// | `cfg(foo)`                            | `(false, false)` | `foo` is not a strongly defined cfg value.       |
+/// | `cfg(target_os = "redox")`            | `(false, false)` | `redox` is not a supported platform.             |
 pub fn is_bazel_supported_platform(target: &str) -> (bool, bool) {
   // Ensure the target is represented as an expression
   let target_exp = match target.starts_with("cfg(") {
@@ -113,11 +102,10 @@ pub fn is_bazel_supported_platform(target: &str) -> (bool, bool) {
   (is_supported, matches_all)
 }
 
-/** Maps a Rust cfg or triple target to Bazel supported triples.
- *
- * Note, the Bazel triples must be defined in:
- * https://github.com/bazelbuild/rules_rust/blob/master/rust/platform/platform.bzl
- */
+/// Maps a Rust cfg or triple target to Bazel supported triples.
+///
+/// Note, the Bazel triples must be defined in:
+/// https://github.com/bazelbuild/rules_rust/blob/master/rust/platform/platform.bzl
 pub fn get_matching_bazel_triples(target: &str) -> Result<Vec<String>> {
   let target_exp = match target.starts_with("cfg(") {
     true => target.to_owned(),
@@ -149,7 +137,7 @@ pub fn get_matching_bazel_triples(target: &str) -> Result<Vec<String>> {
   Ok(triples)
 }
 
-/** Produces a list of triples based on a provided whitelist */
+/// Produces a list of triples based on a provided whitelist
 pub fn filter_bazel_triples(triples: &mut Vec<String>, triples_whitelist: &Vec<String>) {
   // Early-out if the filter list is empty
   if triples_whitelist.len() == 0 {
@@ -162,9 +150,8 @@ pub fn filter_bazel_triples(triples: &mut Vec<String>, triples_whitelist: &Vec<S
   triples.sort();
 }
 
-/** Returns a list of Bazel targets for use in `select` statements based on a
- * given list of triples.
- */
+/// Returns a list of Bazel targets for use in `select` statements based on a
+/// given list of triples.
 pub fn generate_bazel_conditions(
   rust_rules_workspace_name: &str,
   triples: &Vec<String>,
@@ -189,7 +176,7 @@ pub fn generate_bazel_conditions(
   Ok(bazel_triples)
 }
 
-/** Returns whether or not the given path is a Bazel workspace root */
+/// Returns whether or not the given path is a Bazel workspace root
 pub fn is_bazel_workspace_root(dir: &Path) -> bool {
   let workspace_files = [dir.join("WORKSPACE.bazel"), dir.join("WORKSPACE")];
 
@@ -202,9 +189,8 @@ pub fn is_bazel_workspace_root(dir: &Path) -> bool {
   return false;
 }
 
-/** Returns a path to a Bazel workspace root based on the current working
- * directory, otherwise None if not workspace is detected.
- */
+/// Returns a path to a Bazel workspace root based on the current working
+/// directory, otherwise None if not workspace is detected.
 pub fn find_bazel_workspace_root(manifest_path: &Path) -> Option<PathBuf> {
   let mut dir = if manifest_path.is_dir() {
     Some(manifest_path)
@@ -297,7 +283,7 @@ pub fn sanitize_ident(ident: &str) -> String {
   slug::slugify(&ident).replace("-", "_")
 }
 
-/** Gets the proper system attributes for the provided platform triple using rustc. */
+/// Gets the proper system attributes for the provided platform triple using rustc.
 fn fetch_attrs(target: &str) -> Result<Vec<Cfg>> {
   let args = vec![format!("--target={}", target), "--print=cfg".to_owned()];
 


### PR DESCRIPTION
Closes https://github.com/google/cargo-raze/issues/299

This changes the documentation style of 
```rust
/** Header
 *
 * body
 */
fn hello() {}
```

to 
```rust
/// Header
///
/// body
fn hello() {}
```

So that documentation can be generated via rustdoc