### PR TITLE
Add initial bazelci/presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -17,6 +17,3 @@ tasks:
       - "..."
     test_targets:
       - "..."
-
-
-

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,22 @@
+---
+buildifier: latest
+tasks:
+  # TODO(acmcarther): Add check to verify that examples are up-to-date.
+  ubuntu1804:
+    build_targets:
+      - "..."
+    test_targets:
+      - "..."
+  windows:
+    build_targets:
+      - "..."
+    test_targets:
+      - "..."
+  macos:
+    build_targets:
+      - "..."
+    test_targets:
+      - "..."
+
+
+


### PR DESCRIPTION
This PR adds an initial .bazelci/presubmit.yml per onboarding instructions of github.com/bazelbuild/continuous-integration.

We won't be able to sanity check this because we haven't actually been onboarded yet (although a CI run _might_ trigger because I created a pipeline already).