### PR TITLE
Updated buildifier annotations 

### DIFF
--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.addr2line-0.14.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.addr2line-0.14.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.addr2line-0.14.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.addr2line-0.14.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.adler-0.2.3.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.adler-0.2.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.adler-0.2.3.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.adler-0.2.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.adler32-1.2.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.adler32-1.2.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.adler32-1.2.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.adler32-1.2.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.ansi_term-0.11.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.ansi_term-0.11.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.ansi_term-0.11.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.ansi_term-0.11.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.atty-0.2.14.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.atty-0.2.14.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.atty-0.2.14.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.atty-0.2.14.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.autocfg-1.0.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.autocfg-1.0.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.autocfg-1.0.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.autocfg-1.0.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.backtrace-0.3.54.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.backtrace-0.3.54.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.backtrace-0.3.54.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.backtrace-0.3.54.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.bitflags-1.2.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.bitflags-1.2.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.bitflags-1.2.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.bitflags-1.2.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.bytemuck-1.4.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.bytemuck-1.4.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.bytemuck-1.4.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.bytemuck-1.4.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.byteorder-1.3.4.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.byteorder-1.3.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.byteorder-1.3.4.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.byteorder-1.3.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.cfg-if-0.1.10.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.cfg-if-0.1.10.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.cfg-if-0.1.10.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.cfg-if-0.1.10.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.cfg-if-1.0.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.cfg-if-1.0.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.cfg-if-1.0.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.cfg-if-1.0.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.clap-2.33.3.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.clap-2.33.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.clap-2.33.3.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.clap-2.33.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.console-0.13.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.console-0.13.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.console-0.13.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.console-0.13.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.crc32fast-1.2.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.crc32fast-1.2.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.crc32fast-1.2.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.crc32fast-1.2.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.crossbeam-utils-0.7.2.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.crossbeam-utils-0.7.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.crossbeam-utils-0.7.2.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.crossbeam-utils-0.7.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.deflate-0.8.6.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.deflate-0.8.6.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.deflate-0.8.6.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.deflate-0.8.6.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.encode_unicode-0.3.6.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.encode_unicode-0.3.6.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.encode_unicode-0.3.6.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.encode_unicode-0.3.6.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.error-chain-0.10.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.error-chain-0.10.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.error-chain-0.10.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.error-chain-0.10.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.ferris-says-0.2.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.ferris-says-0.2.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.ferris-says-0.2.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.ferris-says-0.2.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.gimli-0.23.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.gimli-0.23.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.gimli-0.23.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.gimli-0.23.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.heck-0.3.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.heck-0.3.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.heck-0.3.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.heck-0.3.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.hermit-abi-0.1.17.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.hermit-abi-0.1.17.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.hermit-abi-0.1.17.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.hermit-abi-0.1.17.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.image-0.23.10.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.image-0.23.10.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.image-0.23.10.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.image-0.23.10.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.indicatif-0.14.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.indicatif-0.14.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.indicatif-0.14.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.indicatif-0.14.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.jpeg-decoder-0.1.20.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.jpeg-decoder-0.1.20.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.jpeg-decoder-0.1.20.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.jpeg-decoder-0.1.20.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.lazy_static-1.4.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.lazy_static-1.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.lazy_static-1.4.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.lazy_static-1.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.libc-0.2.80.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.libc-0.2.80.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.libc-0.2.80.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.libc-0.2.80.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.miniz_oxide-0.3.7.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.miniz_oxide-0.3.7.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.miniz_oxide-0.3.7.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.miniz_oxide-0.3.7.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num-integer-0.1.44.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num-integer-0.1.44.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num-integer-0.1.44.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num-integer-0.1.44.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num-iter-0.1.42.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num-iter-0.1.42.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num-iter-0.1.42.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num-iter-0.1.42.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num-rational-0.3.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num-rational-0.3.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num-rational-0.3.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num-rational-0.3.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num-traits-0.2.14.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num-traits-0.2.14.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num-traits-0.2.14.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num-traits-0.2.14.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num_cpus-1.13.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num_cpus-1.13.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.num_cpus-1.13.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.num_cpus-1.13.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.number_prefix-0.3.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.number_prefix-0.3.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.number_prefix-0.3.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.number_prefix-0.3.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.object-0.22.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.object-0.22.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.object-0.22.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.object-0.22.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.pdqselect-0.1.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.pdqselect-0.1.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.pdqselect-0.1.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.pdqselect-0.1.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.png-0.16.7.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.png-0.16.7.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.png-0.16.7.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.png-0.16.7.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.ppv-lite86-0.2.9.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.ppv-lite86-0.2.9.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.ppv-lite86-0.2.9.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.ppv-lite86-0.2.9.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro-error-1.0.4.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro-error-1.0.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro-error-1.0.4.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro-error-1.0.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro-error-attr-1.0.4.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro-error-attr-1.0.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro-error-attr-1.0.4.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro-error-attr-1.0.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro2-1.0.24.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro2-1.0.24.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro2-1.0.24.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.proc-macro2-1.0.24.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.quote-1.0.7.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.quote-1.0.7.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.quote-1.0.7.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.quote-1.0.7.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rand-0.7.3.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rand-0.7.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rand-0.7.3.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rand-0.7.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_chacha-0.2.2.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_chacha-0.2.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_chacha-0.2.2.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_chacha-0.2.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_core-0.5.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_core-0.5.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_core-0.5.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_core-0.5.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_hc-0.2.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_hc-0.2.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_hc-0.2.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_hc-0.2.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_pcg-0.2.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_pcg-0.2.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_pcg-0.2.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rand_pcg-0.2.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.regex-1.4.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.regex-1.4.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.regex-1.4.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.regex-1.4.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.regex-syntax-0.6.20.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.regex-syntax-0.6.20.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.regex-syntax-0.6.20.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.regex-syntax-0.6.20.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rstar-0.7.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rstar-0.7.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rstar-0.7.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rstar-0.7.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rustc-demangle-0.1.18.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rustc-demangle-0.1.18.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.rustc-demangle-0.1.18.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.rustc-demangle-0.1.18.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.smallvec-0.4.5.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.smallvec-0.4.5.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.smallvec-0.4.5.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.smallvec-0.4.5.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.strsim-0.8.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.strsim-0.8.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.strsim-0.8.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.strsim-0.8.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.structopt-0.3.20.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.structopt-0.3.20.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.structopt-0.3.20.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.structopt-0.3.20.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.structopt-derive-0.4.13.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.structopt-derive-0.4.13.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.structopt-derive-0.4.13.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.structopt-derive-0.4.13.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.syn-1.0.48.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.syn-1.0.48.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.syn-1.0.48.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.syn-1.0.48.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.terminal_size-0.1.13.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.terminal_size-0.1.13.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.terminal_size-0.1.13.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.terminal_size-0.1.13.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.texture-synthesis-0.8.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.texture-synthesis-0.8.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.texture-synthesis-0.8.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.texture-synthesis-0.8.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.texture-synthesis-cli-0.8.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.texture-synthesis-cli-0.8.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.texture-synthesis-cli-0.8.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.texture-synthesis-cli-0.8.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.textwrap-0.11.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.textwrap-0.11.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.textwrap-0.11.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.textwrap-0.11.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.unicode-segmentation-1.6.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.unicode-segmentation-1.6.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.unicode-segmentation-1.6.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.unicode-segmentation-1.6.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.unicode-width-0.1.8.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.unicode-width-0.1.8.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.unicode-width-0.1.8.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.unicode-width-0.1.8.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.unicode-xid-0.2.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.unicode-xid-0.2.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.unicode-xid-0.2.1.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.unicode-xid-0.2.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.vec_map-0.8.2.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.vec_map-0.8.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.vec_map-0.8.2.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.vec_map-0.8.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.version_check-0.9.2.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.version_check-0.9.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.version_check-0.9.2.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.version_check-0.9.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-util-0.1.5.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-util-0.1.5.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-util-0.1.5.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-util-0.1.5.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.addr2line-0.13.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.addr2line-0.13.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.addr2line-0.13.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.addr2line-0.13.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.adler-0.2.3.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.adler-0.2.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.adler-0.2.3.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.adler-0.2.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.ansi_term-0.11.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.ansi_term-0.11.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.ansi_term-0.11.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.ansi_term-0.11.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.atty-0.2.14.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.atty-0.2.14.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.atty-0.2.14.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.atty-0.2.14.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.autocfg-1.0.1.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.autocfg-1.0.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.autocfg-1.0.1.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.autocfg-1.0.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.backtrace-0.3.53.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.backtrace-0.3.53.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.backtrace-0.3.53.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.backtrace-0.3.53.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.bitflags-1.2.1.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.bitflags-1.2.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.bitflags-1.2.1.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.bitflags-1.2.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.cfg-if-0.1.10.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.cfg-if-0.1.10.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.cfg-if-0.1.10.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.cfg-if-0.1.10.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.cfg-if-1.0.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.cfg-if-1.0.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.cfg-if-1.0.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.cfg-if-1.0.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.clap-2.33.3.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.clap-2.33.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.clap-2.33.3.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.clap-2.33.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.error-chain-0.10.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.error-chain-0.10.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.error-chain-0.10.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.error-chain-0.10.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.ferris-says-0.2.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.ferris-says-0.2.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.ferris-says-0.2.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.ferris-says-0.2.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.getrandom-0.1.15.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.getrandom-0.1.15.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.getrandom-0.1.15.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.getrandom-0.1.15.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.gimli-0.22.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.gimli-0.22.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.gimli-0.22.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.gimli-0.22.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.hermit-abi-0.1.17.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.hermit-abi-0.1.17.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.hermit-abi-0.1.17.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.hermit-abi-0.1.17.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.libc-0.2.79.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.libc-0.2.79.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.libc-0.2.79.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.libc-0.2.79.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.object-0.21.1.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.object-0.21.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.object-0.21.1.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.object-0.21.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.ppv-lite86-0.2.9.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.ppv-lite86-0.2.9.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.ppv-lite86-0.2.9.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.ppv-lite86-0.2.9.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.rand-0.7.3.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.rand-0.7.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.rand-0.7.3.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.rand-0.7.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.rand_chacha-0.2.2.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.rand_chacha-0.2.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.rand_chacha-0.2.2.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.rand_chacha-0.2.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.rand_core-0.5.1.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.rand_core-0.5.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.rand_core-0.5.1.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.rand_core-0.5.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.rand_hc-0.2.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.rand_hc-0.2.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.rand_hc-0.2.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.rand_hc-0.2.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.rustc-demangle-0.1.17.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.rustc-demangle-0.1.17.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.rustc-demangle-0.1.17.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.rustc-demangle-0.1.17.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.smallvec-0.4.5.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.smallvec-0.4.5.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.smallvec-0.4.5.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.smallvec-0.4.5.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.strsim-0.8.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.strsim-0.8.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.strsim-0.8.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.strsim-0.8.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.textwrap-0.11.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.textwrap-0.11.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.textwrap-0.11.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.textwrap-0.11.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.unicode-width-0.1.8.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.unicode-width-0.1.8.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.unicode-width-0.1.8.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.unicode-width-0.1.8.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.vec_map-0.8.2.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.vec_map-0.8.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.vec_map-0.8.2.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.vec_map-0.8.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.wasi-0.9.0+wasi-snapshot-preview1.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.wasi-0.9.0+wasi-snapshot-preview1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.wasi-0.9.0+wasi-snapshot-preview1.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.wasi-0.9.0+wasi-snapshot-preview1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.MacTypes-sys-1.3.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.MacTypes-sys-1.3.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.MacTypes-sys-1.3.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.MacTypes-sys-1.3.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.aho-corasick-0.6.10.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.aho-corasick-0.6.10.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.aho-corasick-0.6.10.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.aho-corasick-0.6.10.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.arrayvec-0.3.25.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.arrayvec-0.3.25.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.arrayvec-0.3.25.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.arrayvec-0.3.25.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.atom-0.3.5.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.atom-0.3.5.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.atom-0.3.5.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.atom-0.3.5.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.autocfg-1.0.1.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.autocfg-1.0.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.autocfg-1.0.1.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.autocfg-1.0.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.cc-1.0.60.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.cc-1.0.60.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.cc-1.0.60.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.cc-1.0.60.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.cfg-if-0.1.10.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.cfg-if-0.1.10.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.cfg-if-0.1.10.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.cfg-if-0.1.10.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.core-foundation-sys-0.5.1.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.core-foundation-sys-0.5.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.core-foundation-sys-0.5.1.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.core-foundation-sys-0.5.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-0.3.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-0.3.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-0.3.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-0.3.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-channel-0.4.4.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-channel-0.4.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-channel-0.4.4.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-channel-0.4.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-deque-0.7.3.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-deque-0.7.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-deque-0.7.3.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-deque-0.7.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-epoch-0.8.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-epoch-0.8.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-epoch-0.8.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-epoch-0.8.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-utils-0.7.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-utils-0.7.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-utils-0.7.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.crossbeam-utils-0.7.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.derivative-1.0.4.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.derivative-1.0.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.derivative-1.0.4.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.derivative-1.0.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.fnv-1.0.7.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.fnv-1.0.7.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.fnv-1.0.7.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.fnv-1.0.7.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.hermit-abi-0.1.15.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.hermit-abi-0.1.15.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.hermit-abi-0.1.15.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.hermit-abi-0.1.15.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.hibitset-0.3.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.hibitset-0.3.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.hibitset-0.3.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.hibitset-0.3.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.lazy_static-1.4.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.lazy_static-1.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.lazy_static-1.4.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.lazy_static-1.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.libc-0.2.77.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.libc-0.2.77.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.libc-0.2.77.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.libc-0.2.77.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.libloading-0.5.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.libloading-0.5.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.libloading-0.5.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.libloading-0.5.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.maybe-uninit-2.0.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.maybe-uninit-2.0.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.maybe-uninit-2.0.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.maybe-uninit-2.0.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.memchr-2.3.3.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.memchr-2.3.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.memchr-2.3.3.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.memchr-2.3.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.memoffset-0.5.5.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.memoffset-0.5.5.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.memoffset-0.5.5.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.memoffset-0.5.5.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.mopa-0.2.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.mopa-0.2.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.mopa-0.2.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.mopa-0.2.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.nodrop-0.1.14.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.nodrop-0.1.14.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.nodrop-0.1.14.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.nodrop-0.1.14.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.num_cpus-1.13.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.num_cpus-1.13.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.num_cpus-1.13.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.num_cpus-1.13.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.odds-0.2.26.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.odds-0.2.26.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.odds-0.2.26.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.odds-0.2.26.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.proc-macro2-0.4.30.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.proc-macro2-0.4.30.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.proc-macro2-0.4.30.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.proc-macro2-0.4.30.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.pulse-0.5.3.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.pulse-0.5.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.pulse-0.5.3.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.pulse-0.5.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.quote-0.3.15.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.quote-0.3.15.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.quote-0.3.15.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.quote-0.3.15.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.quote-0.6.13.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.quote-0.6.13.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.quote-0.6.13.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.quote-0.6.13.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.rayon-0.8.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.rayon-0.8.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.rayon-0.8.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.rayon-0.8.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.rayon-core-1.8.1.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.rayon-core-1.8.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.rayon-core-1.8.1.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.rayon-core-1.8.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.regex-0.2.5.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.regex-0.2.5.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.regex-0.2.5.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.regex-0.2.5.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.regex-syntax-0.4.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.regex-syntax-0.4.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.regex-syntax-0.4.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.regex-syntax-0.4.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.scopeguard-1.1.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.scopeguard-1.1.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.scopeguard-1.1.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.scopeguard-1.1.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.security-framework-sys-0.2.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.security-framework-sys-0.2.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.security-framework-sys-0.2.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.security-framework-sys-0.2.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.shred-0.5.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.shred-0.5.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.shred-0.5.2.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.shred-0.5.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.shred-derive-0.3.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.shred-derive-0.3.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.shred-derive-0.3.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.shred-derive-0.3.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.smallvec-0.4.5.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.smallvec-0.4.5.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.smallvec-0.4.5.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.smallvec-0.4.5.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.specs-0.10.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.specs-0.10.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.specs-0.10.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.specs-0.10.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.syn-0.11.11.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.syn-0.11.11.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.syn-0.11.11.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.syn-0.11.11.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.syn-0.15.44.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.syn-0.15.44.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.syn-0.15.44.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.syn-0.15.44.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.synom-0.11.3.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.synom-0.11.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.synom-0.11.3.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.synom-0.11.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.thread_local-0.3.6.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.thread_local-0.3.6.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.thread_local-0.3.6.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.thread_local-0.3.6.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.time-0.1.44.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.time-0.1.44.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.time-0.1.44.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.time-0.1.44.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.tuple_utils-0.2.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.tuple_utils-0.2.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.tuple_utils-0.2.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.tuple_utils-0.2.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.unicode-xid-0.0.4.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.unicode-xid-0.0.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.unicode-xid-0.0.4.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.unicode-xid-0.0.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.unicode-xid-0.1.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.unicode-xid-0.1.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.unicode-xid-0.1.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.unicode-xid-0.1.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.utf8-ranges-1.0.4.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.utf8-ranges-1.0.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.utf8-ranges-1.0.4.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.utf8-ranges-1.0.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.wasi-0.10.0+wasi-snapshot-preview1.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.wasi-0.10.0+wasi-snapshot-preview1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.wasi-0.10.0+wasi-snapshot-preview1.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.wasi-0.10.0+wasi-snapshot-preview1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.addr2line-0.14.1.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.addr2line-0.14.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.addr2line-0.14.1.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.addr2line-0.14.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.adler-0.2.3.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.adler-0.2.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.adler-0.2.3.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.adler-0.2.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.ansi_term-0.11.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.ansi_term-0.11.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.ansi_term-0.11.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.ansi_term-0.11.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.atty-0.2.14.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.atty-0.2.14.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.atty-0.2.14.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.atty-0.2.14.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.autocfg-1.0.1.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.autocfg-1.0.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.autocfg-1.0.1.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.autocfg-1.0.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.backtrace-0.3.56.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.backtrace-0.3.56.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.backtrace-0.3.56.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.backtrace-0.3.56.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.bitflags-1.2.1.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.bitflags-1.2.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.bitflags-1.2.1.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.bitflags-1.2.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.cfg-if-1.0.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.cfg-if-1.0.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.cfg-if-1.0.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.cfg-if-1.0.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.clap-2.33.3.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.clap-2.33.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.clap-2.33.3.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.clap-2.33.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.error-chain-0.10.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.error-chain-0.10.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.error-chain-0.10.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.error-chain-0.10.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.ferris-says-0.2.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.ferris-says-0.2.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.ferris-says-0.2.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.ferris-says-0.2.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.gimli-0.23.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.gimli-0.23.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.gimli-0.23.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.gimli-0.23.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.hermit-abi-0.1.18.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.hermit-abi-0.1.18.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.hermit-abi-0.1.18.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.hermit-abi-0.1.18.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.indoc-1.0.3.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.indoc-1.0.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.indoc-1.0.3.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.indoc-1.0.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.libc-0.2.85.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.libc-0.2.85.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.libc-0.2.85.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.libc-0.2.85.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.object-0.23.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.object-0.23.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.object-0.23.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.object-0.23.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.rustc-demangle-0.1.18.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.rustc-demangle-0.1.18.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.rustc-demangle-0.1.18.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.rustc-demangle-0.1.18.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.smallvec-0.4.5.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.smallvec-0.4.5.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.smallvec-0.4.5.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.smallvec-0.4.5.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.strsim-0.8.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.strsim-0.8.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.strsim-0.8.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.strsim-0.8.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.textwrap-0.11.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.textwrap-0.11.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.textwrap-0.11.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.textwrap-0.11.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.unicode-width-0.1.8.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.unicode-width-0.1.8.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.unicode-width-0.1.8.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.unicode-width-0.1.8.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.unindent-0.1.7.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.unindent-0.1.7.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.unindent-0.1.7.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.unindent-0.1.7.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.vec_map-0.8.2.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.vec_map-0.8.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.vec_map-0.8.2.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.vec_map-0.8.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.aho-corasick-0.6.10.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.aho-corasick-0.6.10.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.aho-corasick-0.6.10.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.aho-corasick-0.6.10.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.atty-0.2.14.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.atty-0.2.14.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.atty-0.2.14.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.atty-0.2.14.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.bitflags-1.2.1.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.bitflags-1.2.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.bitflags-1.2.1.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.bitflags-1.2.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.cfg-if-0.1.10.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.cfg-if-0.1.10.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.cfg-if-0.1.10.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.cfg-if-0.1.10.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.env_logger-0.5.5.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.env_logger-0.5.5.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.env_logger-0.5.5.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.env_logger-0.5.5.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.fuchsia-zircon-0.3.3.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.fuchsia-zircon-0.3.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.fuchsia-zircon-0.3.3.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.fuchsia-zircon-0.3.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.fuchsia-zircon-sys-0.3.3.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.fuchsia-zircon-sys-0.3.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.fuchsia-zircon-sys-0.3.3.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.fuchsia-zircon-sys-0.3.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.hermit-abi-0.1.15.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.hermit-abi-0.1.15.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.hermit-abi-0.1.15.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.hermit-abi-0.1.15.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.humantime-1.3.0.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.humantime-1.3.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.humantime-1.3.0.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.humantime-1.3.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.lazy_static-1.4.0.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.lazy_static-1.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.lazy_static-1.4.0.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.lazy_static-1.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.libc-0.2.77.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.libc-0.2.77.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.libc-0.2.77.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.libc-0.2.77.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.log-0.4.0.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.log-0.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.log-0.4.0.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.log-0.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.log-0.4.11.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.log-0.4.11.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.log-0.4.11.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.log-0.4.11.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.memchr-2.3.3.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.memchr-2.3.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.memchr-2.3.3.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.memchr-2.3.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.quick-error-1.2.3.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.quick-error-1.2.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.quick-error-1.2.3.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.quick-error-1.2.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.rand-0.4.1.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.rand-0.4.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.rand-0.4.1.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.rand-0.4.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.regex-0.2.11.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.regex-0.2.11.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.regex-0.2.11.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.regex-0.2.11.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.regex-syntax-0.5.6.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.regex-syntax-0.5.6.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.regex-syntax-0.5.6.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.regex-syntax-0.5.6.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.termcolor-0.3.6.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.termcolor-0.3.6.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.termcolor-0.3.6.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.termcolor-0.3.6.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.thread_local-0.3.6.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.thread_local-0.3.6.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.thread_local-0.3.6.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.thread_local-0.3.6.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.ucd-util-0.1.8.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.ucd-util-0.1.8.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.ucd-util-0.1.8.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.ucd-util-0.1.8.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.utf8-ranges-1.0.4.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.utf8-ranges-1.0.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.utf8-ranges-1.0.4.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.utf8-ranges-1.0.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.wincolor-0.1.6.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.wincolor-0.1.6.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.wincolor-0.1.6.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.wincolor-0.1.6.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/addr2line-0.13.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/addr2line-0.13.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/addr2line-0.13.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/addr2line-0.13.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/adler-0.2.3/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/adler-0.2.3/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/adler-0.2.3/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/adler-0.2.3/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/ansi_term-0.11.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/ansi_term-0.11.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/ansi_term-0.11.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/ansi_term-0.11.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/atty-0.2.14/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/atty-0.2.14/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/atty-0.2.14/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/atty-0.2.14/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/autocfg-1.0.1/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/autocfg-1.0.1/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/autocfg-1.0.1/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/autocfg-1.0.1/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/backtrace-0.3.53/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/backtrace-0.3.53/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/backtrace-0.3.53/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/backtrace-0.3.53/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/bitflags-1.2.1/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/bitflags-1.2.1/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/bitflags-1.2.1/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/bitflags-1.2.1/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/vendored/cargo_workspace/cargo/vendor/cfg-if-0.1.10/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/cfg-if-0.1.10/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/cfg-if-0.1.10/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/cfg-if-0.1.10/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/cfg-if-1.0.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/cfg-if-1.0.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/cfg-if-1.0.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/cfg-if-1.0.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/clap-2.33.3/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/clap-2.33.3/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/clap-2.33.3/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/clap-2.33.3/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/error-chain-0.10.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/error-chain-0.10.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/error-chain-0.10.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/error-chain-0.10.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/ferris-says-0.2.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/ferris-says-0.2.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/ferris-says-0.2.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/ferris-says-0.2.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/getrandom-0.1.15/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/getrandom-0.1.15/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/getrandom-0.1.15/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/getrandom-0.1.15/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/vendored/cargo_workspace/cargo/vendor/gimli-0.22.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/gimli-0.22.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/gimli-0.22.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/gimli-0.22.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/hermit-abi-0.1.17/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/hermit-abi-0.1.17/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/hermit-abi-0.1.17/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/hermit-abi-0.1.17/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/libc-0.2.79/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/libc-0.2.79/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/libc-0.2.79/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/libc-0.2.79/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/vendored/cargo_workspace/cargo/vendor/miniz_oxide-0.4.3/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/miniz_oxide-0.4.3/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/miniz_oxide-0.4.3/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/miniz_oxide-0.4.3/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/vendored/cargo_workspace/cargo/vendor/object-0.21.1/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/object-0.21.1/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/object-0.21.1/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/object-0.21.1/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/ppv-lite86-0.2.9/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/ppv-lite86-0.2.9/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/ppv-lite86-0.2.9/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/ppv-lite86-0.2.9/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/rand-0.7.3/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/rand-0.7.3/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/rand-0.7.3/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/rand-0.7.3/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/rand_chacha-0.2.2/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/rand_chacha-0.2.2/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/rand_chacha-0.2.2/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/rand_chacha-0.2.2/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/rand_core-0.5.1/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/rand_core-0.5.1/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/rand_core-0.5.1/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/rand_core-0.5.1/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/rand_hc-0.2.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/rand_hc-0.2.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/rand_hc-0.2.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/rand_hc-0.2.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/rustc-demangle-0.1.17/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/rustc-demangle-0.1.17/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/rustc-demangle-0.1.17/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/rustc-demangle-0.1.17/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/smallvec-0.4.5/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/smallvec-0.4.5/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/smallvec-0.4.5/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/smallvec-0.4.5/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/strsim-0.8.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/strsim-0.8.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/strsim-0.8.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/strsim-0.8.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/textwrap-0.11.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/textwrap-0.11.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/textwrap-0.11.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/textwrap-0.11.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/unicode-width-0.1.8/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/unicode-width-0.1.8/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/unicode-width-0.1.8/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/unicode-width-0.1.8/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/vec_map-0.8.2/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/vec_map-0.8.2/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/vec_map-0.8.2/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/vec_map-0.8.2/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/wasi-0.9.0+wasi-snapshot-preview1/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/wasi-0.9.0+wasi-snapshot-preview1/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/wasi-0.9.0+wasi-snapshot-preview1/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/wasi-0.9.0+wasi-snapshot-preview1/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/cargo_workspace/cargo/vendor/winapi-0.3.9/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/winapi-0.3.9/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/winapi-0.3.9/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/winapi-0.3.9/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/vendored/cargo_workspace/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/vendored/cargo_workspace/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/cargo_workspace/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/MacTypes-sys-2.1.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/MacTypes-sys-2.1.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/MacTypes-sys-2.1.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/MacTypes-sys-2.1.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/arrayvec-0.3.25/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/arrayvec-0.3.25/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/arrayvec-0.3.25/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/arrayvec-0.3.25/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/atom-0.3.5/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/atom-0.3.5/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/atom-0.3.5/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/atom-0.3.5/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/autocfg-1.0.1/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/autocfg-1.0.1/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/autocfg-1.0.1/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/autocfg-1.0.1/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/cfg-if-0.1.10/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/cfg-if-0.1.10/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/cfg-if-0.1.10/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/cfg-if-0.1.10/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/conduit-mime-types-0.7.3/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/conduit-mime-types-0.7.3/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/conduit-mime-types-0.7.3/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/conduit-mime-types-0.7.3/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/core-foundation-sys-0.5.1/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/core-foundation-sys-0.5.1/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/core-foundation-sys-0.5.1/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/core-foundation-sys-0.5.1/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-0.3.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-0.3.2/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-0.3.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-0.3.2/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-channel-0.4.4/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-channel-0.4.4/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-channel-0.4.4/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-channel-0.4.4/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-deque-0.7.3/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-deque-0.7.3/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-deque-0.7.3/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-deque-0.7.3/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-epoch-0.8.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-epoch-0.8.2/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-epoch-0.8.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-epoch-0.8.2/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-utils-0.7.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-utils-0.7.2/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-utils-0.7.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/crossbeam-utils-0.7.2/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/derivative-1.0.4/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/derivative-1.0.4/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/derivative-1.0.4/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/derivative-1.0.4/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/fnv-1.0.7/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/fnv-1.0.7/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/fnv-1.0.7/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/fnv-1.0.7/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/hermit-abi-0.1.15/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/hermit-abi-0.1.15/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/hermit-abi-0.1.15/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/hermit-abi-0.1.15/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/hibitset-0.3.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/hibitset-0.3.2/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/hibitset-0.3.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/hibitset-0.3.2/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/lazy_static-1.4.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/lazy_static-1.4.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/lazy_static-1.4.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/lazy_static-1.4.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/libc-0.2.77/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/libc-0.2.77/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/libc-0.2.77/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/libc-0.2.77/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/maybe-uninit-2.0.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/maybe-uninit-2.0.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/maybe-uninit-2.0.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/maybe-uninit-2.0.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/memchr-2.3.3/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/memchr-2.3.3/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/memchr-2.3.3/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/memchr-2.3.3/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/memoffset-0.5.5/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/memoffset-0.5.5/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/memoffset-0.5.5/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/memoffset-0.5.5/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/mopa-0.2.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/mopa-0.2.2/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/mopa-0.2.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/mopa-0.2.2/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/nodrop-0.1.14/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/nodrop-0.1.14/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/nodrop-0.1.14/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/nodrop-0.1.14/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/num_cpus-1.13.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/num_cpus-1.13.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/num_cpus-1.13.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/num_cpus-1.13.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/odds-0.2.26/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/odds-0.2.26/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/odds-0.2.26/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/odds-0.2.26/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/proc-macro2-0.4.30/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/proc-macro2-0.4.30/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/proc-macro2-0.4.30/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/proc-macro2-0.4.30/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/pulse-0.5.3/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/pulse-0.5.3/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/pulse-0.5.3/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/pulse-0.5.3/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/quote-0.3.15/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/quote-0.3.15/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/quote-0.3.15/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/quote-0.3.15/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/quote-0.6.13/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/quote-0.6.13/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/quote-0.6.13/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/quote-0.6.13/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-0.8.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-0.8.2/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-0.8.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-0.8.2/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-core-1.8.1/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-core-1.8.1/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-core-1.8.1/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/rayon-core-1.8.1/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/regex-0.2.11/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/regex-0.2.11/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/regex-0.2.11/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/regex-0.2.11/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/regex-syntax-0.5.6/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/regex-syntax-0.5.6/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/regex-syntax-0.5.6/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/regex-syntax-0.5.6/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/rustc-serialize-0.3.24/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/rustc-serialize-0.3.24/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/rustc-serialize-0.3.24/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/rustc-serialize-0.3.24/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/scopeguard-1.1.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/scopeguard-1.1.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/scopeguard-1.1.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/scopeguard-1.1.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/security-framework-sys-0.2.3/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/security-framework-sys-0.2.3/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/security-framework-sys-0.2.3/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/security-framework-sys-0.2.3/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/shred-0.5.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/shred-0.5.2/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/shred-0.5.2/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/shred-0.5.2/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/shred-derive-0.3.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/shred-derive-0.3.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/shred-derive-0.3.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/shred-derive-0.3.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/smallvec-0.4.5/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/smallvec-0.4.5/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/smallvec-0.4.5/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/smallvec-0.4.5/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/specs-0.10.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/specs-0.10.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/specs-0.10.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/specs-0.10.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.11.11/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.11.11/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.11.11/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.11.11/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.15.44/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.15.44/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.15.44/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/syn-0.15.44/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/synom-0.11.3/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/synom-0.11.3/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/synom-0.11.3/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/synom-0.11.3/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/thread_local-0.3.6/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/thread_local-0.3.6/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/thread_local-0.3.6/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/thread_local-0.3.6/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/time-0.1.44/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/time-0.1.44/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/time-0.1.44/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/time-0.1.44/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/tuple_utils-0.2.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/tuple_utils-0.2.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/tuple_utils-0.2.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/tuple_utils-0.2.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/ucd-util-0.1.8/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/ucd-util-0.1.8/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/ucd-util-0.1.8/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/ucd-util-0.1.8/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.0.4/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.0.4/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.0.4/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.0.4/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.1.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.1.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.1.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/unicode-xid-0.1.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/utf8-ranges-1.0.4/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/utf8-ranges-1.0.4/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/utf8-ranges-1.0.4/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/utf8-ranges-1.0.4/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/wasi-0.10.0+wasi-snapshot-preview1/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/wasi-0.10.0+wasi-snapshot-preview1/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/wasi-0.10.0+wasi-snapshot-preview1/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/wasi-0.10.0+wasi-snapshot-preview1/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-0.3.9/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-0.3.9/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-0.3.9/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-0.3.9/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/vendored/complicated_cargo_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/hello_cargo_library/cargo/vendor/fern-0.3.5/BUILD.bazel
+++ b/examples/vendored/hello_cargo_library/cargo/vendor/fern-0.3.5/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/hello_cargo_library/cargo/vendor/fern-0.3.5/BUILD.bazel
+++ b/examples/vendored/hello_cargo_library/cargo/vendor/fern-0.3.5/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/hello_cargo_library/cargo/vendor/log-0.3.6/BUILD.bazel
+++ b/examples/vendored/hello_cargo_library/cargo/vendor/log-0.3.6/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/hello_cargo_library/cargo/vendor/log-0.3.6/BUILD.bazel
+++ b/examples/vendored/hello_cargo_library/cargo/vendor/log-0.3.6/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/aho-corasick-0.6.10/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/atty-0.2.14/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/atty-0.2.14/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/atty-0.2.14/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/atty-0.2.14/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/cfg-if-0.1.10/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/cfg-if-0.1.10/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/cfg-if-0.1.10/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/cfg-if-0.1.10/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/either-1.6.1/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/either-1.6.1/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/either-1.6.1/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/either-1.6.1/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/env_logger-0.5.5/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/env_logger-0.5.5/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/env_logger-0.5.5/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/env_logger-0.5.5/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-0.2.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-0.2.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-channel-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-channel-0.2.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-channel-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-channel-0.2.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-core-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-core-0.2.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-core-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-core-0.2.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-executor-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-executor-0.2.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-executor-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-executor-0.2.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-io-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-io-0.2.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-io-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-io-0.2.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-sink-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-sink-0.2.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-sink-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-sink-0.2.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-stable-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-stable-0.2.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-stable-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-stable-0.2.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-util-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-util-0.2.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/futures-util-0.2.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/futures-util-0.2.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/hermit-abi-0.1.15/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/hermit-abi-0.1.15/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/hermit-abi-0.1.15/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/hermit-abi-0.1.15/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/humantime-1.3.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/humantime-1.3.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/humantime-1.3.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/humantime-1.3.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/iovec-0.1.4/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/iovec-0.1.4/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/iovec-0.1.4/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/iovec-0.1.4/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/lazy_static-1.4.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/lazy_static-1.4.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/lazy_static-1.4.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/lazy_static-1.4.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/libc-0.2.77/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/libc-0.2.77/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/libc-0.2.77/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/libc-0.2.77/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.11/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.11/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.11/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/log-0.4.11/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/memchr-2.3.3/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/memchr-2.3.3/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/memchr-2.3.3/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/memchr-2.3.3/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/num_cpus-1.13.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/num_cpus-1.13.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/num_cpus-1.13.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/num_cpus-1.13.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/quick-error-1.2.3/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/quick-error-1.2.3/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/quick-error-1.2.3/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/quick-error-1.2.3/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/regex-0.2.11/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/regex-0.2.11/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/regex-0.2.11/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/regex-0.2.11/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/regex-syntax-0.5.6/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/regex-syntax-0.5.6/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/regex-syntax-0.5.6/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/regex-syntax-0.5.6/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/termcolor-0.3.6/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/termcolor-0.3.6/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/termcolor-0.3.6/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/termcolor-0.3.6/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/thread_local-0.3.6/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/thread_local-0.3.6/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/thread_local-0.3.6/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/thread_local-0.3.6/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/ucd-util-0.1.8/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/ucd-util-0.1.8/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/ucd-util-0.1.8/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/ucd-util-0.1.8/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/utf8-ranges-1.0.4/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/utf8-ranges-1.0.4/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/utf8-ranges-1.0.4/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/utf8-ranges-1.0.4/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/winapi-0.3.9/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/winapi-0.3.9/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/winapi-0.3.9/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/winapi-0.3.9/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/examples/vendored/non_cratesio_library/cargo/vendor/wincolor-0.1.6/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/wincolor-0.1.6/BUILD.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/examples/vendored/non_cratesio_library/cargo/vendor/wincolor-0.1.6/BUILD.bazel
+++ b/examples/vendored/non_cratesio_library/cargo/vendor/wincolor-0.1.6/BUILD.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/impl/src/rendering/templates/crate.BUILD.template
+++ b/impl/src/rendering/templates/crate.BUILD.template
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@{{ rust_rules_workspace_name }}//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/impl/src/rendering/templates/crate.BUILD.template
+++ b/impl/src/rendering/templates/crate.BUILD.template
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@{{ rust_rules_workspace_name }}//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/impl/src/rendering/templates/partials/build_script.template
+++ b/impl/src/rendering/templates/partials/build_script.template
@@ -1,3 +1,4 @@
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@{{ rust_rules_workspace_name }}//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.adler-0.2.3.bazel
+++ b/third_party/cargo/remote/BUILD.adler-0.2.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.adler-0.2.3.bazel
+++ b/third_party/cargo/remote/BUILD.adler-0.2.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.aho-corasick-0.7.15.bazel
+++ b/third_party/cargo/remote/BUILD.aho-corasick-0.7.15.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.aho-corasick-0.7.15.bazel
+++ b/third_party/cargo/remote/BUILD.aho-corasick-0.7.15.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.anyhow-1.0.38.bazel
+++ b/third_party/cargo/remote/BUILD.anyhow-1.0.38.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.anyhow-1.0.38.bazel
+++ b/third_party/cargo/remote/BUILD.anyhow-1.0.38.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.arrayref-0.3.6.bazel
+++ b/third_party/cargo/remote/BUILD.arrayref-0.3.6.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.arrayref-0.3.6.bazel
+++ b/third_party/cargo/remote/BUILD.arrayref-0.3.6.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.arrayvec-0.5.2.bazel
+++ b/third_party/cargo/remote/BUILD.arrayvec-0.5.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.arrayvec-0.5.2.bazel
+++ b/third_party/cargo/remote/BUILD.arrayvec-0.5.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.ascii-canvas-2.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.ascii-canvas-2.0.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.ascii-canvas-2.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.ascii-canvas-2.0.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.assert-json-diff-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.assert-json-diff-1.1.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.assert-json-diff-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.assert-json-diff-1.1.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.async-channel-1.5.1.bazel
+++ b/third_party/cargo/remote/BUILD.async-channel-1.5.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.async-channel-1.5.1.bazel
+++ b/third_party/cargo/remote/BUILD.async-channel-1.5.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.async-executor-1.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.async-executor-1.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.async-executor-1.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.async-executor-1.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.async-global-executor-2.0.2.bazel
+++ b/third_party/cargo/remote/BUILD.async-global-executor-2.0.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.async-global-executor-2.0.2.bazel
+++ b/third_party/cargo/remote/BUILD.async-global-executor-2.0.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.async-io-1.3.1.bazel
+++ b/third_party/cargo/remote/BUILD.async-io-1.3.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.async-io-1.3.1.bazel
+++ b/third_party/cargo/remote/BUILD.async-io-1.3.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.async-lock-2.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.async-lock-2.3.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.async-lock-2.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.async-lock-2.3.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.async-mutex-1.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.async-mutex-1.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.async-mutex-1.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.async-mutex-1.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.async-object-pool-0.1.4.bazel
+++ b/third_party/cargo/remote/BUILD.async-object-pool-0.1.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.async-object-pool-0.1.4.bazel
+++ b/third_party/cargo/remote/BUILD.async-object-pool-0.1.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.async-process-1.0.1.bazel
+++ b/third_party/cargo/remote/BUILD.async-process-1.0.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.async-process-1.0.1.bazel
+++ b/third_party/cargo/remote/BUILD.async-process-1.0.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.async-std-1.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.async-std-1.9.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.async-std-1.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.async-std-1.9.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.async-stream-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.async-stream-0.3.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.async-stream-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.async-stream-0.3.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.async-stream-impl-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.async-stream-impl-0.3.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.async-stream-impl-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.async-stream-impl-0.3.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.async-task-4.0.3.bazel
+++ b/third_party/cargo/remote/BUILD.async-task-4.0.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.async-task-4.0.3.bazel
+++ b/third_party/cargo/remote/BUILD.async-task-4.0.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.async-trait-0.1.42.bazel
+++ b/third_party/cargo/remote/BUILD.async-trait-0.1.42.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.async-trait-0.1.42.bazel
+++ b/third_party/cargo/remote/BUILD.async-trait-0.1.42.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.atomic-waker-1.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.atomic-waker-1.0.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.atomic-waker-1.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.atomic-waker-1.0.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.atty-0.2.14.bazel
+++ b/third_party/cargo/remote/BUILD.atty-0.2.14.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.atty-0.2.14.bazel
+++ b/third_party/cargo/remote/BUILD.atty-0.2.14.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.autocfg-1.0.1.bazel
+++ b/third_party/cargo/remote/BUILD.autocfg-1.0.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.autocfg-1.0.1.bazel
+++ b/third_party/cargo/remote/BUILD.autocfg-1.0.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.base64-0.13.0.bazel
+++ b/third_party/cargo/remote/BUILD.base64-0.13.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.base64-0.13.0.bazel
+++ b/third_party/cargo/remote/BUILD.base64-0.13.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.basic-cookies-0.1.4.bazel
+++ b/third_party/cargo/remote/BUILD.basic-cookies-0.1.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.basic-cookies-0.1.4.bazel
+++ b/third_party/cargo/remote/BUILD.basic-cookies-0.1.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.bit-set-0.5.2.bazel
+++ b/third_party/cargo/remote/BUILD.bit-set-0.5.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.bit-set-0.5.2.bazel
+++ b/third_party/cargo/remote/BUILD.bit-set-0.5.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.bit-vec-0.6.3.bazel
+++ b/third_party/cargo/remote/BUILD.bit-vec-0.6.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.bit-vec-0.6.3.bazel
+++ b/third_party/cargo/remote/BUILD.bit-vec-0.6.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.bitflags-1.2.1.bazel
+++ b/third_party/cargo/remote/BUILD.bitflags-1.2.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.bitflags-1.2.1.bazel
+++ b/third_party/cargo/remote/BUILD.bitflags-1.2.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.blake2b_simd-0.5.11.bazel
+++ b/third_party/cargo/remote/BUILD.blake2b_simd-0.5.11.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.blake2b_simd-0.5.11.bazel
+++ b/third_party/cargo/remote/BUILD.blake2b_simd-0.5.11.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.block-buffer-0.7.3.bazel
+++ b/third_party/cargo/remote/BUILD.block-buffer-0.7.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.block-buffer-0.7.3.bazel
+++ b/third_party/cargo/remote/BUILD.block-buffer-0.7.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.block-padding-0.1.5.bazel
+++ b/third_party/cargo/remote/BUILD.block-padding-0.1.5.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.block-padding-0.1.5.bazel
+++ b/third_party/cargo/remote/BUILD.block-padding-0.1.5.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.blocking-1.0.2.bazel
+++ b/third_party/cargo/remote/BUILD.blocking-1.0.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.blocking-1.0.2.bazel
+++ b/third_party/cargo/remote/BUILD.blocking-1.0.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.bstr-0.2.14.bazel
+++ b/third_party/cargo/remote/BUILD.bstr-0.2.14.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.bstr-0.2.14.bazel
+++ b/third_party/cargo/remote/BUILD.bstr-0.2.14.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.bumpalo-3.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.bumpalo-3.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.bumpalo-3.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.bumpalo-3.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.byte-tools-0.3.1.bazel
+++ b/third_party/cargo/remote/BUILD.byte-tools-0.3.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.byte-tools-0.3.1.bazel
+++ b/third_party/cargo/remote/BUILD.byte-tools-0.3.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.byteorder-1.4.2.bazel
+++ b/third_party/cargo/remote/BUILD.byteorder-1.4.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.byteorder-1.4.2.bazel
+++ b/third_party/cargo/remote/BUILD.byteorder-1.4.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.bytes-1.0.1.bazel
+++ b/third_party/cargo/remote/BUILD.bytes-1.0.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.bytes-1.0.1.bazel
+++ b/third_party/cargo/remote/BUILD.bytes-1.0.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.cache-padded-1.1.1.bazel
+++ b/third_party/cargo/remote/BUILD.cache-padded-1.1.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.cache-padded-1.1.1.bazel
+++ b/third_party/cargo/remote/BUILD.cache-padded-1.1.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.cargo-clone-crate-0.1.6.bazel
+++ b/third_party/cargo/remote/BUILD.cargo-clone-crate-0.1.6.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.cargo-clone-crate-0.1.6.bazel
+++ b/third_party/cargo/remote/BUILD.cargo-clone-crate-0.1.6.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.cargo-lock-6.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.cargo-lock-6.0.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.cargo-lock-6.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.cargo-lock-6.0.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.cargo-platform-0.1.1.bazel
+++ b/third_party/cargo/remote/BUILD.cargo-platform-0.1.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.cargo-platform-0.1.1.bazel
+++ b/third_party/cargo/remote/BUILD.cargo-platform-0.1.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.cargo_metadata-0.12.3.bazel
+++ b/third_party/cargo/remote/BUILD.cargo_metadata-0.12.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.cargo_metadata-0.12.3.bazel
+++ b/third_party/cargo/remote/BUILD.cargo_metadata-0.12.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.cargo_toml-0.8.1.bazel
+++ b/third_party/cargo/remote/BUILD.cargo_toml-0.8.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.cargo_toml-0.8.1.bazel
+++ b/third_party/cargo/remote/BUILD.cargo_toml-0.8.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.cc-1.0.66.bazel
+++ b/third_party/cargo/remote/BUILD.cc-1.0.66.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.cc-1.0.66.bazel
+++ b/third_party/cargo/remote/BUILD.cc-1.0.66.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.cfg-expr-0.6.0.bazel
+++ b/third_party/cargo/remote/BUILD.cfg-expr-0.6.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.cfg-expr-0.6.0.bazel
+++ b/third_party/cargo/remote/BUILD.cfg-expr-0.6.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.cfg-if-0.1.10.bazel
+++ b/third_party/cargo/remote/BUILD.cfg-if-0.1.10.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.cfg-if-0.1.10.bazel
+++ b/third_party/cargo/remote/BUILD.cfg-if-0.1.10.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.cfg-if-1.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.cfg-if-1.0.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.cfg-if-1.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.cfg-if-1.0.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.chrono-0.4.19.bazel
+++ b/third_party/cargo/remote/BUILD.chrono-0.4.19.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.chrono-0.4.19.bazel
+++ b/third_party/cargo/remote/BUILD.chrono-0.4.19.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.chrono-tz-0.5.3.bazel
+++ b/third_party/cargo/remote/BUILD.chrono-tz-0.5.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.chrono-tz-0.5.3.bazel
+++ b/third_party/cargo/remote/BUILD.chrono-tz-0.5.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.concurrent-queue-1.2.2.bazel
+++ b/third_party/cargo/remote/BUILD.concurrent-queue-1.2.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.concurrent-queue-1.2.2.bazel
+++ b/third_party/cargo/remote/BUILD.concurrent-queue-1.2.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.constant_time_eq-0.1.5.bazel
+++ b/third_party/cargo/remote/BUILD.constant_time_eq-0.1.5.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.constant_time_eq-0.1.5.bazel
+++ b/third_party/cargo/remote/BUILD.constant_time_eq-0.1.5.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.core-foundation-0.9.1.bazel
+++ b/third_party/cargo/remote/BUILD.core-foundation-0.9.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.core-foundation-0.9.1.bazel
+++ b/third_party/cargo/remote/BUILD.core-foundation-0.9.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.core-foundation-sys-0.8.2.bazel
+++ b/third_party/cargo/remote/BUILD.core-foundation-sys-0.8.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.core-foundation-sys-0.8.2.bazel
+++ b/third_party/cargo/remote/BUILD.core-foundation-sys-0.8.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.crates-index-0.16.2.bazel
+++ b/third_party/cargo/remote/BUILD.crates-index-0.16.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.crates-index-0.16.2.bazel
+++ b/third_party/cargo/remote/BUILD.crates-index-0.16.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.crc32fast-1.2.1.bazel
+++ b/third_party/cargo/remote/BUILD.crc32fast-1.2.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.crc32fast-1.2.1.bazel
+++ b/third_party/cargo/remote/BUILD.crc32fast-1.2.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.crossbeam-utils-0.8.1.bazel
+++ b/third_party/cargo/remote/BUILD.crossbeam-utils-0.8.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.crossbeam-utils-0.8.1.bazel
+++ b/third_party/cargo/remote/BUILD.crossbeam-utils-0.8.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.crunchy-0.2.2.bazel
+++ b/third_party/cargo/remote/BUILD.crunchy-0.2.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.crunchy-0.2.2.bazel
+++ b/third_party/cargo/remote/BUILD.crunchy-0.2.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.curl-0.4.34.bazel
+++ b/third_party/cargo/remote/BUILD.curl-0.4.34.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.curl-0.4.34.bazel
+++ b/third_party/cargo/remote/BUILD.curl-0.4.34.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.curl-sys-0.4.39+curl-7.74.0.bazel
+++ b/third_party/cargo/remote/BUILD.curl-sys-0.4.39+curl-7.74.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.curl-sys-0.4.39+curl-7.74.0.bazel
+++ b/third_party/cargo/remote/BUILD.curl-sys-0.4.39+curl-7.74.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.deunicode-0.4.3.bazel
+++ b/third_party/cargo/remote/BUILD.deunicode-0.4.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.deunicode-0.4.3.bazel
+++ b/third_party/cargo/remote/BUILD.deunicode-0.4.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.diff-0.1.12.bazel
+++ b/third_party/cargo/remote/BUILD.diff-0.1.12.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.diff-0.1.12.bazel
+++ b/third_party/cargo/remote/BUILD.diff-0.1.12.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.difference-2.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.difference-2.0.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.difference-2.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.difference-2.0.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.digest-0.8.1.bazel
+++ b/third_party/cargo/remote/BUILD.digest-0.8.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.digest-0.8.1.bazel
+++ b/third_party/cargo/remote/BUILD.digest-0.8.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.dirs-1.0.5.bazel
+++ b/third_party/cargo/remote/BUILD.dirs-1.0.5.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.dirs-1.0.5.bazel
+++ b/third_party/cargo/remote/BUILD.dirs-1.0.5.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.docopt-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.docopt-1.1.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.docopt-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.docopt-1.1.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.either-1.6.1.bazel
+++ b/third_party/cargo/remote/BUILD.either-1.6.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.either-1.6.1.bazel
+++ b/third_party/cargo/remote/BUILD.either-1.6.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.ena-0.14.0.bazel
+++ b/third_party/cargo/remote/BUILD.ena-0.14.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.ena-0.14.0.bazel
+++ b/third_party/cargo/remote/BUILD.ena-0.14.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.encoding_rs-0.8.26.bazel
+++ b/third_party/cargo/remote/BUILD.encoding_rs-0.8.26.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.encoding_rs-0.8.26.bazel
+++ b/third_party/cargo/remote/BUILD.encoding_rs-0.8.26.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.event-listener-2.5.1.bazel
+++ b/third_party/cargo/remote/BUILD.event-listener-2.5.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.event-listener-2.5.1.bazel
+++ b/third_party/cargo/remote/BUILD.event-listener-2.5.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.extend-0.1.2.bazel
+++ b/third_party/cargo/remote/BUILD.extend-0.1.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.extend-0.1.2.bazel
+++ b/third_party/cargo/remote/BUILD.extend-0.1.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.fake-simd-0.1.2.bazel
+++ b/third_party/cargo/remote/BUILD.fake-simd-0.1.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.fake-simd-0.1.2.bazel
+++ b/third_party/cargo/remote/BUILD.fake-simd-0.1.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.fastrand-1.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.fastrand-1.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.fastrand-1.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.fastrand-1.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.filetime-0.2.14.bazel
+++ b/third_party/cargo/remote/BUILD.filetime-0.2.14.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.filetime-0.2.14.bazel
+++ b/third_party/cargo/remote/BUILD.filetime-0.2.14.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.fixedbitset-0.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.fixedbitset-0.2.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.fixedbitset-0.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.fixedbitset-0.2.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.flate2-1.0.19.bazel
+++ b/third_party/cargo/remote/BUILD.flate2-1.0.19.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.flate2-1.0.19.bazel
+++ b/third_party/cargo/remote/BUILD.flate2-1.0.19.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.flume-0.10.1.bazel
+++ b/third_party/cargo/remote/BUILD.flume-0.10.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.flume-0.10.1.bazel
+++ b/third_party/cargo/remote/BUILD.flume-0.10.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.fnv-1.0.7.bazel
+++ b/third_party/cargo/remote/BUILD.fnv-1.0.7.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.fnv-1.0.7.bazel
+++ b/third_party/cargo/remote/BUILD.fnv-1.0.7.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.foreign-types-0.3.2.bazel
+++ b/third_party/cargo/remote/BUILD.foreign-types-0.3.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.foreign-types-0.3.2.bazel
+++ b/third_party/cargo/remote/BUILD.foreign-types-0.3.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.foreign-types-shared-0.1.1.bazel
+++ b/third_party/cargo/remote/BUILD.foreign-types-shared-0.1.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.foreign-types-shared-0.1.1.bazel
+++ b/third_party/cargo/remote/BUILD.foreign-types-shared-0.1.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.form_urlencoded-1.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.form_urlencoded-1.0.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.form_urlencoded-1.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.form_urlencoded-1.0.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.futures-channel-0.3.12.bazel
+++ b/third_party/cargo/remote/BUILD.futures-channel-0.3.12.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.futures-channel-0.3.12.bazel
+++ b/third_party/cargo/remote/BUILD.futures-channel-0.3.12.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.futures-core-0.3.12.bazel
+++ b/third_party/cargo/remote/BUILD.futures-core-0.3.12.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.futures-core-0.3.12.bazel
+++ b/third_party/cargo/remote/BUILD.futures-core-0.3.12.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.futures-io-0.3.12.bazel
+++ b/third_party/cargo/remote/BUILD.futures-io-0.3.12.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.futures-io-0.3.12.bazel
+++ b/third_party/cargo/remote/BUILD.futures-io-0.3.12.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.futures-lite-1.11.3.bazel
+++ b/third_party/cargo/remote/BUILD.futures-lite-1.11.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.futures-lite-1.11.3.bazel
+++ b/third_party/cargo/remote/BUILD.futures-lite-1.11.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.futures-macro-0.3.12.bazel
+++ b/third_party/cargo/remote/BUILD.futures-macro-0.3.12.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.futures-macro-0.3.12.bazel
+++ b/third_party/cargo/remote/BUILD.futures-macro-0.3.12.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.futures-sink-0.3.12.bazel
+++ b/third_party/cargo/remote/BUILD.futures-sink-0.3.12.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.futures-sink-0.3.12.bazel
+++ b/third_party/cargo/remote/BUILD.futures-sink-0.3.12.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.futures-task-0.3.12.bazel
+++ b/third_party/cargo/remote/BUILD.futures-task-0.3.12.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.futures-task-0.3.12.bazel
+++ b/third_party/cargo/remote/BUILD.futures-task-0.3.12.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.futures-util-0.3.12.bazel
+++ b/third_party/cargo/remote/BUILD.futures-util-0.3.12.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.futures-util-0.3.12.bazel
+++ b/third_party/cargo/remote/BUILD.futures-util-0.3.12.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.generic-array-0.12.3.bazel
+++ b/third_party/cargo/remote/BUILD.generic-array-0.12.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.generic-array-0.12.3.bazel
+++ b/third_party/cargo/remote/BUILD.generic-array-0.12.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.getrandom-0.1.16.bazel
+++ b/third_party/cargo/remote/BUILD.getrandom-0.1.16.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.getrandom-0.1.16.bazel
+++ b/third_party/cargo/remote/BUILD.getrandom-0.1.16.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.getrandom-0.2.2.bazel
+++ b/third_party/cargo/remote/BUILD.getrandom-0.2.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.getrandom-0.2.2.bazel
+++ b/third_party/cargo/remote/BUILD.getrandom-0.2.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.git2-0.13.16.bazel
+++ b/third_party/cargo/remote/BUILD.git2-0.13.16.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.git2-0.13.16.bazel
+++ b/third_party/cargo/remote/BUILD.git2-0.13.16.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.glob-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.glob-0.3.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.glob-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.glob-0.3.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.globset-0.4.6.bazel
+++ b/third_party/cargo/remote/BUILD.globset-0.4.6.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.globset-0.4.6.bazel
+++ b/third_party/cargo/remote/BUILD.globset-0.4.6.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.globwalk-0.8.1.bazel
+++ b/third_party/cargo/remote/BUILD.globwalk-0.8.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.globwalk-0.8.1.bazel
+++ b/third_party/cargo/remote/BUILD.globwalk-0.8.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.gloo-timers-0.2.1.bazel
+++ b/third_party/cargo/remote/BUILD.gloo-timers-0.2.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.gloo-timers-0.2.1.bazel
+++ b/third_party/cargo/remote/BUILD.gloo-timers-0.2.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.h2-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.h2-0.3.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.h2-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.h2-0.3.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.hamcrest2-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.hamcrest2-0.3.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.hamcrest2-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.hamcrest2-0.3.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.hashbrown-0.9.1.bazel
+++ b/third_party/cargo/remote/BUILD.hashbrown-0.9.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.hashbrown-0.9.1.bazel
+++ b/third_party/cargo/remote/BUILD.hashbrown-0.9.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.hermit-abi-0.1.18.bazel
+++ b/third_party/cargo/remote/BUILD.hermit-abi-0.1.18.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.hermit-abi-0.1.18.bazel
+++ b/third_party/cargo/remote/BUILD.hermit-abi-0.1.18.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.hex-0.4.2.bazel
+++ b/third_party/cargo/remote/BUILD.hex-0.4.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.hex-0.4.2.bazel
+++ b/third_party/cargo/remote/BUILD.hex-0.4.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.home-0.5.3.bazel
+++ b/third_party/cargo/remote/BUILD.home-0.5.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.home-0.5.3.bazel
+++ b/third_party/cargo/remote/BUILD.home-0.5.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.http-0.2.3.bazel
+++ b/third_party/cargo/remote/BUILD.http-0.2.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.http-0.2.3.bazel
+++ b/third_party/cargo/remote/BUILD.http-0.2.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.http-body-0.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.http-body-0.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.http-body-0.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.http-body-0.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.httparse-1.3.4.bazel
+++ b/third_party/cargo/remote/BUILD.httparse-1.3.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.httparse-1.3.4.bazel
+++ b/third_party/cargo/remote/BUILD.httparse-1.3.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.httpdate-0.3.2.bazel
+++ b/third_party/cargo/remote/BUILD.httpdate-0.3.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.httpdate-0.3.2.bazel
+++ b/third_party/cargo/remote/BUILD.httpdate-0.3.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.httpmock-0.5.4.bazel
+++ b/third_party/cargo/remote/BUILD.httpmock-0.5.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.httpmock-0.5.4.bazel
+++ b/third_party/cargo/remote/BUILD.httpmock-0.5.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.humansize-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.humansize-1.1.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.humansize-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.humansize-1.1.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.hyper-0.14.2.bazel
+++ b/third_party/cargo/remote/BUILD.hyper-0.14.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.hyper-0.14.2.bazel
+++ b/third_party/cargo/remote/BUILD.hyper-0.14.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.hyper-tls-0.5.0.bazel
+++ b/third_party/cargo/remote/BUILD.hyper-tls-0.5.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.hyper-tls-0.5.0.bazel
+++ b/third_party/cargo/remote/BUILD.hyper-tls-0.5.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.idna-0.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.idna-0.2.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.idna-0.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.idna-0.2.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.ignore-0.4.17.bazel
+++ b/third_party/cargo/remote/BUILD.ignore-0.4.17.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.ignore-0.4.17.bazel
+++ b/third_party/cargo/remote/BUILD.ignore-0.4.17.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.indexmap-1.6.1.bazel
+++ b/third_party/cargo/remote/BUILD.indexmap-1.6.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.indexmap-1.6.1.bazel
+++ b/third_party/cargo/remote/BUILD.indexmap-1.6.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.indoc-1.0.3.bazel
+++ b/third_party/cargo/remote/BUILD.indoc-1.0.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.indoc-1.0.3.bazel
+++ b/third_party/cargo/remote/BUILD.indoc-1.0.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.instant-0.1.9.bazel
+++ b/third_party/cargo/remote/BUILD.instant-0.1.9.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.instant-0.1.9.bazel
+++ b/third_party/cargo/remote/BUILD.instant-0.1.9.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.ipnet-2.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.ipnet-2.3.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.ipnet-2.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.ipnet-2.3.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.isahc-1.0.3.bazel
+++ b/third_party/cargo/remote/BUILD.isahc-1.0.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.isahc-1.0.3.bazel
+++ b/third_party/cargo/remote/BUILD.isahc-1.0.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.itertools-0.10.0.bazel
+++ b/third_party/cargo/remote/BUILD.itertools-0.10.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.itertools-0.10.0.bazel
+++ b/third_party/cargo/remote/BUILD.itertools-0.10.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.itertools-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.itertools-0.9.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.itertools-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.itertools-0.9.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.itoa-0.4.7.bazel
+++ b/third_party/cargo/remote/BUILD.itoa-0.4.7.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.itoa-0.4.7.bazel
+++ b/third_party/cargo/remote/BUILD.itoa-0.4.7.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.jobserver-0.1.21.bazel
+++ b/third_party/cargo/remote/BUILD.jobserver-0.1.21.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.jobserver-0.1.21.bazel
+++ b/third_party/cargo/remote/BUILD.jobserver-0.1.21.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.js-sys-0.3.46.bazel
+++ b/third_party/cargo/remote/BUILD.js-sys-0.3.46.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.js-sys-0.3.46.bazel
+++ b/third_party/cargo/remote/BUILD.js-sys-0.3.46.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.kv-log-macro-1.0.7.bazel
+++ b/third_party/cargo/remote/BUILD.kv-log-macro-1.0.7.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.kv-log-macro-1.0.7.bazel
+++ b/third_party/cargo/remote/BUILD.kv-log-macro-1.0.7.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.lalrpop-0.19.4.bazel
+++ b/third_party/cargo/remote/BUILD.lalrpop-0.19.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.lalrpop-0.19.4.bazel
+++ b/third_party/cargo/remote/BUILD.lalrpop-0.19.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.lalrpop-util-0.19.4.bazel
+++ b/third_party/cargo/remote/BUILD.lalrpop-util-0.19.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.lalrpop-util-0.19.4.bazel
+++ b/third_party/cargo/remote/BUILD.lalrpop-util-0.19.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.lazy_static-1.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.lazy_static-1.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.lazy_static-1.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.lazy_static-1.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.levenshtein-1.0.4.bazel
+++ b/third_party/cargo/remote/BUILD.levenshtein-1.0.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.levenshtein-1.0.4.bazel
+++ b/third_party/cargo/remote/BUILD.levenshtein-1.0.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.libc-0.2.82.bazel
+++ b/third_party/cargo/remote/BUILD.libc-0.2.82.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.libc-0.2.82.bazel
+++ b/third_party/cargo/remote/BUILD.libc-0.2.82.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.libgit2-sys-0.12.18+1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.libgit2-sys-0.12.18+1.1.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.libgit2-sys-0.12.18+1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.libgit2-sys-0.12.18+1.1.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.libnghttp2-sys-0.1.5+1.42.0.bazel
+++ b/third_party/cargo/remote/BUILD.libnghttp2-sys-0.1.5+1.42.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.libnghttp2-sys-0.1.5+1.42.0.bazel
+++ b/third_party/cargo/remote/BUILD.libnghttp2-sys-0.1.5+1.42.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.libssh2-sys-0.2.20.bazel
+++ b/third_party/cargo/remote/BUILD.libssh2-sys-0.2.20.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.libssh2-sys-0.2.20.bazel
+++ b/third_party/cargo/remote/BUILD.libssh2-sys-0.2.20.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.libz-sys-1.1.2.bazel
+++ b/third_party/cargo/remote/BUILD.libz-sys-1.1.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.libz-sys-1.1.2.bazel
+++ b/third_party/cargo/remote/BUILD.libz-sys-1.1.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.lock_api-0.4.2.bazel
+++ b/third_party/cargo/remote/BUILD.lock_api-0.4.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.lock_api-0.4.2.bazel
+++ b/third_party/cargo/remote/BUILD.lock_api-0.4.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.log-0.4.13.bazel
+++ b/third_party/cargo/remote/BUILD.log-0.4.13.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.log-0.4.13.bazel
+++ b/third_party/cargo/remote/BUILD.log-0.4.13.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.maplit-1.0.2.bazel
+++ b/third_party/cargo/remote/BUILD.maplit-1.0.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.maplit-1.0.2.bazel
+++ b/third_party/cargo/remote/BUILD.maplit-1.0.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.matches-0.1.8.bazel
+++ b/third_party/cargo/remote/BUILD.matches-0.1.8.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.matches-0.1.8.bazel
+++ b/third_party/cargo/remote/BUILD.matches-0.1.8.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.memchr-2.3.4.bazel
+++ b/third_party/cargo/remote/BUILD.memchr-2.3.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.memchr-2.3.4.bazel
+++ b/third_party/cargo/remote/BUILD.memchr-2.3.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.mime-0.3.16.bazel
+++ b/third_party/cargo/remote/BUILD.mime-0.3.16.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.mime-0.3.16.bazel
+++ b/third_party/cargo/remote/BUILD.mime-0.3.16.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
+++ b/third_party/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
+++ b/third_party/cargo/remote/BUILD.miniz_oxide-0.4.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.mio-0.7.7.bazel
+++ b/third_party/cargo/remote/BUILD.mio-0.7.7.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.mio-0.7.7.bazel
+++ b/third_party/cargo/remote/BUILD.mio-0.7.7.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.miow-0.3.6.bazel
+++ b/third_party/cargo/remote/BUILD.miow-0.3.6.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.miow-0.3.6.bazel
+++ b/third_party/cargo/remote/BUILD.miow-0.3.6.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.native-tls-0.2.7.bazel
+++ b/third_party/cargo/remote/BUILD.native-tls-0.2.7.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.native-tls-0.2.7.bazel
+++ b/third_party/cargo/remote/BUILD.native-tls-0.2.7.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.nb-connect-1.0.2.bazel
+++ b/third_party/cargo/remote/BUILD.nb-connect-1.0.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.nb-connect-1.0.2.bazel
+++ b/third_party/cargo/remote/BUILD.nb-connect-1.0.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.new_debug_unreachable-1.0.4.bazel
+++ b/third_party/cargo/remote/BUILD.new_debug_unreachable-1.0.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.new_debug_unreachable-1.0.4.bazel
+++ b/third_party/cargo/remote/BUILD.new_debug_unreachable-1.0.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.ntapi-0.3.6.bazel
+++ b/third_party/cargo/remote/BUILD.ntapi-0.3.6.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.ntapi-0.3.6.bazel
+++ b/third_party/cargo/remote/BUILD.ntapi-0.3.6.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.num-0.2.1.bazel
+++ b/third_party/cargo/remote/BUILD.num-0.2.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.num-0.2.1.bazel
+++ b/third_party/cargo/remote/BUILD.num-0.2.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.num-bigint-0.2.6.bazel
+++ b/third_party/cargo/remote/BUILD.num-bigint-0.2.6.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.num-bigint-0.2.6.bazel
+++ b/third_party/cargo/remote/BUILD.num-bigint-0.2.6.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.num-complex-0.2.4.bazel
+++ b/third_party/cargo/remote/BUILD.num-complex-0.2.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.num-complex-0.2.4.bazel
+++ b/third_party/cargo/remote/BUILD.num-complex-0.2.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.num-integer-0.1.44.bazel
+++ b/third_party/cargo/remote/BUILD.num-integer-0.1.44.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.num-integer-0.1.44.bazel
+++ b/third_party/cargo/remote/BUILD.num-integer-0.1.44.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.num-iter-0.1.42.bazel
+++ b/third_party/cargo/remote/BUILD.num-iter-0.1.42.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.num-iter-0.1.42.bazel
+++ b/third_party/cargo/remote/BUILD.num-iter-0.1.42.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.num-rational-0.2.4.bazel
+++ b/third_party/cargo/remote/BUILD.num-rational-0.2.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.num-rational-0.2.4.bazel
+++ b/third_party/cargo/remote/BUILD.num-rational-0.2.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.num-traits-0.2.14.bazel
+++ b/third_party/cargo/remote/BUILD.num-traits-0.2.14.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.num-traits-0.2.14.bazel
+++ b/third_party/cargo/remote/BUILD.num-traits-0.2.14.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.num_cpus-1.13.0.bazel
+++ b/third_party/cargo/remote/BUILD.num_cpus-1.13.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.num_cpus-1.13.0.bazel
+++ b/third_party/cargo/remote/BUILD.num_cpus-1.13.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.once_cell-1.5.2.bazel
+++ b/third_party/cargo/remote/BUILD.once_cell-1.5.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.once_cell-1.5.2.bazel
+++ b/third_party/cargo/remote/BUILD.once_cell-1.5.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.opaque-debug-0.2.3.bazel
+++ b/third_party/cargo/remote/BUILD.opaque-debug-0.2.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.opaque-debug-0.2.3.bazel
+++ b/third_party/cargo/remote/BUILD.opaque-debug-0.2.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.openssl-0.10.32.bazel
+++ b/third_party/cargo/remote/BUILD.openssl-0.10.32.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.openssl-0.10.32.bazel
+++ b/third_party/cargo/remote/BUILD.openssl-0.10.32.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.openssl-probe-0.1.2.bazel
+++ b/third_party/cargo/remote/BUILD.openssl-probe-0.1.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.openssl-probe-0.1.2.bazel
+++ b/third_party/cargo/remote/BUILD.openssl-probe-0.1.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.openssl-sys-0.9.60.bazel
+++ b/third_party/cargo/remote/BUILD.openssl-sys-0.9.60.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.openssl-sys-0.9.60.bazel
+++ b/third_party/cargo/remote/BUILD.openssl-sys-0.9.60.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.parking-2.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.parking-2.0.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.parking-2.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.parking-2.0.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.parse-zoneinfo-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.parse-zoneinfo-0.3.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.parse-zoneinfo-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.parse-zoneinfo-0.3.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.pathdiff-0.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.pathdiff-0.2.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.pathdiff-0.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.pathdiff-0.2.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.percent-encoding-2.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.percent-encoding-2.1.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.percent-encoding-2.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.percent-encoding-2.1.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.pest-2.1.3.bazel
+++ b/third_party/cargo/remote/BUILD.pest-2.1.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.pest-2.1.3.bazel
+++ b/third_party/cargo/remote/BUILD.pest-2.1.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.pest_derive-2.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.pest_derive-2.1.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.pest_derive-2.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.pest_derive-2.1.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.pest_generator-2.1.3.bazel
+++ b/third_party/cargo/remote/BUILD.pest_generator-2.1.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.pest_generator-2.1.3.bazel
+++ b/third_party/cargo/remote/BUILD.pest_generator-2.1.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.pest_meta-2.1.3.bazel
+++ b/third_party/cargo/remote/BUILD.pest_meta-2.1.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.pest_meta-2.1.3.bazel
+++ b/third_party/cargo/remote/BUILD.pest_meta-2.1.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.petgraph-0.5.1.bazel
+++ b/third_party/cargo/remote/BUILD.petgraph-0.5.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.petgraph-0.5.1.bazel
+++ b/third_party/cargo/remote/BUILD.petgraph-0.5.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.phf_shared-0.8.0.bazel
+++ b/third_party/cargo/remote/BUILD.phf_shared-0.8.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.phf_shared-0.8.0.bazel
+++ b/third_party/cargo/remote/BUILD.phf_shared-0.8.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.pico-args-0.3.4.bazel
+++ b/third_party/cargo/remote/BUILD.pico-args-0.3.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.pico-args-0.3.4.bazel
+++ b/third_party/cargo/remote/BUILD.pico-args-0.3.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.pin-project-0.4.27.bazel
+++ b/third_party/cargo/remote/BUILD.pin-project-0.4.27.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.pin-project-0.4.27.bazel
+++ b/third_party/cargo/remote/BUILD.pin-project-0.4.27.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.pin-project-1.0.4.bazel
+++ b/third_party/cargo/remote/BUILD.pin-project-1.0.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.pin-project-1.0.4.bazel
+++ b/third_party/cargo/remote/BUILD.pin-project-1.0.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.pin-project-internal-0.4.27.bazel
+++ b/third_party/cargo/remote/BUILD.pin-project-internal-0.4.27.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.pin-project-internal-0.4.27.bazel
+++ b/third_party/cargo/remote/BUILD.pin-project-internal-0.4.27.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.pin-project-internal-1.0.4.bazel
+++ b/third_party/cargo/remote/BUILD.pin-project-internal-1.0.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.pin-project-internal-1.0.4.bazel
+++ b/third_party/cargo/remote/BUILD.pin-project-internal-1.0.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.pin-project-lite-0.2.4.bazel
+++ b/third_party/cargo/remote/BUILD.pin-project-lite-0.2.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.pin-project-lite-0.2.4.bazel
+++ b/third_party/cargo/remote/BUILD.pin-project-lite-0.2.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.pin-utils-0.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.pin-utils-0.1.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.pin-utils-0.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.pin-utils-0.1.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.pkg-config-0.3.19.bazel
+++ b/third_party/cargo/remote/BUILD.pkg-config-0.3.19.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.pkg-config-0.3.19.bazel
+++ b/third_party/cargo/remote/BUILD.pkg-config-0.3.19.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.polling-2.0.2.bazel
+++ b/third_party/cargo/remote/BUILD.polling-2.0.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.polling-2.0.2.bazel
+++ b/third_party/cargo/remote/BUILD.polling-2.0.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.ppv-lite86-0.2.10.bazel
+++ b/third_party/cargo/remote/BUILD.ppv-lite86-0.2.10.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.ppv-lite86-0.2.10.bazel
+++ b/third_party/cargo/remote/BUILD.ppv-lite86-0.2.10.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.precomputed-hash-0.1.1.bazel
+++ b/third_party/cargo/remote/BUILD.precomputed-hash-0.1.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.precomputed-hash-0.1.1.bazel
+++ b/third_party/cargo/remote/BUILD.precomputed-hash-0.1.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.proc-macro-error-1.0.4.bazel
+++ b/third_party/cargo/remote/BUILD.proc-macro-error-1.0.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.proc-macro-error-1.0.4.bazel
+++ b/third_party/cargo/remote/BUILD.proc-macro-error-1.0.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.proc-macro-error-attr-1.0.4.bazel
+++ b/third_party/cargo/remote/BUILD.proc-macro-error-attr-1.0.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.proc-macro-error-attr-1.0.4.bazel
+++ b/third_party/cargo/remote/BUILD.proc-macro-error-attr-1.0.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.proc-macro-hack-0.5.19.bazel
+++ b/third_party/cargo/remote/BUILD.proc-macro-hack-0.5.19.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.proc-macro-hack-0.5.19.bazel
+++ b/third_party/cargo/remote/BUILD.proc-macro-hack-0.5.19.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.proc-macro-nested-0.1.7.bazel
+++ b/third_party/cargo/remote/BUILD.proc-macro-nested-0.1.7.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.proc-macro-nested-0.1.7.bazel
+++ b/third_party/cargo/remote/BUILD.proc-macro-nested-0.1.7.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.proc-macro2-1.0.24.bazel
+++ b/third_party/cargo/remote/BUILD.proc-macro2-1.0.24.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.proc-macro2-1.0.24.bazel
+++ b/third_party/cargo/remote/BUILD.proc-macro2-1.0.24.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.qstring-0.7.2.bazel
+++ b/third_party/cargo/remote/BUILD.qstring-0.7.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.qstring-0.7.2.bazel
+++ b/third_party/cargo/remote/BUILD.qstring-0.7.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.quote-1.0.8.bazel
+++ b/third_party/cargo/remote/BUILD.quote-1.0.8.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.quote-1.0.8.bazel
+++ b/third_party/cargo/remote/BUILD.quote-1.0.8.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.rand-0.8.2.bazel
+++ b/third_party/cargo/remote/BUILD.rand-0.8.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.rand-0.8.2.bazel
+++ b/third_party/cargo/remote/BUILD.rand-0.8.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.rand_chacha-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.rand_chacha-0.3.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.rand_chacha-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.rand_chacha-0.3.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.rand_core-0.6.1.bazel
+++ b/third_party/cargo/remote/BUILD.rand_core-0.6.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.rand_core-0.6.1.bazel
+++ b/third_party/cargo/remote/BUILD.rand_core-0.6.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.rand_hc-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.rand_hc-0.3.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.rand_hc-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.rand_hc-0.3.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.redox_syscall-0.1.57.bazel
+++ b/third_party/cargo/remote/BUILD.redox_syscall-0.1.57.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.redox_syscall-0.1.57.bazel
+++ b/third_party/cargo/remote/BUILD.redox_syscall-0.1.57.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.redox_syscall-0.2.4.bazel
+++ b/third_party/cargo/remote/BUILD.redox_syscall-0.2.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.redox_syscall-0.2.4.bazel
+++ b/third_party/cargo/remote/BUILD.redox_syscall-0.2.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.redox_users-0.3.5.bazel
+++ b/third_party/cargo/remote/BUILD.redox_users-0.3.5.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.redox_users-0.3.5.bazel
+++ b/third_party/cargo/remote/BUILD.redox_users-0.3.5.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.regex-1.4.3.bazel
+++ b/third_party/cargo/remote/BUILD.regex-1.4.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.regex-1.4.3.bazel
+++ b/third_party/cargo/remote/BUILD.regex-1.4.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.regex-syntax-0.6.22.bazel
+++ b/third_party/cargo/remote/BUILD.regex-syntax-0.6.22.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.regex-syntax-0.6.22.bazel
+++ b/third_party/cargo/remote/BUILD.regex-syntax-0.6.22.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.remove_dir_all-0.5.3.bazel
+++ b/third_party/cargo/remote/BUILD.remove_dir_all-0.5.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.remove_dir_all-0.5.3.bazel
+++ b/third_party/cargo/remote/BUILD.remove_dir_all-0.5.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.reqwest-0.11.0.bazel
+++ b/third_party/cargo/remote/BUILD.reqwest-0.11.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.reqwest-0.11.0.bazel
+++ b/third_party/cargo/remote/BUILD.reqwest-0.11.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.rust-argon2-0.8.3.bazel
+++ b/third_party/cargo/remote/BUILD.rust-argon2-0.8.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.rust-argon2-0.8.3.bazel
+++ b/third_party/cargo/remote/BUILD.rust-argon2-0.8.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.rustc-serialize-0.3.24.bazel
+++ b/third_party/cargo/remote/BUILD.rustc-serialize-0.3.24.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.rustc-serialize-0.3.24.bazel
+++ b/third_party/cargo/remote/BUILD.rustc-serialize-0.3.24.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.ryu-1.0.5.bazel
+++ b/third_party/cargo/remote/BUILD.ryu-1.0.5.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.ryu-1.0.5.bazel
+++ b/third_party/cargo/remote/BUILD.ryu-1.0.5.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.same-file-1.0.6.bazel
+++ b/third_party/cargo/remote/BUILD.same-file-1.0.6.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.same-file-1.0.6.bazel
+++ b/third_party/cargo/remote/BUILD.same-file-1.0.6.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.schannel-0.1.19.bazel
+++ b/third_party/cargo/remote/BUILD.schannel-0.1.19.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.schannel-0.1.19.bazel
+++ b/third_party/cargo/remote/BUILD.schannel-0.1.19.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.scopeguard-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.scopeguard-1.1.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.scopeguard-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.scopeguard-1.1.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.security-framework-2.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.security-framework-2.0.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.security-framework-2.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.security-framework-2.0.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.security-framework-sys-2.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.security-framework-sys-2.0.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.security-framework-sys-2.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.security-framework-sys-2.0.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.semver-0.11.0.bazel
+++ b/third_party/cargo/remote/BUILD.semver-0.11.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.semver-0.11.0.bazel
+++ b/third_party/cargo/remote/BUILD.semver-0.11.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.semver-parser-0.10.2.bazel
+++ b/third_party/cargo/remote/BUILD.semver-parser-0.10.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.semver-parser-0.10.2.bazel
+++ b/third_party/cargo/remote/BUILD.semver-parser-0.10.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.serde-1.0.120.bazel
+++ b/third_party/cargo/remote/BUILD.serde-1.0.120.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.serde-1.0.120.bazel
+++ b/third_party/cargo/remote/BUILD.serde-1.0.120.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.serde_derive-1.0.120.bazel
+++ b/third_party/cargo/remote/BUILD.serde_derive-1.0.120.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.serde_derive-1.0.120.bazel
+++ b/third_party/cargo/remote/BUILD.serde_derive-1.0.120.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.serde_json-1.0.61.bazel
+++ b/third_party/cargo/remote/BUILD.serde_json-1.0.61.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.serde_json-1.0.61.bazel
+++ b/third_party/cargo/remote/BUILD.serde_json-1.0.61.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.serde_regex-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.serde_regex-1.1.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.serde_regex-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.serde_regex-1.1.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.serde_urlencoded-0.7.0.bazel
+++ b/third_party/cargo/remote/BUILD.serde_urlencoded-0.7.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.serde_urlencoded-0.7.0.bazel
+++ b/third_party/cargo/remote/BUILD.serde_urlencoded-0.7.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.sha-1-0.8.2.bazel
+++ b/third_party/cargo/remote/BUILD.sha-1-0.8.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.sha-1-0.8.2.bazel
+++ b/third_party/cargo/remote/BUILD.sha-1-0.8.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.signal-hook-0.1.17.bazel
+++ b/third_party/cargo/remote/BUILD.signal-hook-0.1.17.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.signal-hook-0.1.17.bazel
+++ b/third_party/cargo/remote/BUILD.signal-hook-0.1.17.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.signal-hook-registry-1.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.signal-hook-registry-1.3.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.signal-hook-registry-1.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.signal-hook-registry-1.3.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.siphasher-0.3.3.bazel
+++ b/third_party/cargo/remote/BUILD.siphasher-0.3.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.siphasher-0.3.3.bazel
+++ b/third_party/cargo/remote/BUILD.siphasher-0.3.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.slab-0.4.2.bazel
+++ b/third_party/cargo/remote/BUILD.slab-0.4.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.slab-0.4.2.bazel
+++ b/third_party/cargo/remote/BUILD.slab-0.4.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.slug-0.1.4.bazel
+++ b/third_party/cargo/remote/BUILD.slug-0.1.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.slug-0.1.4.bazel
+++ b/third_party/cargo/remote/BUILD.slug-0.1.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.sluice-0.5.3.bazel
+++ b/third_party/cargo/remote/BUILD.sluice-0.5.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.sluice-0.5.3.bazel
+++ b/third_party/cargo/remote/BUILD.sluice-0.5.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.smallvec-1.6.1.bazel
+++ b/third_party/cargo/remote/BUILD.smallvec-1.6.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.smallvec-1.6.1.bazel
+++ b/third_party/cargo/remote/BUILD.smallvec-1.6.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.smartstring-0.2.6.bazel
+++ b/third_party/cargo/remote/BUILD.smartstring-0.2.6.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.smartstring-0.2.6.bazel
+++ b/third_party/cargo/remote/BUILD.smartstring-0.2.6.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.socket2-0.3.19.bazel
+++ b/third_party/cargo/remote/BUILD.socket2-0.3.19.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.socket2-0.3.19.bazel
+++ b/third_party/cargo/remote/BUILD.socket2-0.3.19.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.spdx-0.3.4.bazel
+++ b/third_party/cargo/remote/BUILD.spdx-0.3.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.spdx-0.3.4.bazel
+++ b/third_party/cargo/remote/BUILD.spdx-0.3.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.spinning_top-0.2.2.bazel
+++ b/third_party/cargo/remote/BUILD.spinning_top-0.2.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.spinning_top-0.2.2.bazel
+++ b/third_party/cargo/remote/BUILD.spinning_top-0.2.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.static_assertions-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.static_assertions-1.1.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.static_assertions-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.static_assertions-1.1.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.string_cache-0.8.1.bazel
+++ b/third_party/cargo/remote/BUILD.string_cache-0.8.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.string_cache-0.8.1.bazel
+++ b/third_party/cargo/remote/BUILD.string_cache-0.8.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.strsim-0.9.3.bazel
+++ b/third_party/cargo/remote/BUILD.strsim-0.9.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.strsim-0.9.3.bazel
+++ b/third_party/cargo/remote/BUILD.strsim-0.9.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.syn-1.0.58.bazel
+++ b/third_party/cargo/remote/BUILD.syn-1.0.58.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.syn-1.0.58.bazel
+++ b/third_party/cargo/remote/BUILD.syn-1.0.58.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.tar-0.4.30.bazel
+++ b/third_party/cargo/remote/BUILD.tar-0.4.30.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.tar-0.4.30.bazel
+++ b/third_party/cargo/remote/BUILD.tar-0.4.30.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.tempfile-3.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.tempfile-3.2.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.tempfile-3.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.tempfile-3.2.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.tera-1.6.1.bazel
+++ b/third_party/cargo/remote/BUILD.tera-1.6.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.tera-1.6.1.bazel
+++ b/third_party/cargo/remote/BUILD.tera-1.6.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.term-0.5.2.bazel
+++ b/third_party/cargo/remote/BUILD.term-0.5.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.term-0.5.2.bazel
+++ b/third_party/cargo/remote/BUILD.term-0.5.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.thread_local-1.1.1.bazel
+++ b/third_party/cargo/remote/BUILD.thread_local-1.1.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.thread_local-1.1.1.bazel
+++ b/third_party/cargo/remote/BUILD.thread_local-1.1.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.time-0.1.43.bazel
+++ b/third_party/cargo/remote/BUILD.time-0.1.43.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.time-0.1.43.bazel
+++ b/third_party/cargo/remote/BUILD.time-0.1.43.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.tiny-keccak-2.0.2.bazel
+++ b/third_party/cargo/remote/BUILD.tiny-keccak-2.0.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.tiny-keccak-2.0.2.bazel
+++ b/third_party/cargo/remote/BUILD.tiny-keccak-2.0.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.tinyvec-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.tinyvec-1.1.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.tinyvec-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.tinyvec-1.1.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.tinyvec_macros-0.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.tinyvec_macros-0.1.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.tinyvec_macros-0.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.tinyvec_macros-0.1.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.tokio-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.tokio-1.1.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.tokio-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.tokio-1.1.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.tokio-macros-1.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.tokio-macros-1.0.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.tokio-macros-1.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.tokio-macros-1.0.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.tokio-native-tls-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.tokio-native-tls-0.3.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.tokio-native-tls-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.tokio-native-tls-0.3.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.tokio-stream-0.1.2.bazel
+++ b/third_party/cargo/remote/BUILD.tokio-stream-0.1.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.tokio-stream-0.1.2.bazel
+++ b/third_party/cargo/remote/BUILD.tokio-stream-0.1.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.tokio-util-0.6.2.bazel
+++ b/third_party/cargo/remote/BUILD.tokio-util-0.6.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.tokio-util-0.6.2.bazel
+++ b/third_party/cargo/remote/BUILD.tokio-util-0.6.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.toml-0.5.8.bazel
+++ b/third_party/cargo/remote/BUILD.toml-0.5.8.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.toml-0.5.8.bazel
+++ b/third_party/cargo/remote/BUILD.toml-0.5.8.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.tower-service-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.tower-service-0.3.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.tower-service-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.tower-service-0.3.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.tracing-0.1.22.bazel
+++ b/third_party/cargo/remote/BUILD.tracing-0.1.22.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.tracing-0.1.22.bazel
+++ b/third_party/cargo/remote/BUILD.tracing-0.1.22.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.tracing-attributes-0.1.11.bazel
+++ b/third_party/cargo/remote/BUILD.tracing-attributes-0.1.11.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.tracing-attributes-0.1.11.bazel
+++ b/third_party/cargo/remote/BUILD.tracing-attributes-0.1.11.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.tracing-core-0.1.17.bazel
+++ b/third_party/cargo/remote/BUILD.tracing-core-0.1.17.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.tracing-core-0.1.17.bazel
+++ b/third_party/cargo/remote/BUILD.tracing-core-0.1.17.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.tracing-futures-0.2.4.bazel
+++ b/third_party/cargo/remote/BUILD.tracing-futures-0.2.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.tracing-futures-0.2.4.bazel
+++ b/third_party/cargo/remote/BUILD.tracing-futures-0.2.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.try-lock-0.2.3.bazel
+++ b/third_party/cargo/remote/BUILD.try-lock-0.2.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.try-lock-0.2.3.bazel
+++ b/third_party/cargo/remote/BUILD.try-lock-0.2.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.typenum-1.12.0.bazel
+++ b/third_party/cargo/remote/BUILD.typenum-1.12.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.typenum-1.12.0.bazel
+++ b/third_party/cargo/remote/BUILD.typenum-1.12.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.ucd-trie-0.1.3.bazel
+++ b/third_party/cargo/remote/BUILD.ucd-trie-0.1.3.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.ucd-trie-0.1.3.bazel
+++ b/third_party/cargo/remote/BUILD.ucd-trie-0.1.3.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.unic-char-property-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.unic-char-property-0.9.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.unic-char-property-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.unic-char-property-0.9.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.unic-char-range-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.unic-char-range-0.9.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.unic-char-range-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.unic-char-range-0.9.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.unic-common-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.unic-common-0.9.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.unic-common-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.unic-common-0.9.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.unic-segment-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.unic-segment-0.9.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.unic-segment-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.unic-segment-0.9.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.unic-ucd-segment-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.unic-ucd-segment-0.9.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.unic-ucd-segment-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.unic-ucd-segment-0.9.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.unic-ucd-version-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.unic-ucd-version-0.9.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.unic-ucd-version-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.unic-ucd-version-0.9.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.unicode-bidi-0.3.4.bazel
+++ b/third_party/cargo/remote/BUILD.unicode-bidi-0.3.4.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.unicode-bidi-0.3.4.bazel
+++ b/third_party/cargo/remote/BUILD.unicode-bidi-0.3.4.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.unicode-normalization-0.1.16.bazel
+++ b/third_party/cargo/remote/BUILD.unicode-normalization-0.1.16.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.unicode-normalization-0.1.16.bazel
+++ b/third_party/cargo/remote/BUILD.unicode-normalization-0.1.16.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.unicode-xid-0.2.1.bazel
+++ b/third_party/cargo/remote/BUILD.unicode-xid-0.2.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.unicode-xid-0.2.1.bazel
+++ b/third_party/cargo/remote/BUILD.unicode-xid-0.2.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.unindent-0.1.7.bazel
+++ b/third_party/cargo/remote/BUILD.unindent-0.1.7.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.unindent-0.1.7.bazel
+++ b/third_party/cargo/remote/BUILD.unindent-0.1.7.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.url-2.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.url-2.2.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.url-2.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.url-2.2.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.vcpkg-0.2.11.bazel
+++ b/third_party/cargo/remote/BUILD.vcpkg-0.2.11.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.vcpkg-0.2.11.bazel
+++ b/third_party/cargo/remote/BUILD.vcpkg-0.2.11.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.vec-arena-1.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.vec-arena-1.0.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.vec-arena-1.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.vec-arena-1.0.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.version_check-0.9.2.bazel
+++ b/third_party/cargo/remote/BUILD.version_check-0.9.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.version_check-0.9.2.bazel
+++ b/third_party/cargo/remote/BUILD.version_check-0.9.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.waker-fn-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.waker-fn-1.1.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.waker-fn-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.waker-fn-1.1.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.walkdir-2.3.1.bazel
+++ b/third_party/cargo/remote/BUILD.walkdir-2.3.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.walkdir-2.3.1.bazel
+++ b/third_party/cargo/remote/BUILD.walkdir-2.3.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.want-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.want-0.3.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.want-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.want-0.3.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.wasi-0.10.1+wasi-snapshot-preview1.bazel
+++ b/third_party/cargo/remote/BUILD.wasi-0.10.1+wasi-snapshot-preview1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.wasi-0.10.1+wasi-snapshot-preview1.bazel
+++ b/third_party/cargo/remote/BUILD.wasi-0.10.1+wasi-snapshot-preview1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.wasi-0.9.0+wasi-snapshot-preview1.bazel
+++ b/third_party/cargo/remote/BUILD.wasi-0.9.0+wasi-snapshot-preview1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.wasi-0.9.0+wasi-snapshot-preview1.bazel
+++ b/third_party/cargo/remote/BUILD.wasi-0.9.0+wasi-snapshot-preview1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.wasm-bindgen-0.2.69.bazel
+++ b/third_party/cargo/remote/BUILD.wasm-bindgen-0.2.69.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.wasm-bindgen-0.2.69.bazel
+++ b/third_party/cargo/remote/BUILD.wasm-bindgen-0.2.69.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.wasm-bindgen-backend-0.2.69.bazel
+++ b/third_party/cargo/remote/BUILD.wasm-bindgen-backend-0.2.69.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.wasm-bindgen-backend-0.2.69.bazel
+++ b/third_party/cargo/remote/BUILD.wasm-bindgen-backend-0.2.69.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.wasm-bindgen-futures-0.4.19.bazel
+++ b/third_party/cargo/remote/BUILD.wasm-bindgen-futures-0.4.19.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.wasm-bindgen-futures-0.4.19.bazel
+++ b/third_party/cargo/remote/BUILD.wasm-bindgen-futures-0.4.19.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.wasm-bindgen-macro-0.2.69.bazel
+++ b/third_party/cargo/remote/BUILD.wasm-bindgen-macro-0.2.69.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.wasm-bindgen-macro-0.2.69.bazel
+++ b/third_party/cargo/remote/BUILD.wasm-bindgen-macro-0.2.69.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.wasm-bindgen-macro-support-0.2.69.bazel
+++ b/third_party/cargo/remote/BUILD.wasm-bindgen-macro-support-0.2.69.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.wasm-bindgen-macro-support-0.2.69.bazel
+++ b/third_party/cargo/remote/BUILD.wasm-bindgen-macro-support-0.2.69.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.wasm-bindgen-shared-0.2.69.bazel
+++ b/third_party/cargo/remote/BUILD.wasm-bindgen-shared-0.2.69.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.wasm-bindgen-shared-0.2.69.bazel
+++ b/third_party/cargo/remote/BUILD.wasm-bindgen-shared-0.2.69.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.web-sys-0.3.46.bazel
+++ b/third_party/cargo/remote/BUILD.web-sys-0.3.46.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.web-sys-0.3.46.bazel
+++ b/third_party/cargo/remote/BUILD.web-sys-0.3.46.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.wepoll-sys-3.0.1.bazel
+++ b/third_party/cargo/remote/BUILD.wepoll-sys-3.0.1.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.wepoll-sys-3.0.1.bazel
+++ b/third_party/cargo/remote/BUILD.wepoll-sys-3.0.1.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/third_party/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/third_party/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.winapi-util-0.1.5.bazel
+++ b/third_party/cargo/remote/BUILD.winapi-util-0.1.5.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.winapi-util-0.1.5.bazel
+++ b/third_party/cargo/remote/BUILD.winapi-util-0.1.5.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
@@ -29,6 +31,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/third_party/cargo/remote/BUILD.winreg-0.7.0.bazel
+++ b/third_party/cargo/remote/BUILD.winreg-0.7.0.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.winreg-0.7.0.bazel
+++ b/third_party/cargo/remote/BUILD.winreg-0.7.0.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 

--- a/third_party/cargo/remote/BUILD.xattr-0.2.2.bazel
+++ b/third_party/cargo/remote/BUILD.xattr-0.2.2.bazel
@@ -5,7 +5,9 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-# buildifier: disable=out-of-order-load
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,10 +15,6 @@ load(
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/third_party/cargo/remote/BUILD.xattr-0.2.2.bazel
+++ b/third_party/cargo/remote/BUILD.xattr-0.2.2.bazel
@@ -5,6 +5,7 @@ cargo-raze crate build file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
@@ -13,6 +14,7 @@ load(
     "rust_test",
 )
 
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load
 load("@bazel_skylib//lib:selects.bzl", "selects")
 


### PR DESCRIPTION
This makes it so users running `buildifier -lint=fix -mode=fix -warnings=all -r ./` don't generate diffs in the generated build files. The output build files should now stay the same no matter what buildifier flags are used.