### PR TITLE
Set links attribute

### DIFF
--- a/impl/src/rendering/templates/partials/build_script.template
+++ b/impl/src/rendering/templates/partials/build_script.template
@@ -38,6 +38,9 @@ cargo_build_script(
     {%- else %},
     {%- endif %}
     edition = "{{ crate.edition }}",
+    {%- if crate.links %}
+    links = "{{ crate.links }}",
+    {%- endif %}
     {%- if crate.default_deps.build_proc_macro_dependencies %}
     proc_macro_deps = [
     {%- for dependency in crate.default_deps.build_proc_macro_dependencies %}


### PR DESCRIPTION
This was added to rules_rust in
https://github.com/bazelbuild/rules_rust/pull/480 and we started parsing
out the metadata in cargo_raze in #281 but didn't start populating it in
generated BUILD files.

This enables us to remove a hack in rules_rust where we try to infer the
correct value for the `links` attribute if it wasn't set, based on the
name, which in turn will allow us to remove the `crate_name` attribute
completely.