### PR TITLE
Added support for a `CARGO` environment variable

### DIFF
--- a/impl/src/metadata.rs
+++ b/impl/src/metadata.rs
@@ -14,7 +14,7 @@
 
 use std::{
   collections::HashMap,
-  fs,
+  env, fs,
   path::{Path, PathBuf},
   string::String,
 };
@@ -48,7 +48,9 @@ struct CargoMetadataFetcher {
 impl Default for CargoMetadataFetcher {
   fn default() -> CargoMetadataFetcher {
     CargoMetadataFetcher {
-      cargo_bin_path: SYSTEM_CARGO_BIN_PATH.into(),
+      cargo_bin_path: env::var("CARGO")
+        .unwrap_or(SYSTEM_CARGO_BIN_PATH.to_string())
+        .into(),
     }
   }
 }
@@ -476,7 +478,7 @@ impl RazeMetadataFetcher {
 impl Default for RazeMetadataFetcher {
   fn default() -> RazeMetadataFetcher {
     RazeMetadataFetcher::new(
-      SYSTEM_CARGO_BIN_PATH,
+      env::var("CARGO").unwrap_or(SYSTEM_CARGO_BIN_PATH.to_string()),
       // UNWRAP: The default is covered by testing and should never return err
       Url::parse(DEFAULT_CRATE_REGISTRY_URL).unwrap(),
       Url::parse(DEFAULT_CRATE_INDEX_URL).unwrap(),
@@ -559,7 +561,7 @@ pub mod tests {
         .with_context(|| {
           format!(
             "Failed to run `{} metadata` with contents:\n{}",
-            SYSTEM_CARGO_BIN_PATH,
+            env::var("CARGO").unwrap_or(SYSTEM_CARGO_BIN_PATH.to_string()),
             fs::read_to_string(working_dir.join("Cargo.toml")).unwrap()
           )
         })
@@ -586,7 +588,7 @@ pub mod tests {
     let tempdir = TempDir::new().unwrap();
     let mock_server = MockServer::start();
     let mut fetcher = RazeMetadataFetcher::new(
-      SYSTEM_CARGO_BIN_PATH,
+      env::var("CARGO").unwrap_or(SYSTEM_CARGO_BIN_PATH.to_string()),
       Url::parse(&mock_server.base_url()).unwrap(),
       Url::parse(&format!("file://{}", tempdir.as_ref().display())).unwrap(),
     );

--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -24,6 +24,7 @@ use semver::VersionReq;
 use serde::{Deserialize, Serialize};
 use std::{
   collections::HashMap,
+  env,
   hash::Hash,
   path::{Path, PathBuf},
 };
@@ -711,7 +712,9 @@ pub struct SettingsMetadataFetcher {
 impl Default for SettingsMetadataFetcher {
   fn default() -> SettingsMetadataFetcher {
     SettingsMetadataFetcher {
-      cargo_bin_path: SYSTEM_CARGO_BIN_PATH.into(),
+      cargo_bin_path: env::var("CARGO")
+        .unwrap_or(SYSTEM_CARGO_BIN_PATH.to_string())
+        .into(),
     }
   }
 }


### PR DESCRIPTION
Similar to [cargo_metadata::MetadataCommand::cargo_path](https://docs.rs/cargo_metadata/0.12.3/cargo_metadata/struct.MetadataCommand.html#method.cargo_path) (which is the underlying crate used for the primary cargo commands in `cargo-raze`), Cargo raze will now accept an optional `CARGO` environment variable for specifying the path to the Cargo binary. This makes it realistic to use `cargo-raze` in Bazel rules since `cargo-raze` requires a Cargo binary.