### PR TITLE
Fixed windows bug in examples repository rule

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -2,6 +2,7 @@ package(default_visibility = ["//:__subpackages__"])
 
 exports_files([
     "examples_repository_tools.sh",
+    "examples_repository_tools.bat",
 ])
 
 sh_binary(

--- a/tools/examples_repository.bzl
+++ b/tools/examples_repository.bzl
@@ -12,8 +12,8 @@ def _examples_dir(repository_ctx):
     Returns:
         path: A path to the cargo-raze workspace root
     """
-    workspace_root = repository_ctx.path(repository_ctx.attr._script).dirname.dirname
-    return repository_ctx.path(str(workspace_root) + "/" + repository_ctx.attr._examples_dir.lstrip("/"))
+    examples_cargo_raze_root = repository_ctx.path(repository_ctx.attr._script).dirname.dirname
+    return repository_ctx.path(str(examples_cargo_raze_root) + "/examples")
 
 EXECUTE_FAIL_MESSAGE = """\
 Failed to setup examples repository with exit code ({}).
@@ -31,7 +31,6 @@ def _examples_repository_impl(repository_ctx):
     """
 
     examples_dir = _examples_dir(repository_ctx)
-    vendor_script = repository_ctx.attr._script
 
     if repository_ctx.attr.target_triple:
         target_triple = repository_ctx.attr.target_triple
@@ -59,17 +58,29 @@ def _examples_repository_impl(repository_ctx):
             continue
         repository_ctx.symlink(item, item.basename)
 
-    # Vendor sources
-    results = repository_ctx.execute(
-        [
+    if "windows" in repository_ctx.os.name:
+        vendor_script = repository_ctx.path(repository_ctx.attr._script_windows)
+        command = [vendor_script]
+        environment = {
+            "CARGO": "{}/bin/cargo".format(repository_ctx.path(".")).replace("/", "\\"),
+            "EXAMPLES_DIR": str(examples_dir).replace("/", "\\"),
+        }
+    else:
+        vendor_script = repository_ctx.path(repository_ctx.attr._script)
+        command = [
             vendor_script,
             "vendor",
-        ],
-        quiet = True,
+        ]
         environment = {
-            "EXAMPLES_DIR": str(examples_dir),
             "CARGO": "{}/bin/cargo".format(repository_ctx.path(".")),
-        },
+            "EXAMPLES_DIR": str(examples_dir),
+        }
+
+    # Vendor sources
+    repository_ctx.report_progress("Vendoring example sources")
+    results = repository_ctx.execute(
+        command,
+        environment = environment,
     )
 
     if results.return_code != 0:
@@ -90,13 +101,17 @@ _examples_repository = repository_rule(
         "target_triple": attr.string(
             doc = "The target triple of the cargo binary to download",
         ),
-        "_examples_dir": attr.string(
-            doc = "The path to the examples directory relative to `_root_file",
-            default = "examples",
-        ),
         "_script": attr.label(
-            doc = "A script containing the ability to vendor crates into examples",
-            default = Label("@cargo_raze//tools:examples_repository_tools.sh"),
+            doc = (
+                "A script containing the ability to vendor crates into examples. " +
+                "This script is also used to detect the path of the examples."
+            ),
+            default = Label("//tools:examples_repository_tools.sh"),
+            allow_single_file = True,
+        ),
+        "_script_windows": attr.label(
+            doc = "The windows equivilant of `_script`",
+            default = Label("//tools:examples_repository_tools.bat"),
             allow_single_file = True,
         ),
     },

--- a/tools/examples_repository_tools.bat
+++ b/tools/examples_repository_tools.bat
@@ -1,0 +1,39 @@
+@ECHO OFF
+setlocal ENABLEDELAYEDEXPANSION
+:: Windows only supports vendoring
+
+for /D %%i in (%EXAMPLES_DIR%\vendored\*) do (
+    echo Vendoring Sources for %%i
+
+    :: Make a temporary directory to save existing BUILD files into
+    echo Making temp dir
+    rmdir /Q /S %%i\.temp
+    mkdir %%i\.temp
+
+    :: Save BUILD files
+    echo Saving BUILD files
+    pushd %%i\cargo\vendor
+    for /D %%s in (*) do (
+        echo Saving %%s\BUILD.bazel to %%i\.temp\%%s\BUILD.bazel
+        mkdir "%%i\.temp\%%s"
+        copy /v /y /b "%%s\BUILD.bazel" "%%i\.temp\%%s\BUILD.bazel"
+    )
+    popd
+
+    :: Do vendoring
+    echo Vendoring
+    START /b /d %%i /wait %CARGO% vendor -q --versioned-dirs cargo\vendor
+
+    :: Restore BUILD files
+    echo Restoring BUILD files
+    pushd %%i\.temp
+    for /D %%r in (*) do (
+        echo Restoring %%r\BUILD.bazel to %%i\cargo\vendor\%%r\BUILD.bazel
+        copy /v /y /b "%%r\BUILD.bazel" "%%i\cargo\vendor\%%r\BUILD.bazel"
+    )
+    popd
+
+    :: Cleanup
+    rmdir /Q /S %%i\.temp
+    echo Done
+)


### PR DESCRIPTION
This fixes vendoring examples source on windows machines. I found out that just because `bash` exists on a Windows host (namely on a BuildKite Windows worker), doesn't mean the programs are the same. The issue I ran into was `FIND: Parameter format not correct` and this is because the `find` program on a unix host is not the same on windows. Thus the bash script would not have worked as is. I decided to write my first ever batch script.