### PR TITLE
Update to latest `rules_foreign_cc` commit

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -17,10 +17,10 @@ def cargo_raze_repositories():
     maybe(
         http_archive,
         name = "rules_foreign_cc",
-        sha256 = "379b1cd5cd13da154ba99df3aeb91f9cbb81910641fc520bb90f2a95e324353d",
-        strip_prefix = "rules_foreign_cc-689c96aaa7337eb129235e5388f4ebc88fa14e87",
+        sha256 = "a45511a054598dd9b87d4d5765a18df4e5777736026087cf96ffc30704e6c918",
+        strip_prefix = "rules_foreign_cc-87df6b25f6c009883da87f07ea680d38780a4d6f",
         urls = [
-            "https://github.com/bazelbuild/rules_foreign_cc/archive/689c96aaa7337eb129235e5388f4ebc88fa14e87.zip",
+            "https://github.com/bazelbuild/rules_foreign_cc/archive/87df6b25f6c009883da87f07ea680d38780a4d6f.zip",
         ],
     )
 

--- a/third_party/curl/BUILD.curl.bazel
+++ b/third_party/curl/BUILD.curl.bazel
@@ -8,7 +8,7 @@ filegroup(
 _CACHE_ENTRIES = {
     "BUILD_CURL_EXE": "off",
     "BUILD_SHARED_LIBS": "off",
-    "CMAKE_PREFIX_PATH": "$CMAKE_PREFIX_PATH;$EXT_BUILD_DEPS/openssl",
+    "CMAKE_PREFIX_PATH": "$EXT_BUILD_DEPS/openssl",
     # TODO: ldap should likely be enabled
     "CURL_DISABLE_LDAP": "on",
 }
@@ -19,7 +19,7 @@ _MACOS_CACHE_ENTRIES = dict(_CACHE_ENTRIES.items() + {
 }.items())
 
 _LINUX_CACHE_ENTRIES = dict(_CACHE_ENTRIES.items() + {
-    "CMAKE_C_FLAGS": "$CMAKE_C_FLAGS -fPIC",
+    "CMAKE_C_FLAGS": "-fPIC",
 }.items())
 
 cmake_external(

--- a/third_party/libgit2/BUILD.libgit2.bazel
+++ b/third_party/libgit2/BUILD.libgit2.bazel
@@ -13,13 +13,13 @@ _CACHE_ENTRIES = {
     "BUILD_EXAMPLES": "off",
     "BUILD_FUZZERS": "off",
     "BUILD_SHARED_LIBS": "off",
-    "CMAKE_PREFIX_PATH": "$EXT_BUILD_DEPS/pcre;$EXT_BUILD_DEPS/openssl;$EXT_BUILD_DEPS/libssh2;$EXT_BUILD_DEPS/zlib;$CMAKE_PREFIX_PATH",
+    "CMAKE_PREFIX_PATH": "$EXT_BUILD_DEPS/pcre;$EXT_BUILD_DEPS/openssl;$EXT_BUILD_DEPS/libssh2;$EXT_BUILD_DEPS/zlib",
     "EMBED_SSH_PATH": "$(execpath @cargo_raze__libssh2//:libssh2)",
     "USE_HTTPS": "on",
 }
 
 _LINUX_CACHE_ENTRIES = dict(_CACHE_ENTRIES.items() + {
-    "CMAKE_C_FLAGS": "$CMAKE_C_FLAGS -fPIC",
+    "CMAKE_C_FLAGS": "-fPIC",
     "REGEX_BACKEND": "pcre",
 }.items())
 

--- a/third_party/libssh2/BUILD.libssh2.bazel
+++ b/third_party/libssh2/BUILD.libssh2.bazel
@@ -10,11 +10,11 @@ _CACHE_ENTRIES = {
     "BUILD_SHARED_LIBS": "off",
     "BUILD_TESTING": "off",
     "CMAKE_FIND_DEBUG_MODE": "on",
-    "CMAKE_PREFIX_PATH": "$CMAKE_PREFIX_PATH;$EXT_BUILD_DEPS/openssl",
+    "CMAKE_PREFIX_PATH": "$EXT_BUILD_DEPS/openssl",
 }
 
 _LINUX_CACHE_ENTRIES = dict(_CACHE_ENTRIES.items() + {
-    "CMAKE_C_FLAGS": "$CMAKE_C_FLAGS -fPIC",
+    "CMAKE_C_FLAGS": "-fPIC",
 }.items())
 
 cmake_external(

--- a/third_party/pcre/BUILD.pcre.bazel
+++ b/third_party/pcre/BUILD.pcre.bazel
@@ -10,7 +10,7 @@ filegroup(
 cmake_external(
     name = "pcre",
     cache_entries = {
-        "CMAKE_C_FLAGS": "$CMAKE_C_FLAGS -fPIC",
+        "CMAKE_C_FLAGS": "-fPIC",
     },
     lib_source = ":all",
     static_libraries = ["libpcre.a"],


### PR DESCRIPTION
There is a MacOS bug fix in the latest `rules_foreign_cc` release that should be included here if users are going to be relying on building `cargo-raze` in Bazel. This also fixes some bugs that're now caught in the newest commit.