### PR TITLE
Add github actions for cargo-based builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.46.0
+          - 1.45.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -30,6 +30,8 @@ jobs:
       matrix:
         rust:
           - stable
+          # 1.45 triggers bug in parse_raze_settings_any_package
+          # with settings_packages.len() == 0
           - 1.46.0
     steps:
       - uses: actions/checkout@v2
@@ -42,3 +44,47 @@ jobs:
         with:
           command: test
           args: --manifest-path impl/Cargo.toml
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          # The rustfmt.toml appears to use nightly only features
+          - nightly-2021-01-31
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --manifest-path impl/Cargo.toml --all -- --check
+
+  # TODO: enable when clippy lints are fixed.  There's enough that
+  # it didn't make sense to change all of them right now.
+  # clippy:
+  #   name: Clippy
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       rust:
+  #         - stable
+  #         - 1.45.0
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: minimal
+  #         toolchain: ${{ matrix.rust }}
+  #         override: true
+  #     - run: rustup component add clippy
+  #     - uses: actions-rs/cargo@v1
+  #       with:
+  #         command: clippy
+  #         args: --manifest-path impl/Cargo.toml -- -D warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,44 @@
+on: [push, pull_request]
+
+name: CI
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - 1.46.0
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path impl/Cargo.toml
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - 1.46.0
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path impl/Cargo.toml

--- a/impl/src/bin/cargo-raze.rs
+++ b/impl/src/bin/cargo-raze.rs
@@ -149,7 +149,10 @@ fn fetch_local_metadata(options: &Options) -> Result<Metadata> {
   let working_directory = if let Some(manifest_path) = &options.flag_manifest_path {
     let manifest_path = PathBuf::from(manifest_path).canonicalize()?;
     if !manifest_path.is_file() {
-      return Err(anyhow!("manifest path `{}` is not a file.", manifest_path.display()));
+      return Err(anyhow!(
+        "manifest path `{}` is not a file.",
+        manifest_path.display()
+      ));
     }
     // UNWRAP: Unwrap safe due to check above.
     PathBuf::from(manifest_path.parent().unwrap())

--- a/impl/src/planning.rs
+++ b/impl/src/planning.rs
@@ -130,10 +130,14 @@ mod tests {
 
   #[test]
   fn test_plan_build_minimum_workspace_dependency() {
-    let planned_build_res =
-      BuildPlannerImpl::new(template_raze_metadata(templates::DUMMY_MODIFIED_METADATA), dummy_raze_settings()).plan_build(Some(
-        PlatformDetails::new("some_target_triple".to_owned(), Vec::new() /* attrs */),
-      ));
+    let planned_build_res = BuildPlannerImpl::new(
+      template_raze_metadata(templates::DUMMY_MODIFIED_METADATA),
+      dummy_raze_settings(),
+    )
+    .plan_build(Some(PlatformDetails::new(
+      "some_target_triple".to_owned(),
+      Vec::new(), /* attrs */
+    )));
 
     let planned_build = planned_build_res.unwrap();
     assert_eq!(planned_build.crate_contexts.len(), 1);
@@ -255,7 +259,10 @@ mod tests {
       krate_context.default_deps.aliased_dependencies[0].target,
       "@raze_test__log__0_3_9//:log"
     );
-    assert_eq!(krate_context.default_deps.aliased_dependencies[0].alias, "old_log");
+    assert_eq!(
+      krate_context.default_deps.aliased_dependencies[0].alias,
+      "old_log"
+    );
   }
   #[test]
   fn test_plan_build_produces_proc_macro_dependencies() {
@@ -302,9 +309,7 @@ mod tests {
     settings.genmode = GenMode::Remote;
 
     let planner = BuildPlannerImpl::new(
-      dummy_workspace_crate_metadata(
-        templates::PLAN_BUILD_PRODUCES_BUILD_PROC_MACRO_DEPENDENCIES,
-      ),
+      dummy_workspace_crate_metadata(templates::PLAN_BUILD_PRODUCES_BUILD_PROC_MACRO_DEPENDENCIES),
       settings,
     );
     let planned_build = planner
@@ -340,9 +345,7 @@ mod tests {
   #[test]
   fn test_subplan_produces_crate_root_with_forward_slash() {
     let planner = BuildPlannerImpl::new(
-      dummy_workspace_crate_metadata(
-        templates::SUBPLAN_PRODUCES_CRATE_ROOT_WITH_FORWARD_SLASH,
-      ),
+      dummy_workspace_crate_metadata(templates::SUBPLAN_PRODUCES_CRATE_ROOT_WITH_FORWARD_SLASH),
       dummy_raze_settings(),
     );
     let planned_build = planner

--- a/impl/src/testing.rs
+++ b/impl/src/testing.rs
@@ -37,14 +37,19 @@ use crate::{
 /// A module containing constants for each metadata template
 pub mod templates {
   pub const BASIC_METADATA: &str = "basic_metadata.json.template";
-  pub const DUMMY_BINARY_DEPENDENCY_REMOTE: &str =  "dummy_binary_dependency_remote.json.template";
-  pub const DUMMY_MODIFIED_METADATA: &str =  "dummy_modified_metadata.json.template";
-  pub const DUMMY_WORKSPACE_MEMBERS_METADATA: &str =  "dummy_workspace_members_metadata.json.template";
-  pub const PLAN_BUILD_PRODUCES_ALIASED_DEPENDENCIES: &str =  "plan_build_produces_aliased_dependencies.json.template";
-  pub const PLAN_BUILD_PRODUCES_BUILD_PROC_MACRO_DEPENDENCIES: &str =  "plan_build_produces_build_proc_macro_dependencies.json.template";
-  pub const PLAN_BUILD_PRODUCES_PROC_MACRO_DEPENDENCIES: &str =  "plan_build_produces_proc_macro_dependencies.json.template";
-  pub const SEMVER_MATCHING: &str =  "semver_matching.json.template";
-  pub const SUBPLAN_PRODUCES_CRATE_ROOT_WITH_FORWARD_SLASH: &str =  "subplan_produces_crate_root_with_forward_slash.json.template";
+  pub const DUMMY_BINARY_DEPENDENCY_REMOTE: &str = "dummy_binary_dependency_remote.json.template";
+  pub const DUMMY_MODIFIED_METADATA: &str = "dummy_modified_metadata.json.template";
+  pub const DUMMY_WORKSPACE_MEMBERS_METADATA: &str =
+    "dummy_workspace_members_metadata.json.template";
+  pub const PLAN_BUILD_PRODUCES_ALIASED_DEPENDENCIES: &str =
+    "plan_build_produces_aliased_dependencies.json.template";
+  pub const PLAN_BUILD_PRODUCES_BUILD_PROC_MACRO_DEPENDENCIES: &str =
+    "plan_build_produces_build_proc_macro_dependencies.json.template";
+  pub const PLAN_BUILD_PRODUCES_PROC_MACRO_DEPENDENCIES: &str =
+    "plan_build_produces_proc_macro_dependencies.json.template";
+  pub const SEMVER_MATCHING: &str = "semver_matching.json.template";
+  pub const SUBPLAN_PRODUCES_CRATE_ROOT_WITH_FORWARD_SLASH: &str =
+    "subplan_produces_crate_root_with_forward_slash.json.template";
 }
 
 pub const fn basic_toml_contents() -> &'static str {
@@ -300,14 +305,14 @@ pub fn mock_crate_index(
 /// Generate RazeMetadata from a cargo metadata template
 pub fn template_raze_metadata(template_path: &str) -> RazeMetadata {
   let dir = make_basic_workspace();
-    let (mut fetcher, _server, _index_dir) = dummy_raze_metadata_fetcher();
+  let (mut fetcher, _server, _index_dir) = dummy_raze_metadata_fetcher();
 
-    // Always render basic metadata
-    fetcher.set_metadata_fetcher(Box::new(DummyCargoMetadataFetcher {
-      metadata_template: Some(template_path.to_string()),
-    }));
+  // Always render basic metadata
+  fetcher.set_metadata_fetcher(Box::new(DummyCargoMetadataFetcher {
+    metadata_template: Some(template_path.to_string()),
+  }));
 
-    fetcher.fetch_metadata(dir.as_ref(), None, None).unwrap()
+  fetcher.fetch_metadata(dir.as_ref(), None, None).unwrap()
 }
 
 /// Load a cargo metadata template


### PR DESCRIPTION
I don't have a lot of familiarity with bazelci, so I'm not sure how much I can help on that front.  My team uses github actions so I'm a little more familiar with that.

This PR puts together a basic version of a cargo-only version of the CI.  It's based off of the [MRSV example](https://github.com/actions-rs/meta/blob/master/recipes/msrv.md) from the actions-rs project.  I might have a chance to look at bazel-based builds later on, but perhaps this will unblock some things.

Perhaps there was something I didn't completely understand on the rustfmt options, but it seems like there were some formatting regressions that I fixed in a separate commit in the stack.