### PR TITLE
Disable windows build in Buildkite, and update badge

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -7,11 +7,11 @@ tasks:
       - "..."
     test_targets:
       - "..."
-  windows:
-    build_targets:
-      - "..."
-    test_targets:
-      - "..."
+# windows:
+#   build_targets:
+#     - "..."
+#   test_targets:
+#     - "..."
   macos:
     build_targets:
       - "..."

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # cargo-raze: Bazel BUILD generation for Rust Crates
 
-[![Build Status](https://travis-ci.org/google/cargo-raze.svg?branch=master)](https://travis-ci.org/google/cargo-raze)
+[![Build
+status](https://badge.buildkite.com/bd8945700a2e0ddb094b1fefabde71cb81bad9a93bb774c384.svg)](https://buildkite.com/bazel/cargo-raze)
 
 An experimental support Cargo plugin for distilling a workspace-level
 Cargo.toml into BUILD targets that code using [rules_rust](https://github.com/bazelbuild/rules_rust)


### PR DESCRIPTION
Windows is broken for a somewhat inconsequential reason:

TL;DR: It can't execute the repository rule for `cargo_raze_examples`. I think this can be skipped in windows if necessary.

```
$ bazel --output_user_root=C:/b --nomaster_bazelrc --bazelrc=/dev/null info
--
  | INFO: SHA256 (https://static.rust-lang.org/dist/cargo-1.49.0-x86_64-pc-windows-msvc.tar.gz) = 84b44835a3f275fef70cd86a527d086c537e59fb3209fe8bbef1eeb1da6edbb6
  | INFO: Repository cargo_raze_examples instantiated at:
  | C:/b/bk-windows-r4v8/bazel/cargo-raze/WORKSPACE.bazel:32:20: in <toplevel>
  | C:/b/bk-windows-r4v8/bazel/cargo-raze/tools/examples_repository.bzl:108:25: in examples_repository
  | Repository rule _examples_repository defined at:
  | C:/b/bk-windows-r4v8/bazel/cargo-raze/tools/examples_repository.bzl:82:39: in <toplevel>
  | ERROR: An error occurred during the fetch of repository 'cargo_raze_examples':
  | Traceback (most recent call last):
  | File "C:/b/bk-windows-r4v8/bazel/cargo-raze/tools/examples_repository.bzl", line 76, column 13, in _examples_repository_impl
  | fail(EXECUTE_FAIL_MESSAGE.format(
  | Error in fail: Failed to setup examples repository with exit code (256).
  | --------stdout:
  |  
  | --------stderr:
  | java.io.IOException: ERROR: src/main/native/windows/process.cc(202): CreateProcessW("C:\b\bk-windows-r4v8\bazel\cargo-raze\tools\examples_repository_tools.sh" vendor): %1 is not a valid Win32 application.
  | (error: 193)
  | ERROR: Error fetching repository: Traceback (most recent call last):
  | File "C:/b/bk-windows-r4v8/bazel/cargo-raze/tools/examples_repository.bzl", line 76, column 13, in _examples_repository_impl
  | fail(EXECUTE_FAIL_MESSAGE.format(
  | Error in fail: Failed to setup examples repository with exit code (256).
  | --------stdout:
  |  
  | --------stderr:
  | java.io.IOException: ERROR: src/main/native/windows/process.cc(202): CreateProcessW("C:\b\bk-windows-r4v8\bazel\cargo-raze\tools\examples_repository_tools.sh" vendor): %1 is not a valid Win32 application.
  | (error: 193)
  | ERROR: no such package '@cargo_raze_examples//': Failed to setup examples repository with exit code (256).
  | --------stdout:

```