### PR TITLE
Update comments on workspace_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,28 +78,10 @@ path = "fake_lib.rs"
 [dependencies]
 log = "=0.3.6"
 
-[workspace.metadata.raze]
-# The path relative path to the Bazel workspace root (location of
-# WORKSPACE.bazel/WORKSPACE file). If no workspace file is found,
-# the current working directory is used.
-workspace_path = "//cargo"
-
-# This causes aliases for dependencies to be rendered in the BUILD
-# file located next to this `Cargo.toml` file.
-package_aliases_dir = "."
-
-# The set of targets to generate BUILD rules for.
-targets = [
-    "x86_64-apple-darwin",
-    "x86_64-pc-windows-msvc",
-    "x86_64-unknown-linux-gnu",
-]
-
-# The two acceptable options are "Remote" and "Vendored" which
-# is used to idnicate whether the user is using a non-vendored or
-# vendored set of dependencies.
-genmode = "Remote"
 ```
+
+Once the standard Cargo.toml is in place, add the `[package.metadata.raze]`
+directives per the next section.
 
 ### Using existing Cargo.toml
 
@@ -112,9 +94,11 @@ files to be used for generating Bazel files
 # Above this line should be the contents of your Cargo.toml file
 
 [package.metadata.raze]
-# The path relative path to the Bazel workspace root (location of
-# WORKSPACE.bazel/WORKSPACE file). If no workspace file is found,
-# the current working directory is used.
+# The path at which to write output files.
+#
+# `cargo raze` will generate Bazel-compatible BUILD files into this path.
+# This can either be a relative path (e.g. "foo/bar"), relative to this
+# Cargo.toml file; or relative to the Bazel workspace root (e.g. "//foo/bar").
 workspace_path = "//cargo"
 
 # This causes aliases for dependencies to be rendered in the BUILD
@@ -129,7 +113,7 @@ targets = [
 ]
 
 # The two acceptable options are "Remote" and "Vendored" which
-# is used to idnicate whether the user is using a non-vendored or
+# is used to indicate whether the user is using a non-vendored or
 # vendored set of dependencies.
 genmode = "Remote"
 ```
@@ -164,7 +148,7 @@ additional_flags = [
 ]
 ```
 
-[cargo_workspaces]: https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html)
+[cargo_workspaces]: https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html
 
 ### Remote Dependency Mode
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ In projects that use [cargo workspaces](cargo_workspaces) uses should organize
 all of their `raze` settings into the `[workspace.metadata.raze]` field in the
 top level `Cargo.toml` file which contains the `[workspace]` definition. These
 settings should be identical to the ones seen in `[package.metadata.raze]` in
-[the previous section](#Using existing Cargo.toml). However, crate settings may still
+[the previous section](#using-existing-cargotoml). However, crate settings may still
 be placed in the `Cargo.toml` files of the workspace memebers:
 
 ```toml

--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -33,7 +33,11 @@ pub type CrateSettingsPerVersion = HashMap<VersionReq, CrateSettings>;
 /// The configuration settings for `cargo-raze`, included in a projects Cargo metadata
 #[derive(Debug, Clone, Deserialize)]
 pub struct RazeSettings {
-  /// The path to the Cargo.toml working directory.
+  /// The path to write BUILD file outputs to.
+  ///
+  /// This may be a workspace-relative path (e.g. `//foo/bar`) or a path relative to the `Cargo.toml` file's directory
+  /// (e.g. if the Cargo metadata file is `//foo:Cargo.toml`, this could be `third_party` to put
+  /// outputs in `//foo/third_party`.)
   pub workspace_path: String,
 
   /// The relative path within each workspace member directory where aliases the member's dependencies should be rendered.
@@ -44,7 +48,7 @@ pub struct RazeSettings {
   /// as the Cargo.toml file to be overwritten.
   #[serde(default = "default_package_aliases_dir")]
   pub package_aliases_dir: String,
-  
+
   /// If true, package alises will be rendered based on the functionality described by `package_aliases_dir`.
   #[serde(default = "default_render_package_aliases")]
   pub render_package_aliases: bool,
@@ -462,7 +466,7 @@ struct RawRazeSettings {
   #[serde(default)]
   pub vendor_dir: Option<String>,
   #[serde(default)]
-  pub experimental_api: Option<bool>
+  pub experimental_api: Option<bool>,
 }
 
 impl RawRazeSettings {
@@ -485,7 +489,6 @@ impl RawRazeSettings {
   }
 
   fn print_notices_and_warnings(&self) {
-
     if self.target.is_some() {
       eprintln!(
         "WARNING: `[*.raze.target]` is deprecated. Please update your project to use \


### PR DESCRIPTION
Per [issue 335], I didn't find these docstrings very helpful. The
important bit of this property appears to be "this is where outputs go".

Try to make that clearer in the property docstring and the README.

Also do a little cleanup:

- README:
  - Deduplicate the `Cargo.toml` contents between two headers. We only need to list the specifics once.
  - Use `package.metadata.raze` when used in a package-metadata context (rather than workspace-metadata)
  - Fix typos 
- Run `rustfmt` on `settings.rs` (my precommits complain otherwise).

[issue 335]: https://github.com/google/cargo-raze/issues/335