### PR TITLE
Fixed missing "CARGO" environment variable uses

### DIFF
--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -14,9 +14,8 @@
 
 use crate::{
   error::RazeError,
-  metadata::{
-    MetadataFetcher, DEFAULT_CRATE_INDEX_URL, DEFAULT_CRATE_REGISTRY_URL, SYSTEM_CARGO_BIN_PATH,
-  },
+  metadata::{MetadataFetcher, DEFAULT_CRATE_INDEX_URL, DEFAULT_CRATE_REGISTRY_URL},
+  util,
 };
 use anyhow::{anyhow, Context, Result};
 use cargo_metadata::{Metadata, MetadataCommand, Package};
@@ -24,7 +23,6 @@ use semver::VersionReq;
 use serde::{Deserialize, Serialize};
 use std::{
   collections::HashMap,
-  env,
   hash::Hash,
   path::{Path, PathBuf},
 };
@@ -700,9 +698,7 @@ pub struct SettingsMetadataFetcher {
 impl Default for SettingsMetadataFetcher {
   fn default() -> SettingsMetadataFetcher {
     SettingsMetadataFetcher {
-      cargo_bin_path: env::var("CARGO")
-        .unwrap_or_else(|_| SYSTEM_CARGO_BIN_PATH.to_string())
-        .into(),
+      cargo_bin_path: util::cargo_bin_path(),
     }
   }
 }
@@ -731,12 +727,17 @@ pub fn load_settings_from_manifest<T: AsRef<Path>>(
   cargo_toml_path: T,
   cargo_bin_path: Option<String>,
 ) -> Result<RazeSettings, RazeError> {
-  // Create a MetadataFetcher from either an optional Cargo binary path
-  // or a fallback expected to be found on the system.
+  // Get the path to the cargo binary from either an optional Cargo binary
+  // path or a fallback expected to be found on the system.
+  let bin_path: PathBuf = if let Some(path) = cargo_bin_path {
+    path.into()
+  } else {
+    util::cargo_bin_path()
+  };
+
+  // Create a MetadataFetcher
   let fetcher = SettingsMetadataFetcher {
-    cargo_bin_path: cargo_bin_path
-      .unwrap_or_else(|| SYSTEM_CARGO_BIN_PATH.to_string())
-      .into(),
+    cargo_bin_path: bin_path,
   };
 
   let cargo_toml_dir = cargo_toml_path.as_ref().parent().ok_or_else(|| {

--- a/impl/src/util.rs
+++ b/impl/src/util.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{fmt, iter::Iterator, path::Path, path::PathBuf, process::Command, str::FromStr};
+use std::{env, fmt, iter::Iterator, path::Path, path::PathBuf, process::Command, str::FromStr};
 
 use anyhow::{anyhow, Result};
 
@@ -21,6 +21,7 @@ use cargo_platform::Cfg;
 use cfg_expr::{targets::get_builtin_target_by_triple, Expression, Predicate};
 use pathdiff::diff_paths;
 
+pub(crate) const SYSTEM_CARGO_BIN_PATH: &str = "cargo";
 pub(crate) const RAZE_LOCKFILE_NAME: &str = "Cargo.raze.lock";
 
 static SUPPORTED_PLATFORM_TRIPLES: &[&str] = &[
@@ -339,6 +340,11 @@ pub fn find_lockfile(cargo_workspace_root: &Path, raze_output_dir: &Path) -> Opt
 
   // No lockfile is available.
   None
+}
+
+/// Locates a cargo binary form either an evironment variable or PATH
+pub fn cargo_bin_path() -> PathBuf {
+  PathBuf::from(env::var("CARGO").unwrap_or_else(|_| SYSTEM_CARGO_BIN_PATH.to_string()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
A bug was fixed where the `"CARGO"` environment variable wasn't being when looking for a cargo binary. This has been corrected and is now in use.