### PR TITLE
Rust library and binary dependencies are all sorted before rendering

### DIFF
--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.ferris-says-0.2.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.ferris-says-0.2.0.bazel
@@ -50,7 +50,6 @@ rust_binary(
     version = "0.2.0",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":ferris_says",
         "@remote_binary_dependencies__clap__2_33_3//:clap",
         "@remote_binary_dependencies__error_chain__0_10_0//:error_chain",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.ferris-says-0.2.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.ferris-says-0.2.0.bazel
@@ -50,7 +50,6 @@ rust_binary(
     version = "0.2.0",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":ferris_says",
         "@remote_cargo_workspace__clap__2_33_3//:clap",
         "@remote_cargo_workspace__error_chain__0_10_0//:error_chain",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.aho-corasick-0.6.10.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.aho-corasick-0.6.10.bazel
@@ -52,7 +52,6 @@ rust_binary(
     version = "0.6.10",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":aho_corasick",
         "@remote_complicated_cargo_library__memchr__2_3_3//:memchr",
     ],

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.cc-1.0.60.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.cc-1.0.60.bazel
@@ -50,7 +50,6 @@ rust_binary(
     version = "1.0.60",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":cc",
     ],
 )

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-0.3.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-0.3.2.bazel
@@ -50,7 +50,6 @@ rust_binary(
     version = "0.3.2",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":crossbeam",
     ],
 )
@@ -75,7 +74,6 @@ rust_binary(
     version = "0.3.2",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":crossbeam",
     ],
 )

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.regex-0.2.5.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.regex-0.2.5.bazel
@@ -68,9 +68,9 @@ rust_library(
         "@remote_complicated_cargo_library__aho_corasick__0_6_10//:aho_corasick",
         "@remote_complicated_cargo_library__memchr__2_3_3//:memchr",
         "@remote_complicated_cargo_library__regex_syntax__0_4_2//:regex_syntax",
+        "@remote_complicated_cargo_library__specs__0_10_0//:specs",
         "@remote_complicated_cargo_library__thread_local__0_3_6//:thread_local",
         "@remote_complicated_cargo_library__utf8_ranges__1_0_4//:utf8_ranges",
-        "@remote_complicated_cargo_library__specs__0_10_0//:specs",
     ],
 )
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.aho-corasick-0.6.10.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.aho-corasick-0.6.10.bazel
@@ -52,7 +52,6 @@ rust_binary(
     version = "0.6.10",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":aho_corasick",
         "@remote_non_cratesio__memchr__2_3_3//:memchr",
     ],

--- a/examples/vendored/cargo_workspace/cargo/vendor/ferris-says-0.2.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/ferris-says-0.2.0/BUILD.bazel
@@ -50,13 +50,12 @@ rust_binary(
     version = "0.2.0",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
-        ":ferris_says",
         "//vendored/cargo_workspace/cargo/vendor/clap-2.33.3:clap",
         "//vendored/cargo_workspace/cargo/vendor/error-chain-0.10.0:error_chain",
         "//vendored/cargo_workspace/cargo/vendor/smallvec-0.4.5:smallvec",
         "//vendored/cargo_workspace/cargo/vendor/textwrap-0.11.0:textwrap",
         "//vendored/cargo_workspace/cargo/vendor/unicode-width-0.1.8:unicode_width",
+        ":ferris_says",
     ],
 )
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/getrandom-0.1.15/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/getrandom-0.1.15/BUILD.bazel
@@ -119,8 +119,8 @@ rust_library(
     version = "0.1.15",
     # buildifier: leave-alone
     deps = [
-        ":getrandom_build_script",
         "//vendored/cargo_workspace/cargo/vendor/cfg-if-0.1.10:cfg_if",
+        ":getrandom_build_script",
     ] + selects.with_or({
         # cfg(target_os = "wasi")
         (

--- a/examples/vendored/cargo_workspace/cargo/vendor/miniz_oxide-0.4.3/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/miniz_oxide-0.4.3/BUILD.bazel
@@ -78,7 +78,7 @@ rust_library(
     version = "0.4.3",
     # buildifier: leave-alone
     deps = [
-        ":miniz_oxide_build_script",
         "//vendored/cargo_workspace/cargo/vendor/adler-0.2.3:adler",
+        ":miniz_oxide_build_script",
     ],
 )

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
@@ -52,9 +52,8 @@ rust_binary(
     version = "0.6.10",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
-        ":aho_corasick",
         "//vendored/complicated_cargo_library/cargo/vendor/memchr-2.3.3:memchr",
+        ":aho_corasick",
     ],
 )
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-0.3.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-0.3.2/BUILD.bazel
@@ -50,7 +50,6 @@ rust_binary(
     version = "0.3.2",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":crossbeam",
     ],
 )
@@ -75,7 +74,6 @@ rust_binary(
     version = "0.3.2",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":crossbeam",
     ],
 )

--- a/examples/vendored/non_cratesio_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
@@ -52,9 +52,8 @@ rust_binary(
     version = "0.6.10",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
-        ":aho_corasick",
         "//vendored/non_cratesio_library/cargo/vendor/memchr-2.3.3:memchr",
+        ":aho_corasick",
     ],
 )
 

--- a/impl/src/rendering/bazel.rs
+++ b/impl/src/rendering/bazel.rs
@@ -53,7 +53,7 @@ pub struct BazelRenderer {
   internal_renderer: Tera,
 }
 
-/** Generate the expected Bazel package name */
+/// Generate the expected Bazel package name
 fn bazel_package_name(render_details: &RenderDetails) -> String {
   if let Some(package_name) = diff_paths(&render_details.cargo_root, &render_details.bazel_root) {
     package_name.display().to_string().replace("\\", "/")

--- a/impl/src/rendering/templates/partials/rust_binary.template
+++ b/impl/src/rendering/templates/partials/rust_binary.template
@@ -16,7 +16,7 @@ rust_binary(
 {%- for dependency in crate.raze_settings.additional_deps %}
     {%- set_global deps = deps | concat(with=dependency) %}
 {%- endfor %}
-    # buildifier: leave-alone{# The sort below is different from what Buildifier does. Buildifier should ignore this section #}
+    # buildifier: leave-alone{# TODO: The sort below is different from what Buildifier does. We should write a Buildifier compliant sort function and register it so we can use it below. See https://tera.netlify.app/docs#filters for details #}
     deps = [
         {%- for dep in deps | sort %}
         "{{ dep }}",

--- a/impl/src/rendering/templates/partials/rust_binary.template
+++ b/impl/src/rendering/templates/partials/rust_binary.template
@@ -16,7 +16,7 @@ rust_binary(
 {%- for dependency in crate.raze_settings.additional_deps %}
     {%- set_global deps = deps | concat(with=dependency) %}
 {%- endfor %}
-    # buildifier: leave-alone{# TODO: The sort below is different from what Buildifier does. We should write a Buildifier compliant sort function and register it so we can use it below. See https://tera.netlify.app/docs#filters for details #}
+    # buildifier: leave-alone{# TODO: https://github.com/google/cargo-raze/issues/348 #}
     deps = [
         {%- for dep in deps | sort %}
         "{{ dep }}",

--- a/impl/src/rendering/templates/partials/rust_binary.template
+++ b/impl/src/rendering/templates/partials/rust_binary.template
@@ -3,20 +3,23 @@ rust_binary(
     # N.B.: The exact form of this is subject to change.
     name = "cargo_bin_{{ target_name_sanitized }}",
 {% include "templates/partials/common_attrs.template" %}
-    # buildifier: leave-alone
+{%- set deps = [] %}
+{%- if crate.lib_target_name %}{# Binaries get an implicit dependency on their crate's lib #}
+    {%- set deps = deps | concat(with=":" ~ crate.lib_target_name | replace(from='-', to='_')) %}
+{%- endif %}
+{%- if crate.build_script_target %}
+    {%- set deps = deps | concat(with=":" ~ crate_name_sanitized ~ "_build_script") %}
+{%- endif %}
+{%- for dependency in crate.default_deps.dependencies %}
+    {%- set_global deps = deps | concat(with=dependency.buildable_target) %}
+{%- endfor %}
+{%- for dependency in crate.raze_settings.additional_deps %}
+    {%- set_global deps = deps | concat(with=dependency) %}
+{%- endfor %}
+    # buildifier: leave-alone{# The sort below is different from what Buildifier does. Buildifier should ignore this section #}
     deps = [
-        {%- if crate.lib_target_name %}
-        # Binaries get an implicit dependency on their crate's lib
-        ":{{crate.lib_target_name | replace(from="-", to="_") }}",
-        {%- endif %}
-        {%- if crate.build_script_target %}
-        ":{{ crate_name_sanitized }}_build_script",
-        {%- endif %}
-        {%- for dependency in crate.default_deps.dependencies %}
-        "{{dependency.buildable_target}}",
-        {%- endfor %}
-        {%- for dependency in crate.raze_settings.additional_deps %}
-        "{{dependency}}",
+        {%- for dep in deps | sort %}
+        "{{ dep }}",
         {%- endfor %}
     ]
     {%- if crate.targeted_deps %} 

--- a/impl/src/rendering/templates/partials/rust_library.template
+++ b/impl/src/rendering/templates/partials/rust_library.template
@@ -12,16 +12,20 @@ alias(
 rust_library(
     name = "{{ target_name_sanitized }}",
 {% include "templates/partials/common_attrs.template" %}
-    # buildifier: leave-alone
+{%- set deps = [] %}
+{%- if crate.build_script_target %}
+    {%- set deps = deps | concat(with=":" ~ crate_name_sanitized ~ "_build_script") %}
+{%- endif %}
+{%- for dependency in crate.default_deps.dependencies %}
+    {%- set_global deps = deps | concat(with=dependency.buildable_target) %}
+{%- endfor %}
+{%- for dependency in crate.raze_settings.additional_deps %}
+    {%- set_global deps = deps | concat(with=dependency) %}
+{%- endfor %}
+    # buildifier: leave-alone{# The sort below is different from what Buildifier does. Buildifier should ignore this section #}
     deps = [
-        {%- if crate.build_script_target %}
-        ":{{ crate_name_sanitized }}_build_script",
-        {%- endif %}
-        {%- for dependency in crate.default_deps.dependencies %}
-        "{{dependency.buildable_target}}",
-        {%- endfor %}
-        {%- for dependency in crate.raze_settings.additional_deps %}
-        "{{dependency}}",
+        {%- for dep in deps | sort %}
+        "{{ dep }}",
         {%- endfor %}
     ]
     {%- if crate.targeted_deps %} 

--- a/impl/src/rendering/templates/partials/rust_library.template
+++ b/impl/src/rendering/templates/partials/rust_library.template
@@ -22,7 +22,7 @@ rust_library(
 {%- for dependency in crate.raze_settings.additional_deps %}
     {%- set_global deps = deps | concat(with=dependency) %}
 {%- endfor %}
-    # buildifier: leave-alone{# The sort below is different from what Buildifier does. Buildifier should ignore this section #}
+    # buildifier: leave-alone{# TODO: The sort below is different from what Buildifier does. We should write a Buildifier compliant sort function and register it so we can use it below. See https://tera.netlify.app/docs#filters for details #}
     deps = [
         {%- for dep in deps | sort %}
         "{{ dep }}",

--- a/impl/src/rendering/templates/partials/rust_library.template
+++ b/impl/src/rendering/templates/partials/rust_library.template
@@ -22,7 +22,7 @@ rust_library(
 {%- for dependency in crate.raze_settings.additional_deps %}
     {%- set_global deps = deps | concat(with=dependency) %}
 {%- endfor %}
-    # buildifier: leave-alone{# TODO: The sort below is different from what Buildifier does. We should write a Buildifier compliant sort function and register it so we can use it below. See https://tera.netlify.app/docs#filters for details #}
+    # buildifier: leave-alone{# TODO: https://github.com/google/cargo-raze/issues/348 #}
     deps = [
         {%- for dep in deps | sort %}
         "{{ dep }}",


### PR DESCRIPTION
This is a slight improvement to how dependencies for `rust_binary` and `rust_library` targets get rendered. Instead of looping over multiple lists and rendering labels for dependencies, they're combined into a single list, sorted and then rendered. 

Unfortunately, this does not mean that the `buildifier: leave-alone` tag can be removed. Buildifier appears to follow a different sorting rule than what [tera](https://github.com/Keats/tera) makes available. To solve for this, we should register a custom [filter](https://tera.netlify.app/docs#filters) that performs a Buildifier compliant sort.

A diff can be found below highlighting the differences: 
```diff
diff --git a/examples/vendored/cargo_workspace/cargo/vendor/ferris-says-0.2.0/BUILD.bazel b/examples/vendored/cargo_workspace/cargo/vendor/ferris-says-0.2.0/BUILD.bazel
index b025cee1..cdba75a0 100644
--- a/examples/vendored/cargo_workspace/cargo/vendor/ferris-says-0.2.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/ferris-says-0.2.0/BUILD.bazel
@@ -49,12 +49,12 @@ rust_binary(
     ],
     version = "0.2.0",
     deps = [
+        ":ferris_says",
         "//vendored/cargo_workspace/cargo/vendor/clap-2.33.3:clap",
         "//vendored/cargo_workspace/cargo/vendor/error-chain-0.10.0:error_chain",
         "//vendored/cargo_workspace/cargo/vendor/smallvec-0.4.5:smallvec",
         "//vendored/cargo_workspace/cargo/vendor/textwrap-0.11.0:textwrap",
         "//vendored/cargo_workspace/cargo/vendor/unicode-width-0.1.8:unicode_width",
-        ":ferris_says",
     ],
 )
 
diff --git a/examples/vendored/cargo_workspace/cargo/vendor/miniz_oxide-0.4.3/BUILD.bazel b/examples/vendored/cargo_workspace/cargo/vendor/miniz_oxide-0.4.3/BUILD.bazel
index 0bf167cf..4d581473 100644
--- a/examples/vendored/cargo_workspace/cargo/vendor/miniz_oxide-0.4.3/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/miniz_oxide-0.4.3/BUILD.bazel
@@ -77,7 +77,7 @@ rust_library(
     ],
     version = "0.4.3",
     deps = [
-        "//vendored/cargo_workspace/cargo/vendor/adler-0.2.3:adler",
         ":miniz_oxide_build_script",
+        "//vendored/cargo_workspace/cargo/vendor/adler-0.2.3:adler",
     ],
 )
diff --git a/examples/vendored/complicated_cargo_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel b/examples/vendored/complicated_cargo_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
index 5d4877c2..494b0fe0 100644
--- a/examples/vendored/complicated_cargo_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
@@ -51,8 +51,8 @@ rust_binary(
     ],
     version = "0.6.10",
     deps = [
-        "//vendored/complicated_cargo_library/cargo/vendor/memchr-2.3.3:memchr",
         ":aho_corasick",
+        "//vendored/complicated_cargo_library/cargo/vendor/memchr-2.3.3:memchr",
     ],
 )
 
diff --git a/examples/vendored/complicated_cargo_library/cargo/vendor/regex-0.2.11/BUILD.bazel b/examples/vendored/complicated_cargo_library/cargo/vendor/regex-0.2.11/BUILD.bazel
index f977c9ad..84c5cadd 100644
--- a/examples/vendored/complicated_cargo_library/cargo/vendor/regex-0.2.11/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/regex-0.2.11/BUILD.bazel
@@ -67,12 +67,12 @@ rust_library(
     ],
     version = "0.2.11",
     deps = [
+        "//vendored/complicated_cargo_library/cargo:specs",
         "//vendored/complicated_cargo_library/cargo/vendor/aho-corasick-0.6.10:aho_corasick",
         "//vendored/complicated_cargo_library/cargo/vendor/memchr-2.3.3:memchr",
         "//vendored/complicated_cargo_library/cargo/vendor/regex-syntax-0.5.6:regex_syntax",
         "//vendored/complicated_cargo_library/cargo/vendor/thread_local-0.3.6:thread_local",
         "//vendored/complicated_cargo_library/cargo/vendor/utf8-ranges-1.0.4:utf8_ranges",
-        "//vendored/complicated_cargo_library/cargo:specs",
     ],
 )
 
diff --git a/examples/vendored/non_cratesio_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel b/examples/vendored/non_cratesio_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
index 7c021a60..13f7dcd6 100644
--- a/examples/vendored/non_cratesio_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
@@ -51,8 +51,8 @@ rust_binary(
     ],
     version = "0.6.10",
     deps = [
-        "//vendored/non_cratesio_library/cargo/vendor/memchr-2.3.3:memchr",
         ":aho_corasick",
+        "//vendored/non_cratesio_library/cargo/vendor/memchr-2.3.3:memchr",
     ],
 )
 
```


