### PR TITLE
Fixed the need for cargo on the host when running `//:raze`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,7 +6,7 @@ alias(
 
 alias(
     name = "raze",
-    actual = "//impl:cargo_raze_bin",
+    actual = "//tools:raze",
     visibility = ["//visibility:public"],
 )
 

--- a/impl/BUILD.bazel
+++ b/impl/BUILD.bazel
@@ -28,39 +28,15 @@ rust_binary(
     deps = [":cargo_raze"] + all_crate_deps(),
 )
 
-alias(
-    name = "cargo",
-    actual = select({
-        "@rules_rust//rust/platform:aarch64-apple-darwin": "@rust_darwin_aarch64//:cargo",
-        "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": "@rust_linux_aarch64//:cargo",
-        "@rules_rust//rust/platform:x86_64-apple-darwin": "@rust_darwin_x86_64//:cargo",
-        "@rules_rust//rust/platform:x86_64-pc-windows-msvc": "@rust_windows_x86_64//:cargo",
-        "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": "@rust_linux_x86_64//:cargo",
-    }),
-    visibility = ["//visibility:private"],
-)
-
-alias(
-    name = "rustc",
-    actual = select({
-        "@rules_rust//rust/platform:aarch64-apple-darwin": "@rust_darwin_aarch64//:rustc",
-        "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": "@rust_linux_aarch64//:rustc",
-        "@rules_rust//rust/platform:x86_64-apple-darwin": "@rust_darwin_x86_64//:rustc",
-        "@rules_rust//rust/platform:x86_64-pc-windows-msvc": "@rust_windows_x86_64//:rustc",
-        "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": "@rust_linux_x86_64//:rustc",
-    }),
-    visibility = ["//visibility:private"],
-)
-
 _TEST_DATA = glob(["src/**/*.template"]) + [
-    ":cargo",
-    ":rustc",
+    "//tools:cargo",
+    "//tools:rustc",
 ]
 
 _TEST_ENV = {
-    "CARGO": "$(execpath :cargo)",
-    "CARGO_HOME": "$(execpath :cargo).home",
-    "RUSTC": "$(execpath :rustc)",
+    "CARGO": "$(execpath //tools:cargo)",
+    "CARGO_HOME": "$(execpath //tools:cargo).home",
+    "RUSTC": "$(execpath //tools:rustc)",
 }
 
 rust_test(

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -40,3 +40,40 @@ sh_binary(
     ],
     data = ["//impl:cargo_raze_bin"],
 )
+
+alias(
+    name = "cargo",
+    actual = select({
+        "@rules_rust//rust/platform:aarch64-apple-darwin": "@rust_darwin_aarch64//:cargo",
+        "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": "@rust_linux_aarch64//:cargo",
+        "@rules_rust//rust/platform:x86_64-apple-darwin": "@rust_darwin_x86_64//:cargo",
+        "@rules_rust//rust/platform:x86_64-pc-windows-msvc": "@rust_windows_x86_64//:cargo",
+        "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": "@rust_linux_x86_64//:cargo",
+    }),
+)
+
+alias(
+    name = "rustc",
+    actual = select({
+        "@rules_rust//rust/platform:aarch64-apple-darwin": "@rust_darwin_aarch64//:rustc",
+        "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": "@rust_linux_aarch64//:rustc",
+        "@rules_rust//rust/platform:x86_64-apple-darwin": "@rust_darwin_x86_64//:rustc",
+        "@rules_rust//rust/platform:x86_64-pc-windows-msvc": "@rust_windows_x86_64//:rustc",
+        "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": "@rust_linux_x86_64//:rustc",
+    }),
+)
+
+sh_binary(
+    name = "raze",
+    srcs = ["wrapper.sh"],
+    data = [
+        ":cargo",
+        ":rustc",
+        "//impl:cargo_raze_bin",
+    ],
+    env = {
+        "CARGO": "$(execpath :cargo)",
+        "CARGO_RAZE": "$(execpath //impl:cargo_raze_bin)",
+        "RUSTC": "$(execpath :rustc)",
+    },
+)

--- a/tools/wrapper.sh
+++ b/tools/wrapper.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+exec env \
+CARGO="$(pwd)/${CARGO}" \
+RUSTC="$(pwd)/${RUSTC}" \
+"${BUILD_WORKSPACE_DIRECTORY}/${CARGO_RAZE}" "$@"


### PR DESCRIPTION
I forgot that I still have cargo installed on my machine when testing this scenario. The `//:raze` target should be a wrapper script that explicitly sets the needed environment variables for running `cargo-raze` without installing cargo components on the host

With the following diff:
```diff
diff --git a/examples/WORKSPACE b/examples/WORKSPACE
index 327a21ef..bf138d0c 100644
--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -19,3 +19,12 @@ rust_repositories()
 load("//:repositories.bzl", "repositories")

 repositories()
+
+local_repository(
+    name = "cargo_raze",
+    path = "..",
+)
+load("@cargo_raze//:repositories.bzl", "cargo_raze_repositories")
+cargo_raze_repositories()
+load("@cargo_raze//:transitive_deps.bzl", "cargo_raze_transitive_deps")
```

I'm still able to run raze in another workspace
```
examples % bazel run @cargo_raze//:raze -- --help
```
```
INFO: Invocation ID: d2c294cd-d33d-4df6-b66e-1fbb7a6b49e5
INFO: Analyzed target @cargo_raze//:raze (3 packages loaded, 372 targets configured).
INFO: Found 1 target...
Target @cargo_raze//tools:raze up-to-date:
  bazel-bin/external/cargo_raze/tools/raze
INFO: Elapsed time: 4.432s, Critical Path: 0.04s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
Generate BUILD files for your pre-vendored Cargo dependencies.

Usage:
    cargo-raze (-h | --help)
    cargo-raze (-V | --version)
    cargo-raze [--verbose] [--quiet] [--color=<WHEN>] [--dryrun] [--cargo-bin-path=<PATH>]
               [--manifest-path=<PATH>] [--output=<PATH>] [--generate-lockfile]

Options:
    -h, --help                          Print this message
    -V, --version                       Print version info and exit
    -v, --verbose                       Use verbose output
    -q, --quiet                         No output printed to stdout
    --color=<WHEN>                      Coloring: auto, always, never
    -d, --dryrun                        Do not emit any files
    --cargo-bin-path=<PATH>             Path to the cargo binary to be used for loading workspace metadata
    --manifest-path=<PATH>              Path to the Cargo.toml file to generate BUILD files for
    --output=<PATH>                     Path to output the generated into.
    --generate-lockfile                 Force a new `Cargo.raze.lock` file to be generated
```