### PR TITLE
Revert "Ensure examples are up to date in CI"

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,14 +3,13 @@ buildifier:
   version: latest
   warnings: "all"
 tasks:
-  ubuntu2004:
+  # TODO(acmcarther): Add check to verify that examples are up-to-date.
+  ubuntu1804:
     build_targets:
       - "..."
     test_targets:
       - "..."
-    run_targets:
-      - "//tools:examples_check"
-# windows
+# windows:
 #   build_targets:
 #     - "..."
 #   test_targets:


### PR DESCRIPTION
Reverts google/cargo-raze#375

This is broken. Aside from whatever induced the breakage, it's also super spammy in the logs:

https://buildkite.com/organizations/bazel/pipelines/cargo-raze/builds/68/jobs/8c6c14e5-5d97-4e8e-ad07-e159cb8fd185/raw_log
 
literally MBs of this:
```

Running Cargo Vendor for cargo_workspace

/workdir/examples/vendored/cargo_workspace /workdir/examples/vendored/cargo_workspace ~/.cache/bazel/_bazel_buildkite-agent/ec321eb2cc2d0f8f91b676b6d4c66c29/execroot/cargo_raze/bazel-out/k8-fastbuild/bin/tools/examples_check.runfiles/cargo_raze

Running Cargo Vendor for cargo_workspace

/workdir/examples/vendored/cargo_workspace /workdir/examples/vendored/cargo_workspace /workdir/examples/vendored/cargo_workspace ~/.cache/bazel/_bazel_buildkite-agent/ec321eb2cc2d0f8f91b676b6d4c66c29/execroot/cargo_raze/bazel-out/k8-fastbuild/bin/tools/examples_check.runfiles/cargo_raze

Running Cargo Vendor for cargo_workspace

/workdir/examples/vendored/cargo_workspace /workdir/examples/vendored/cargo_workspace /workdir/examples/vendored/cargo_workspace /workdir/examples/vendored/cargo_workspace ~/.cache/bazel/_bazel_buildkite-agent/ec321eb2cc2d0f8f91b676b6d4c66c29/execroot/cargo_raze/bazel-out/k8-fastbuild/bin/tools/examples_check.runfiles/cargo_raze

```