### PR TITLE
Fixed a bug where export_files was being rendered into BUILD files it shouldn't have been

### DIFF
--- a/examples/remote/cargo_workspace/num_printer/cargo/BUILD.bazel
+++ b/examples/remote/cargo_workspace/num_printer/cargo/BUILD.bazel
@@ -20,11 +20,3 @@ alias(
         "manual",
     ],
 )
-
-# Export file for Stardoc support
-exports_files(
-    [
-        "crates.bzl",
-    ],
-    visibility = ["//visibility:public"],
-)

--- a/examples/remote/cargo_workspace/printer/cargo/BUILD.bazel
+++ b/examples/remote/cargo_workspace/printer/cargo/BUILD.bazel
@@ -20,11 +20,3 @@ alias(
         "manual",
     ],
 )
-
-# Export file for Stardoc support
-exports_files(
-    [
-        "crates.bzl",
-    ],
-    visibility = ["//visibility:public"],
-)

--- a/examples/remote/cargo_workspace/rng/cargo/BUILD.bazel
+++ b/examples/remote/cargo_workspace/rng/cargo/BUILD.bazel
@@ -20,11 +20,3 @@ alias(
         "manual",
     ],
 )
-
-# Export file for Stardoc support
-exports_files(
-    [
-        "crates.bzl",
-    ],
-    visibility = ["//visibility:public"],
-)

--- a/examples/vendored/cargo_workspace/cargo/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/BUILD.bazel
@@ -4,3 +4,11 @@ cargo-raze generated Bazel file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
+
+# Export file for Stardoc support
+exports_files(
+    [
+        "crates.bzl",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/examples/vendored/cargo_workspace/num_printer/cargo/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/num_printer/cargo/BUILD.bazel
@@ -20,11 +20,3 @@ alias(
         "manual",
     ],
 )
-
-# Export file for Stardoc support
-exports_files(
-    [
-        "crates.bzl",
-    ],
-    visibility = ["//visibility:public"],
-)

--- a/examples/vendored/cargo_workspace/printer/cargo/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/printer/cargo/BUILD.bazel
@@ -20,11 +20,3 @@ alias(
         "manual",
     ],
 )
-
-# Export file for Stardoc support
-exports_files(
-    [
-        "crates.bzl",
-    ],
-    visibility = ["//visibility:public"],
-)

--- a/examples/vendored/cargo_workspace/rng/cargo/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/rng/cargo/BUILD.bazel
@@ -20,11 +20,3 @@ alias(
         "manual",
     ],
 )
-
-# Export file for Stardoc support
-exports_files(
-    [
-        "crates.bzl",
-    ],
-    visibility = ["//visibility:public"],
-)

--- a/examples/vendored/complicated_cargo_library/cargo/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/BUILD.bazel
@@ -47,11 +47,3 @@ alias(
         "manual",
     ],
 )
-
-# Export file for Stardoc support
-exports_files(
-    [
-        "crates.bzl",
-    ],
-    visibility = ["//visibility:public"],
-)

--- a/examples/vendored/hello_cargo_library/cargo/BUILD.bazel
+++ b/examples/vendored/hello_cargo_library/cargo/BUILD.bazel
@@ -29,11 +29,3 @@ alias(
         "manual",
     ],
 )
-
-# Export file for Stardoc support
-exports_files(
-    [
-        "crates.bzl",
-    ],
-    visibility = ["//visibility:public"],
-)

--- a/examples/vendored/non_cratesio_library/cargo/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/BUILD.bazel
@@ -38,11 +38,3 @@ alias(
         "manual",
     ],
 )
-
-# Export file for Stardoc support
-exports_files(
-    [
-        "crates.bzl",
-    ],
-    visibility = ["//visibility:public"],
-)

--- a/impl/src/rendering/bazel.rs
+++ b/impl/src/rendering/bazel.rs
@@ -340,6 +340,8 @@ impl BuildRenderer for BazelRenderer {
       .as_path()
       .join(&render_details.path_prefix);
 
+    file_outputs.extend(self.render_aliases(planned_build, render_details, false)?);
+
     if render_details.experimental_api {
       let crates_bzl_file_path = path_prefix.as_path().join("crates.bzl");
       let rendered_crates_bzl_file = self
@@ -387,8 +389,6 @@ impl BuildRenderer for BazelRenderer {
         contents: final_crate_build_file,
       })
     }
-
-    file_outputs.extend(self.render_aliases(planned_build, render_details, false)?);
 
     Ok(file_outputs)
   }


### PR DESCRIPTION
This would only impact projects using cargo workspace functionality since they're the the only projects that would have multiple workspace members. 

Aliases are rendered for each workspace member in the Bazel package where they're located, but only the root package will have a `crates.bzl` file. This PR limits where the `exports_files` macro is declared to the correct places.