### PR TITLE
Added `--generate-lockfile` for generating a new lockfile

### DIFF
--- a/impl/src/bin/cargo-raze.rs
+++ b/impl/src/bin/cargo-raze.rs
@@ -192,7 +192,7 @@ fn fetch_raze_metadata(
     remote_genmode_inputs.override_lockfile,
   )?;
 
-  checks::check_metadata(&raze_metadata.metadata, &settings, &cargo_raze_working_dir)?;
+  checks::check_metadata(&raze_metadata, &settings, &cargo_raze_working_dir)?;
   Ok(raze_metadata)
 }
 
@@ -287,7 +287,7 @@ fn write_to_file(path: &Path, contents: &str, verbose: bool) -> Result<()> {
   Ok(())
 }
 
-/* Represents the inputs specific to the Remote genmode. */
+/// Represents the inputs specific to the Remote genmode.
 struct RemoteGenModeInputs<'settings> {
   pub override_lockfile: Option<PathBuf>,
   pub binary_deps: Option<&'settings HashMap<String, cargo_toml::Dependency>>,

--- a/impl/src/bin/cargo-raze.rs
+++ b/impl/src/bin/cargo-raze.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::{
-  collections::HashMap,
   env,
   fs::{self, File},
   io::Write,
@@ -27,7 +26,7 @@ use docopt::Docopt;
 
 use cargo_raze::{
   checks,
-  metadata::{CargoWorkspaceFiles, MetadataFetcher, RazeMetadata, RazeMetadataFetcher},
+  metadata::{find_lockfile, MetadataFetcher, RazeMetadata, RazeMetadataFetcher},
   planning::{BuildPlanner, BuildPlannerImpl, PlannedBuild},
   rendering::FileOutputs,
   rendering::{bazel::BazelRenderer, BuildRenderer, RenderDetails},
@@ -50,6 +49,7 @@ struct Options {
   flag_cargo_bin_path: Option<String>,
   flag_output: Option<String>,
   flag_manifest_path: Option<String>,
+  flag_generate_lockfile: Option<bool>,
 }
 
 const USAGE: &str = r#"
@@ -58,7 +58,7 @@ Generate BUILD files for your pre-vendored Cargo dependencies.
 Usage:
     cargo raze (-h | --help)
     cargo raze [--verbose] [--quiet] [--color=<WHEN>] [--dryrun] [--cargo-bin-path=<PATH>] 
-               [--manifest-path=<PATH>] [--output=<PATH>] 
+               [--manifest-path=<PATH>] [--output=<PATH>] [--generate-lockfile]
     cargo raze (-V | --version)
 
 Options:
@@ -71,6 +71,7 @@ Options:
     --cargo-bin-path=<PATH>             Path to the cargo binary to be used for loading workspace metadata
     --manifest-path=<PATH>              Path to the Cargo.toml file to generate BUILD files for
     --output=<PATH>                     Path to output the generated into.
+    --generate-lockfile                 Force a new `Cargo.raze.lock` file to be generated
 "#;
 
 fn main() -> Result<()> {
@@ -173,23 +174,25 @@ fn fetch_raze_metadata(
   let cargo_raze_working_dir =
     find_bazel_workspace_root(&local_metadata.workspace_root).unwrap_or(env::current_dir()?);
 
-  let toml_path = local_metadata.workspace_root.join("Cargo.toml");
-  let lock_path_opt = {
-    let lock_path = local_metadata.workspace_root.join("Cargo.lock");
-    fs::metadata(&lock_path).ok().map(|_| lock_path)
+  let binary_dep_info = if settings.genmode == GenMode::Remote {
+    Some(&settings.binary_deps)
+  } else {
+    None
   };
 
-  let files = CargoWorkspaceFiles {
-    toml_path,
-    lock_path_opt,
+  let reused_lockfile = if !options.flag_generate_lockfile.unwrap_or(false) {
+    find_lockfile(
+      &local_metadata.workspace_root,
+      &cargo_raze_working_dir.join(settings.workspace_path.trim_start_matches("/")),
+    )
+  } else {
+    None
   };
-
-  let remote_genmode_inputs = gather_remote_genmode_inputs(&cargo_raze_working_dir, &settings);
 
   let raze_metadata = metadata_fetcher.fetch_metadata(
-    &files,
-    remote_genmode_inputs.binary_deps,
-    remote_genmode_inputs.override_lockfile,
+    &local_metadata.workspace_root,
+    binary_dep_info,
+    reused_lockfile,
   )?;
 
   checks::check_metadata(&raze_metadata, &settings, &cargo_raze_working_dir)?;
@@ -285,36 +288,4 @@ fn write_to_file(path: &Path, contents: &str, verbose: bool) -> Result<()> {
     println!("Generated {} successfully", path.display());
   }
   Ok(())
-}
-
-/// Represents the inputs specific to the Remote genmode.
-struct RemoteGenModeInputs<'settings> {
-  pub override_lockfile: Option<PathBuf>,
-  pub binary_deps: Option<&'settings HashMap<String, cargo_toml::Dependency>>,
-}
-
-/// Gathers inputs for the `genmode = "Remote"` builds.
-fn gather_remote_genmode_inputs<'settings>(
-  bazel_root: &Path,
-  settings: &'settings RazeSettings,
-) -> RemoteGenModeInputs<'settings> {
-  if settings.genmode != GenMode::Remote {
-    return RemoteGenModeInputs {
-      override_lockfile: None,
-      binary_deps: None,
-    };
-  }
-
-  let lockfile = bazel_root
-    .join(settings.workspace_path.trim_start_matches("/"))
-    .join("Cargo.raze.lock");
-
-  RemoteGenModeInputs {
-    override_lockfile: if lockfile.exists() {
-      Some(lockfile)
-    } else {
-      None
-    },
-    binary_deps: Some(&settings.binary_deps),
-  }
 }

--- a/impl/src/bin/cargo-raze.rs
+++ b/impl/src/bin/cargo-raze.rs
@@ -26,13 +26,13 @@ use docopt::Docopt;
 
 use cargo_raze::{
   checks,
-  metadata::{find_lockfile, MetadataFetcher, RazeMetadata, RazeMetadataFetcher},
+  metadata::{MetadataFetcher, RazeMetadata, RazeMetadataFetcher},
   planning::{BuildPlanner, BuildPlannerImpl, PlannedBuild},
   rendering::FileOutputs,
   rendering::{bazel::BazelRenderer, BuildRenderer, RenderDetails},
   settings::RazeSettings,
   settings::{load_settings, GenMode, SettingsMetadataFetcher},
-  util::{find_bazel_workspace_root, PlatformDetails},
+  util::{find_bazel_workspace_root, find_lockfile, PlatformDetails},
 };
 
 use serde::Deserialize;

--- a/impl/src/checks.rs
+++ b/impl/src/checks.rs
@@ -326,7 +326,10 @@ mod tests {
 
     // Ensure all packages are workspace members for this test
     for package in raze_metadata.metadata.packages.iter() {
-      assert!(raze_metadata.metadata.workspace_members.contains(&package.id))
+      assert!(raze_metadata
+        .metadata
+        .workspace_members
+        .contains(&package.id))
     }
 
     // Ensure no checks fail

--- a/impl/src/checks.rs
+++ b/impl/src/checks.rs
@@ -20,10 +20,11 @@ use std::{
   path::PathBuf,
 };
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 
 use crate::{
   error::RazeError,
+  metadata::RazeMetadata,
   settings::{CrateSettingsPerVersion, GenMode, RazeSettings},
   util::collect_up_to,
   util::package_ident,
@@ -37,19 +38,67 @@ const MAX_DISPLAYED_MISSING_RESOLVE_PACKAGES: usize = 5;
 
 /// Ensure that the given Metadata is valid and ready to use for planning.
 pub fn check_metadata(
-  metadata: &Metadata,
+  raze_metadata: &RazeMetadata,
   settings: &RazeSettings,
   bazel_workspace_root: &Path,
 ) -> Result<()> {
   // Check for errors
-  check_resolve_matches_packages(metadata)?;
+  check_resolve_matches_packages(&raze_metadata.metadata)?;
 
   if settings.genmode == GenMode::Vendored {
-    check_all_vendored(metadata, settings, bazel_workspace_root)?;
+    check_all_vendored(&raze_metadata.metadata, settings, bazel_workspace_root)?;
+  }
+
+  // Check for incomplete lockfiles
+  if let Err(err) =
+    check_lockfile_for_missing_checksums(&raze_metadata.metadata, &raze_metadata.checksums)
+  {
+    eprintln!("WARNING: {}", err);
   }
 
   // Check for unused crate settings
-  warn_unused_settings(&settings.crates, &metadata.packages);
+  warn_unused_settings(&settings.crates, &raze_metadata.metadata.packages);
+
+  Ok(())
+}
+
+fn check_lockfile_for_missing_checksums(
+  metadata: &Metadata,
+  checksums: &HashMap<String, String>,
+) -> Result<()> {
+  let missing_checksums: Vec<String> = metadata
+    .packages
+    .iter()
+    // Filter out workspace members
+    .filter(|pkg| !metadata.workspace_members.contains(&pkg.id))
+    // Filter out non crates.io sources
+    .filter(|pkg| pkg.source.as_ref().map_or(false, |src| src.is_crates_io()))
+    // Filter for missing checksums and save the package identifier
+    .filter_map(|pkg| {
+      let package_ident = package_ident(&pkg.name, &pkg.version.to_string());
+      if !checksums.contains_key(&package_ident) {
+        Some(package_ident)
+      } else {
+        None
+      }
+    })
+    .collect();
+
+  if !missing_checksums.is_empty() {
+    let lockfile_path = metadata.workspace_root.join("Cargo.lock");
+    if !lockfile_path.exists() {
+      return Err(anyhow!(
+        "Packages are missing checksums, perhaps `cargo generate-lockfile` needs to be run in the \
+         current cargo workspace. Missing checksums: {:?}",
+        missing_checksums
+      ));
+    }
+    return Err(anyhow!(
+      "Packages are missing checksums, perhaps `cargo update` needs to be run in the current \
+       cargo workspace. Missing checksums: {:?}",
+      missing_checksums
+    ));
+  }
 
   Ok(())
 }
@@ -211,8 +260,9 @@ fn warn_unused_settings(
 mod tests {
   use super::*;
   use crate::{
-    metadata::tests::dummy_raze_metadata, settings::tests::dummy_raze_settings,
-    testing::dummy_modified_metadata,
+    metadata::tests::dummy_raze_metadata,
+    settings::tests::dummy_raze_settings,
+    testing::{template_metadata, templates},
   };
 
   #[test]
@@ -238,12 +288,48 @@ mod tests {
     settings.genmode = GenMode::Vendored;
 
     let result = check_all_vendored(
-      &dummy_modified_metadata().metadata,
+      &template_metadata(templates::DUMMY_MODIFIED_METADATA),
       &settings,
       &PathBuf::from("/tmp/some/path"),
     );
 
     // Vendored crates will not have been rendered at that path
     assert!(result.is_err());
+  }
+
+  #[test]
+  fn test_missing_checksums() {
+    let metadata = template_metadata(templates::DUMMY_WORKSPACE_MEMBERS_METADATA);
+    let checksums: HashMap<String, String> = HashMap::new();
+
+    let result = check_lockfile_for_missing_checksums(&metadata, &checksums);
+    assert!(result.is_err());
+  }
+
+  #[test]
+  fn test_valid_checksums() {
+    let metadata = template_metadata(templates::DUMMY_WORKSPACE_MEMBERS_METADATA);
+    let mut checksums: HashMap<String, String> = HashMap::new();
+
+    // Add checksums
+    checksums.insert("unicode-xid-0.1.0".to_owned(), "some-checksum".to_owned());
+    checksums.insert("unicode-xid-0.2.1".to_owned(), "some-checksum".to_owned());
+
+    // Ensure we have a complete match
+    check_lockfile_for_missing_checksums(&metadata, &checksums).unwrap();
+  }
+
+  #[test]
+  fn test_no_deps_and_no_checksums() {
+    let raze_metadata = dummy_raze_metadata();
+    let checksums: HashMap<String, String> = HashMap::new();
+
+    // Ensure all packages are workspace members for this test
+    for package in raze_metadata.metadata.packages.iter() {
+      assert!(raze_metadata.metadata.workspace_members.contains(&package.id))
+    }
+
+    // Ensure no checks fail
+    check_lockfile_for_missing_checksums(&raze_metadata.metadata, &checksums).unwrap();
   }
 }

--- a/impl/src/metadata.rs
+++ b/impl/src/metadata.rs
@@ -34,7 +34,6 @@ use crate::util::package_ident;
 pub(crate) const SYSTEM_CARGO_BIN_PATH: &str = "cargo";
 pub(crate) const DEFAULT_CRATE_REGISTRY_URL: &str = "https://crates.io";
 pub(crate) const DEFAULT_CRATE_INDEX_URL: &str = "https://github.com/rust-lang/crates.io-index";
-pub(crate) const RAZE_LOCKFILE_NAME: &str = "Cargo.raze.lock";
 
 /// An entity that can generate Cargo metadata within a Cargo workspace
 pub trait MetadataFetcher {
@@ -483,26 +482,6 @@ impl Default for RazeMetadataFetcher {
       Url::parse(DEFAULT_CRATE_INDEX_URL).unwrap(),
     )
   }
-}
-
-/// Locates a lockfile for the associated crate. A `Cargo.raze.lock` file in the
-/// [RazeSettings::workspace_path](crate::settings::RazeSettings::workspace_path)
-/// direcotry will take precidence over a standard `Cargo.lock` file.
-pub fn find_lockfile(cargo_workspace_root: &Path, raze_output_dir: &Path) -> Option<PathBuf> {
-  // The custom raze lockfile will always take precidence
-  let raze_lockfile = raze_output_dir.join(RAZE_LOCKFILE_NAME);
-  if raze_lockfile.exists() {
-    return Some(raze_lockfile);
-  }
-
-  // If there is an existing standard lockfile, use it.
-  let cargo_lockfile = cargo_workspace_root.join("Cargo.lock");
-  if cargo_lockfile.exists() {
-    return Some(cargo_lockfile);
-  }
-
-  // No lockfile is available.
-  None
 }
 
 /// A struct containing information about a binary dependency

--- a/impl/src/metadata.rs
+++ b/impl/src/metadata.rs
@@ -432,11 +432,11 @@ impl RazeMetadataFetcher {
         let mut src_dirnames: Vec<String> = Vec::new();
 
         for (name, info) in binary_dep_info.iter() {
-          let version = info.req().to_string();
-          let src_dir = self.fetch_crate_src(cargo_dir.as_ref(), &name, &version)?;
+          let version = info.req();
+          let src_dir = self.fetch_crate_src(cargo_dir.as_ref(), &name, version)?;
           checksums.insert(
-            package_ident(&name, &version),
-            self.fetch_crate_checksum(&name, &version)?,
+            package_ident(name, version),
+            self.fetch_crate_checksum(name, version)?,
           );
           if let Some(dirname) = src_dir.file_name() {
             if let Some(dirname_str) = dirname.to_str() {
@@ -613,7 +613,7 @@ pub mod tests {
 
     // Always render basic metadata
     fetcher.set_metadata_fetcher(Box::new(DummyCargoMetadataFetcher {
-      metadata_template: Some("basic_metadata.json.template".to_string()),
+      metadata_template: Some(templates::BASIC_METADATA.to_string()),
     }));
 
     fetcher.fetch_metadata(&files, None, None).unwrap()

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -131,7 +131,7 @@ mod tests {
   #[test]
   fn test_plan_build_minimum_workspace_dependency() {
     let planned_build_res =
-      BuildPlannerImpl::new(dummy_modified_metadata(), dummy_raze_settings()).plan_build(Some(
+      BuildPlannerImpl::new(template_raze_metadata(templates::DUMMY_MODIFIED_METADATA), dummy_raze_settings()).plan_build(Some(
         PlatformDetails::new("some_target_triple".to_owned(), Vec::new() /* attrs */),
       ));
 
@@ -196,7 +196,7 @@ mod tests {
     settings.genmode = GenMode::Vendored;
 
     let planner = BuildPlannerImpl::new(
-      dummy_workspace_crate_metadata("basic_metadata.json.template"),
+      dummy_workspace_crate_metadata(templates::BASIC_METADATA),
       settings,
     );
     // N.B. This will fail if we don't correctly ignore workspace crates.
@@ -213,7 +213,7 @@ mod tests {
     settings.genmode = GenMode::Remote;
 
     let planner = BuildPlannerImpl::new(
-      dummy_workspace_crate_metadata("plan_build_produces_aliased_dependencies.json.template"),
+      dummy_workspace_crate_metadata(templates::PLAN_BUILD_PRODUCES_ALIASED_DEPENDENCIES),
       settings,
     );
     // N.B. This will fail if we don't correctly ignore workspace crates.
@@ -258,7 +258,7 @@ mod tests {
     settings.genmode = GenMode::Remote;
 
     let planner = BuildPlannerImpl::new(
-      dummy_workspace_crate_metadata("plan_build_produces_proc_macro_dependencies.json.template"),
+      dummy_workspace_crate_metadata(templates::PLAN_BUILD_PRODUCES_PROC_MACRO_DEPENDENCIES),
       settings,
     );
     let planned_build = planner
@@ -298,7 +298,7 @@ mod tests {
 
     let planner = BuildPlannerImpl::new(
       dummy_workspace_crate_metadata(
-        "plan_build_produces_build_proc_macro_dependencies.json.template",
+        templates::PLAN_BUILD_PRODUCES_BUILD_PROC_MACRO_DEPENDENCIES,
       ),
       settings,
     );
@@ -336,7 +336,7 @@ mod tests {
   fn test_subplan_produces_crate_root_with_forward_slash() {
     let planner = BuildPlannerImpl::new(
       dummy_workspace_crate_metadata(
-        "subplan_produces_crate_root_with_forward_slash.json.template",
+        templates::SUBPLAN_PRODUCES_CRATE_ROOT_WITH_FORWARD_SLASH,
       ),
       dummy_raze_settings(),
     );
@@ -360,9 +360,9 @@ mod tests {
     // than the standard metadata. So we use a generated template to represent that state.
     let dummy_metadata_fetcher = DummyCargoMetadataFetcher {
       metadata_template: if is_remote_genmode {
-        Some("dummy_binary_dependency_remote.json.template".to_string())
+        Some(templates::DUMMY_BINARY_DEPENDENCY_REMOTE.to_string())
       } else {
-        Some("basic_metadata.json.template".to_string())
+        Some(templates::BASIC_METADATA.to_string())
       },
     };
     fetcher.set_metadata_fetcher(Box::new(dummy_metadata_fetcher));
@@ -592,7 +592,7 @@ mod tests {
     };
 
     let planner = BuildPlannerImpl::new(
-      dummy_workspace_crate_metadata("semver_matching.json.template"),
+      dummy_workspace_crate_metadata(templates::SEMVER_MATCHING),
       settings,
     );
 

--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -888,7 +888,7 @@ pub mod tests {
       genmode = "Remote"
     "# };
 
-    let (dir, files) = make_workspace(toml_contents, None);
+    let dir = make_workspace(toml_contents, None);
     for member in vec!["crate_a", "crate_b"].iter() {
       let crate_toml = dir.as_ref().join(member).join("Cargo.toml");
       std::fs::create_dir_all(crate_toml.parent().unwrap()).unwrap();
@@ -903,7 +903,7 @@ pub mod tests {
       std::fs::write(crate_toml, toml_contents).unwrap();
     }
 
-    let settings = load_settings_from_manifest(files.toml_path, None).unwrap();
+    let settings = load_settings_from_manifest(dir.as_ref().join("Cargo.toml"), None).unwrap();
     assert_eq!(&settings.workspace_path, "//workspace_path/raze");
     assert_eq!(settings.genmode, GenMode::Remote);
     assert_eq!(settings.crates.len(), 2);

--- a/impl/src/testing.rs
+++ b/impl/src/testing.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use cargo_metadata::Metadata;
 use flate2::Compression;
 use httpmock::{Method::GET, MockRef, MockServer};
 use indoc::{formatdoc, indoc};
@@ -32,6 +33,19 @@ use crate::{
   },
   util::package_ident,
 };
+
+/// A module containing constants for each metadata template
+pub mod templates {
+  pub const BASIC_METADATA: &str = "basic_metadata.json.template";
+  pub const DUMMY_BINARY_DEPENDENCY_REMOTE: &str =  "dummy_binary_dependency_remote.json.template";
+  pub const DUMMY_MODIFIED_METADATA: &str =  "dummy_modified_metadata.json.template";
+  pub const DUMMY_WORKSPACE_MEMBERS_METADATA: &str =  "dummy_workspace_members_metadata.json.template";
+  pub const PLAN_BUILD_PRODUCES_ALIASED_DEPENDENCIES: &str =  "plan_build_produces_aliased_dependencies.json.template";
+  pub const PLAN_BUILD_PRODUCES_BUILD_PROC_MACRO_DEPENDENCIES: &str =  "plan_build_produces_build_proc_macro_dependencies.json.template";
+  pub const PLAN_BUILD_PRODUCES_PROC_MACRO_DEPENDENCIES: &str =  "plan_build_produces_proc_macro_dependencies.json.template";
+  pub const SEMVER_MATCHING: &str =  "semver_matching.json.template";
+  pub const SUBPLAN_PRODUCES_CRATE_ROOT_WITH_FORWARD_SLASH: &str =  "subplan_produces_crate_root_with_forward_slash.json.template";
+}
 
 pub const fn basic_toml_contents() -> &'static str {
   indoc! { r#"
@@ -290,15 +304,20 @@ pub fn mock_crate_index(
   }
 }
 
-/// Generate some basic metadata with an injected mock dependency
-pub fn dummy_modified_metadata() -> RazeMetadata {
-  let (_dir, files) = make_basic_workspace();
-  let (mut fetcher, _server, _index_dir) = dummy_raze_metadata_fetcher();
+/// Generate RazeMetadata from a cargo metadata template
+pub fn template_raze_metadata(template_path: &str) -> RazeMetadata {
+  let dir = make_basic_workspace();
+    let (mut fetcher, _server, _index_dir) = dummy_raze_metadata_fetcher();
 
-  // Always render basic metadata
-  fetcher.set_metadata_fetcher(Box::new(DummyCargoMetadataFetcher {
-    metadata_template: Some("dummy_modified_metadata.json.template".to_string()),
-  }));
+    // Always render basic metadata
+    fetcher.set_metadata_fetcher(Box::new(DummyCargoMetadataFetcher {
+      metadata_template: Some(template_path.to_string()),
+    }));
 
-  fetcher.fetch_metadata(&files, None, None).unwrap()
+    fetcher.fetch_metadata(dir.as_ref(), None, None).unwrap()
+}
+
+/// Load a cargo metadata template
+pub fn template_metadata(template_path: &str) -> Metadata {
+  template_raze_metadata(template_path).metadata
 }

--- a/impl/src/testing.rs
+++ b/impl/src/testing.rs
@@ -29,7 +29,7 @@ use std::{
 use crate::{
   metadata::{
     tests::{dummy_raze_metadata_fetcher, DummyCargoMetadataFetcher},
-    CargoWorkspaceFiles, RazeMetadata,
+    RazeMetadata,
   },
   util::package_ident,
 };
@@ -134,37 +134,30 @@ pub fn named_lock_contents(name: &str, version: &str) -> String {
   "#, name = name, version = version }
 }
 
-pub fn make_workspace(toml_file: &str, lock_file: Option<&str>) -> (TempDir, CargoWorkspaceFiles) {
+pub fn make_workspace(toml_file: &str, lock_file: Option<&str>) -> TempDir {
   let dir = TempDir::new().unwrap();
-  let toml_path = {
+  // Create Cargo.toml
+  {
     let path = dir.path().join("Cargo.toml");
     let mut toml = File::create(&path).unwrap();
     toml.write_all(toml_file.as_bytes()).unwrap();
-    path
-  };
-  let lock_path = match lock_file {
-    Some(lock_file) => {
-      let path = dir.path().join("Cargo.lock");
-      let mut lock = File::create(&path).unwrap();
-      lock.write_all(lock_file.as_bytes()).unwrap();
-      Some(path)
-    },
-    None => None,
-  };
-  let files = CargoWorkspaceFiles {
-    lock_path_opt: lock_path,
-    toml_path,
-  };
+  }
+
+  if let Some(lock_file) = lock_file {
+    let path = dir.path().join("Cargo.lock");
+    let mut lock = File::create(&path).unwrap();
+    lock.write_all(lock_file.as_bytes()).unwrap();
+  }
 
   File::create(dir.as_ref().join("WORKSPACE.bazel")).unwrap();
-  (dir, files)
+  dir
 }
 
-pub fn make_basic_workspace() -> (TempDir, CargoWorkspaceFiles) {
+pub fn make_basic_workspace() -> TempDir {
   make_workspace(basic_toml_contents(), Some(basic_lock_contents()))
 }
 
-pub fn make_workspace_with_dependency() -> (TempDir, CargoWorkspaceFiles) {
+pub fn make_workspace_with_dependency() -> TempDir {
   make_workspace(advanced_toml_contents(), Some(advanced_lock_contents()))
 }
 

--- a/impl/src/util.rs
+++ b/impl/src/util.rs
@@ -21,6 +21,8 @@ use cargo_platform::Cfg;
 use cfg_expr::{targets::get_builtin_target_by_triple, Expression, Predicate};
 use pathdiff::diff_paths;
 
+pub(crate) const RAZE_LOCKFILE_NAME: &str = "Cargo.raze.lock";
+
 static SUPPORTED_PLATFORM_TRIPLES: &'static [&'static str] = &[
   // SUPPORTED_T1_PLATFORM_TRIPLES
   "i686-apple-darwin",
@@ -319,6 +321,26 @@ pub fn get_workspace_member_path(manifest_path: &Path, workspace_root: &Path) ->
 
 pub fn package_ident(package_name: &str, package_version: &str) -> String {
   format!("{}-{}", package_name, package_version)
+}
+
+/// Locates a lockfile for the associated crate. A `Cargo.raze.lock` file in the
+/// [RazeSettings::workspace_path](crate::settings::RazeSettings::workspace_path)
+/// direcotry will take precidence over a standard `Cargo.lock` file.
+pub fn find_lockfile(cargo_workspace_root: &Path, raze_output_dir: &Path) -> Option<PathBuf> {
+  // The custom raze lockfile will always take precidence
+  let raze_lockfile = raze_output_dir.join(RAZE_LOCKFILE_NAME);
+  if raze_lockfile.exists() {
+    return Some(raze_lockfile);
+  }
+
+  // If there is an existing standard lockfile, use it.
+  let cargo_lockfile = cargo_workspace_root.join("Cargo.lock");
+  if cargo_lockfile.exists() {
+    return Some(cargo_lockfile);
+  }
+
+  // No lockfile is available.
+  None
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR adds a new argument `--generate-lockfile` which will force a new lockfile to be generated.

## `CargoWorkspaceFiles` was deleted
`Cargo.toml` and `Cargo.lock` were basically never used for anything other than finding the cargo workspace. It's simpler to pass around a `Path` and allow the underlying cargo command to handle finding the correct metadata.

## `--generate-lockfile`
This will always generate a `Cargo.raze.lock` file which will take precedence over an existing `Cargo.lock` file. As a reminder, this file exists because to allow projects using `binary_deps` to have a lockfile that doesn't conflict with the standard lockfile. I'm hoping to one day delete the need for this file and standardize on the canonical `Cargo.lock` file, but for now, the use of `Cargo.raze.lock` makes the outputs of `cargo-raze` more consistent.

Running this command against the `examples/remote/cargo_workspace` example yields the following changes to the workspace
```command
cargo_workspace % git status
```
```output
On branch checksum
Your branch is up to date with 'origin/checksum'.

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   cargo/crates.bzl
	deleted:    cargo/remote/BUILD.addr2line-0.13.0.bazel
	modified:   cargo/remote/BUILD.atty-0.2.14.bazel
	deleted:    cargo/remote/BUILD.backtrace-0.3.53.bazel
	deleted:    cargo/remote/BUILD.cfg-if-0.1.10.bazel
	modified:   cargo/remote/BUILD.error-chain-0.10.0.bazel
	deleted:    cargo/remote/BUILD.getrandom-0.1.15.bazel
	deleted:    cargo/remote/BUILD.gimli-0.22.0.bazel
	modified:   cargo/remote/BUILD.hermit-abi-0.1.17.bazel
	deleted:    cargo/remote/BUILD.libc-0.2.79.bazel
	deleted:    cargo/remote/BUILD.object-0.21.1.bazel
	deleted:    cargo/remote/BUILD.ppv-lite86-0.2.9.bazel
	modified:   cargo/remote/BUILD.rand-0.7.3.bazel
	modified:   cargo/remote/BUILD.rand_chacha-0.2.2.bazel
	modified:   cargo/remote/BUILD.rand_core-0.5.1.bazel
	deleted:    cargo/remote/BUILD.rustc-demangle-0.1.17.bazel

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	cargo/Cargo.raze.lock
	cargo/remote/BUILD.addr2line-0.14.1.bazel
	cargo/remote/BUILD.backtrace-0.3.55.bazel
	cargo/remote/BUILD.getrandom-0.1.16.bazel
	cargo/remote/BUILD.gimli-0.23.0.bazel
	cargo/remote/BUILD.libc-0.2.81.bazel
	cargo/remote/BUILD.object-0.22.0.bazel
	cargo/remote/BUILD.ppv-lite86-0.2.10.bazel
	cargo/remote/BUILD.rustc-demangle-0.1.18.bazel

no changes added to commit (use "git add" and/or "git commit -a")
```

Note the addition of `cargo/Cargo.raze.lock` here. `cargo-raze` will use this for subsequent runs. It's also worth noting that if no `Cargo.lock` or `Cargo.raze.lock` files exist, a `Cargo.raze.lock` file will be generated.

## New warning for missing checksum
There's a new warning in the `checks` module that will print a warning for when a crates.io crate is missing a checksum:

With the following diff
```diff
diff --git a/examples/remote/cargo_workspace/Cargo.lock b/examples/remote/cargo_workspace/Cargo.lock
index 44494886..54cc7fa1 100644
--- a/examples/remote/cargo_workspace/Cargo.lock
+++ b/examples/remote/cargo_workspace/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 name = "adler"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+#checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"

 [[package]]
 name = "ansi_term"
``` 

The following error is produced
```output
Running Cargo Raze for cargo_workspace
WARNING: Packages are missing checksums, perhaps `cargo generate-lockfile` needs to be run in the current cargo workspace. Missing checksums: ["adler-0.2.3"]
```