### PR TITLE
Fix clippy lints and enable clippy in CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,25 +66,23 @@ jobs:
           command: fmt
           args: --manifest-path impl/Cargo.toml --all -- --check
 
-  # TODO: enable when clippy lints are fixed.  There's enough that
-  # it didn't make sense to change all of them right now.
-  # clippy:
-  #   name: Clippy
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       rust:
-  #         - stable
-  #         - 1.45.0
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: ${{ matrix.rust }}
-  #         override: true
-  #     - run: rustup component add clippy
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         command: clippy
-  #         args: --manifest-path impl/Cargo.toml -- -D warnings
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - 1.45.0
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path impl/Cargo.toml -- -D warnings

--- a/impl/src/bin/cargo-raze.rs
+++ b/impl/src/bin/cargo-raze.rs
@@ -196,7 +196,7 @@ fn fetch_raze_metadata(
   let reused_lockfile = if !options.flag_generate_lockfile.unwrap_or(false) {
     find_lockfile(
       &local_metadata.workspace_root,
-      &cargo_raze_working_dir.join(settings.workspace_path.trim_start_matches("/")),
+      &cargo_raze_working_dir.join(settings.workspace_path.trim_start_matches('/')),
     )
   } else {
     None
@@ -233,7 +233,7 @@ fn render_files(
   let mut bazel_renderer = BazelRenderer::new();
   let render_details = RenderDetails {
     cargo_root: metadata.cargo_workspace_root.clone(),
-    path_prefix: PathBuf::from(&settings.workspace_path.trim_start_matches("/")),
+    path_prefix: PathBuf::from(&settings.workspace_path.trim_start_matches('/')),
     package_aliases_dir: settings.package_aliases_dir.clone(),
     vendored_buildfile_name: settings.output_buildfile_suffix.clone(),
     bazel_root: cargo_raze_working_dir,
@@ -254,12 +254,12 @@ fn render_files(
 }
 
 fn write_files(
-  bazel_file_outputs: &Vec<FileOutputs>,
+  bazel_file_outputs: &[FileOutputs],
   render_details: &RenderDetails,
   settings: &RazeSettings,
   options: &Options,
 ) -> Result<()> {
-  if &settings.genmode == &GenMode::Remote {
+  if settings.genmode == GenMode::Remote {
     let remote_dir = render_details
       .bazel_root
       .join(&render_details.path_prefix)

--- a/impl/src/checks.rs
+++ b/impl/src/checks.rs
@@ -15,7 +15,6 @@
 use std::{
   collections::{HashMap, HashSet},
   fs,
-  iter::FromIterator,
   path::Path,
   path::PathBuf,
 };
@@ -238,7 +237,7 @@ fn warn_unused_settings(
     .iter()
     .map(|pkg| &pkg.name)
     .collect::<HashSet<_>>();
-  let setting_names = HashSet::from_iter(all_crate_settings.keys());
+  let setting_names: HashSet<_> = all_crate_settings.keys().collect();
   for missing in setting_names.difference(&pkg_names) {
     eprintln!("Found unused raze crate settings for `{}`", missing);
   }

--- a/impl/src/planning/license.rs
+++ b/impl/src/planning/license.rs
@@ -119,7 +119,7 @@ impl BazelSpdxLicense {
 
 /// Breaks apart a cargo license string and yields the available license types.
 pub fn get_license_from_str(cargo_license_str: &str) -> LicenseData {
-  if cargo_license_str.len() == 0 {
+  if cargo_license_str.is_empty() {
     return LicenseData::default();
   }
 

--- a/impl/src/planning/subplanners.rs
+++ b/impl/src/planning/subplanners.rs
@@ -189,7 +189,7 @@ impl<'planner> WorkspaceSubplanner<'planner> {
       crate_catalog_entry: &own_crate_catalog_entry,
       source_id: &own_source_id,
       node: &node,
-      crate_settings: crate_settings,
+      crate_settings,
       sha256: &checksum_opt.map(|c| c.to_owned()),
     };
 
@@ -293,7 +293,7 @@ impl<'planner> CrateSubplanner<'planner> {
           .unwrap_or(&Vec::<String>::new()),
       );
 
-      if target_triples.len() == 0 {
+      if target_triples.is_empty() {
         continue;
       }
 
@@ -341,11 +341,13 @@ impl<'planner> CrateSubplanner<'planner> {
           &member.manifest_path,
           &self.crate_catalog.metadata.workspace_root,
         )
-        .ok_or(anyhow!(
-          "Failed to generate workspace_member_path for {} and {}",
-          &package.manifest_path.display(),
-          &self.crate_catalog.metadata.workspace_root.display()
-        ))?;
+        .ok_or_else(|| {
+          anyhow!(
+            "Failed to generate workspace_member_path for {} and {}",
+            &package.manifest_path.display(),
+            &self.crate_catalog.metadata.workspace_root.display()
+          )
+        })?;
 
         match current_dependency.kind {
           DependencyKind::Development => {
@@ -389,8 +391,8 @@ impl<'planner> CrateSubplanner<'planner> {
       features: self.node.features.clone(),
       workspace_member_dependents,
       workspace_member_dev_dependents,
-      is_workspace_member_dependency: is_workspace_member_dependency,
-      is_binary_dependency: is_binary_dependency,
+      is_workspace_member_dependency,
+      is_binary_dependency,
       is_proc_macro,
       default_deps: CrateDependencyContext {
         dependencies: normal_deps,
@@ -716,14 +718,16 @@ impl<'planner> CrateSubplanner<'planner> {
         .components()
         .map(|c| c.as_os_str().to_str())
         .try_fold("".to_owned(), |res, v| Some(format!("{}/{}", res, v?)))
-        .ok_or(io::Error::new(
-          io::ErrorKind::InvalidData,
-          format!(
-            "{:?} contains non UTF-8 characters and is not a legal path in Bazel",
-            &target.src_path
-          ),
-        ))?
-        .trim_start_matches("/")
+        .ok_or_else(|| {
+          io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+              "{:?} contains non UTF-8 characters and is not a legal path in Bazel",
+              &target.src_path
+            ),
+          )
+        })?
+        .trim_start_matches('/')
         .to_owned();
 
       for kind in &target.kind {

--- a/impl/src/rendering/bazel.rs
+++ b/impl/src/rendering/bazel.rs
@@ -236,7 +236,7 @@ impl BazelRenderer {
       let is_root_workspace_member = member_path
         .to_str()
         // Root workspace paths will are represented by an exmpty string
-        .and_then(|member_path| Some(member_path.is_empty()))
+        .map(|member_path| member_path.is_empty())
         .unwrap_or(false);
       if is_root_workspace_member {
         // In remote genmode, a `crates.bzl` file will always be rendered. For
@@ -262,7 +262,7 @@ impl BazelRenderer {
   fn render_crates_bzl_package_file(
     &self,
     path_prefix: &Path,
-    file_outputs: &Vec<FileOutputs>,
+    file_outputs: &[FileOutputs],
   ) -> Result<Option<FileOutputs>> {
     let crates_bzl_pkg_file = path_prefix.join("BUILD.bazel");
     let outputs_contain_crates_bzl_build_file = file_outputs


### PR DESCRIPTION
Most of these are efficiency clean-ups, by replacing modifications with
_else, so that error path is evaluated lazily.  Clippy is somewhat
opinionated, so this does end up adjusting some conventions.  However,
on the whole, blindly accepting it as a linter is probably a win for the
project.