### PR TITLE
Set `CARGO` and `RUSTC` environment variables to make Bazel tests more hermetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_rust",
-    sha256 = "42e60f81e2b269d28334b73b70d02fb516c8de0c16242f5d376bfe6d94a3509f",
-    strip_prefix = "rules_rust-58f709ffec90da93c4e622d8d94f0cd55cd2ef54",
+    sha256 = "accb5a89cbe63d55dcdae85938e56ff3aa56f21eb847ed826a28a83db8500ae6",
+    strip_prefix = "rules_rust-9aa49569b2b0dacecc51c05cee52708b7255bd98",
     urls = [
-        # Main branch as of 2021-02-04
-        "https://github.com/bazelbuild/rules_rust/archive/58f709ffec90da93c4e622d8d94f0cd55cd2ef54.tar.gz",
+        # Main branch as of 2021-02-19
+        "https://github.com/bazelbuild/rules_rust/archive/9aa49569b2b0dacecc51c05cee52708b7255bd98.tar.gz",
     ],
 )
 

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,11 +4,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_rust",
-    sha256 = "42e60f81e2b269d28334b73b70d02fb516c8de0c16242f5d376bfe6d94a3509f",
-    strip_prefix = "rules_rust-58f709ffec90da93c4e622d8d94f0cd55cd2ef54",
+    sha256 = "accb5a89cbe63d55dcdae85938e56ff3aa56f21eb847ed826a28a83db8500ae6",
+    strip_prefix = "rules_rust-9aa49569b2b0dacecc51c05cee52708b7255bd98",
     urls = [
-        # Main branch as of 2021-02-04
-        "https://github.com/bazelbuild/rules_rust/archive/58f709ffec90da93c4e622d8d94f0cd55cd2ef54.tar.gz",
+        # Main branch as of 2021-02-19
+        "https://github.com/bazelbuild/rules_rust/archive/9aa49569b2b0dacecc51c05cee52708b7255bd98.tar.gz",
     ],
 )
 

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -4,11 +4,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_rust",
-    sha256 = "42e60f81e2b269d28334b73b70d02fb516c8de0c16242f5d376bfe6d94a3509f",
-    strip_prefix = "rules_rust-58f709ffec90da93c4e622d8d94f0cd55cd2ef54",
+    sha256 = "accb5a89cbe63d55dcdae85938e56ff3aa56f21eb847ed826a28a83db8500ae6",
+    strip_prefix = "rules_rust-9aa49569b2b0dacecc51c05cee52708b7255bd98",
     urls = [
-        # Main branch as of 2021-02-04
-        "https://github.com/bazelbuild/rules_rust/archive/58f709ffec90da93c4e622d8d94f0cd55cd2ef54.tar.gz",
+        # Main branch as of 2021-02-19
+        "https://github.com/bazelbuild/rules_rust/archive/9aa49569b2b0dacecc51c05cee52708b7255bd98.tar.gz",
     ],
 )
 

--- a/impl/BUILD.bazel
+++ b/impl/BUILD.bazel
@@ -13,6 +13,7 @@ rust_library(
         ["src/**/*.template"],
         exclude = ["src/testing/**/*.template"],
     ),
+    edition = "2018",
     proc_macro_deps = all_crate_deps(proc_macro = True),
     deps = all_crate_deps(),
 )
@@ -22,14 +23,52 @@ rust_binary(
     srcs = [
         "src/bin/cargo-raze.rs",
     ],
+    edition = "2018",
     proc_macro_deps = all_crate_deps(proc_macro = True),
     deps = [":cargo_raze"] + all_crate_deps(),
 )
 
+alias(
+    name = "cargo",
+    actual = select({
+        "@rules_rust//rust/platform:aarch64-apple-darwin": "@rust_darwin_aarch64//:cargo",
+        "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": "@rust_linux_aarch64//:cargo",
+        "@rules_rust//rust/platform:x86_64-apple-darwin": "@rust_darwin_x86_64//:cargo",
+        "@rules_rust//rust/platform:x86_64-pc-windows-msvc": "@rust_windows_x86_64//:cargo",
+        "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": "@rust_linux_x86_64//:cargo",
+    }),
+    visibility = ["//visibility:private"],
+)
+
+alias(
+    name = "rustc",
+    actual = select({
+        "@rules_rust//rust/platform:aarch64-apple-darwin": "@rust_darwin_aarch64//:rustc",
+        "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": "@rust_linux_aarch64//:rustc",
+        "@rules_rust//rust/platform:x86_64-apple-darwin": "@rust_darwin_x86_64//:rustc",
+        "@rules_rust//rust/platform:x86_64-pc-windows-msvc": "@rust_windows_x86_64//:rustc",
+        "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": "@rust_linux_x86_64//:rustc",
+    }),
+    visibility = ["//visibility:private"],
+)
+
+_TEST_DATA = glob(["src/**/*.template"]) + [
+    ":cargo",
+    ":rustc",
+]
+
+_TEST_ENV = {
+    "CARGO": "$(execpath :cargo)",
+    "CARGO_HOME": "$(execpath :cargo).home",
+    "RUSTC": "$(execpath :rustc)",
+}
+
 rust_test(
     name = "cargo_raze_lib_test",
     crate = ":cargo_raze",
-    data = glob(["src/**/*.template"]),
+    data = _TEST_DATA,
+    edition = "2018",
+    env = _TEST_ENV,
     proc_macro_deps = all_crate_deps(proc_macro_dev = True),
     deps = all_crate_deps(normal_dev = True),
 )
@@ -37,7 +76,9 @@ rust_test(
 rust_test(
     name = "cargo_raze_bin_test",
     crate = ":cargo_raze_bin",
-    data = glob(["src/**/*.template"]),
+    data = _TEST_DATA,
+    edition = "2018",
+    env = _TEST_ENV,
     proc_macro_deps = all_crate_deps(proc_macro_dev = True),
     deps = all_crate_deps(normal_dev = True),
 )


### PR DESCRIPTION
Using the changes introduced in https://github.com/bazelbuild/rules_rust/pull/588, cargo raze can now correctly specify the `cargo` and `rustc` binaries to use during tests and no longer require the host to have either installed. For users running the target, however, the binaries are still required to be installed but this should be a simple change that can be made in the future