### PR TITLE
Updated rules_foreign_cc to 0.2.0 and migrated rules to new api.

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -26,11 +26,9 @@ def cargo_raze_repositories():
     maybe(
         http_archive,
         name = "rules_foreign_cc",
-        sha256 = "a45511a054598dd9b87d4d5765a18df4e5777736026087cf96ffc30704e6c918",
-        strip_prefix = "rules_foreign_cc-87df6b25f6c009883da87f07ea680d38780a4d6f",
-        urls = [
-            "https://github.com/bazelbuild/rules_foreign_cc/archive/87df6b25f6c009883da87f07ea680d38780a4d6f.zip",
-        ],
+        sha256 = "d54742ffbdc6924f222d2179f0e10e911c5c659c4ae74158e9fe827aad862ac6",
+        strip_prefix = "rules_foreign_cc-0.2.0",
+        url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.2.0.tar.gz",
     )
 
     maybe(

--- a/third_party/curl/BUILD.curl.bazel
+++ b/third_party/curl/BUILD.curl.bazel
@@ -1,7 +1,7 @@
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 
 filegroup(
-    name = "all",
+    name = "all_srcs",
     srcs = glob(["**"]),
 )
 
@@ -22,15 +22,20 @@ _LINUX_CACHE_ENTRIES = dict(_CACHE_ENTRIES.items() + {
     "CMAKE_C_FLAGS": "-fPIC",
 }.items())
 
-cmake_external(
+cmake(
     name = "curl",
     cache_entries = select({
         "@rules_rust//rust/platform:darwin": _MACOS_CACHE_ENTRIES,
         "@rules_rust//rust/platform:linux": _LINUX_CACHE_ENTRIES,
         "//conditions:default": _CACHE_ENTRIES,
     }),
-    lib_source = ":all",
-    static_libraries = select({
+    cmake_options = select({
+        "@platforms//os:windows": ["-GNinja"],
+        "//conditions:default": [],
+    }),
+    generate_crosstool_file = False,
+    lib_source = ":all_srcs",
+    out_static_libs = select({
         # TODO: I'm guessing at this name. Needs to be checked on windows.
         "@rules_rust//rust/platform:windows": ["curl.lib"],
         "//conditions:default": ["libcurl.a"],

--- a/third_party/iconv/BUILD.iconv.bazel
+++ b/third_party/iconv/BUILD.iconv.bazel
@@ -1,6 +1,6 @@
 """libiconv is only expected to be used on MacOS systems"""
 
-load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
 
 filegroup(
     name = "all",
@@ -20,9 +20,7 @@ configure_make(
         "--enable-static=yes",
     ],
     lib_source = ":all",
-    make_commands = ["make install-lib"],
-    static_libraries = [
-        "libiconv.a",
-    ],
+    out_static_libs = ["libiconv.a"],
+    targets = ["install-lib"],
     visibility = ["//visibility:public"],
 )

--- a/third_party/libgit2/BUILD.libgit2.bazel
+++ b/third_party/libgit2/BUILD.libgit2.bazel
@@ -1,4 +1,4 @@
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 
 filegroup(
     name = "all",
@@ -23,14 +23,14 @@ _LINUX_CACHE_ENTRIES = dict(_CACHE_ENTRIES.items() + {
     "REGEX_BACKEND": "pcre",
 }.items())
 
-cmake_external(
+cmake(
     name = "libgit2",
     cache_entries = select({
         "@rules_rust//rust/platform:linux": _LINUX_CACHE_ENTRIES,
         "//conditions:default": _CACHE_ENTRIES,
     }),
     lib_source = ":all",
-    static_libraries = select({
+    out_static_libs = select({
         # TODO: I'm guessing at this name. Needs to be checked on windows.
         "@rules_rust//rust/platform:windows": ["git2.lib"],
         "//conditions:default": ["libgit2.a"],
@@ -38,8 +38,8 @@ cmake_external(
     visibility = ["//visibility:public"],
     deps = [
         "@cargo_raze__libssh2//:libssh2",
-        "@cargo_raze__zlib//:zlib",
         "@cargo_raze__openssl//:openssl",
+        "@cargo_raze__zlib//:zlib",
     ] + select({
         "@rules_rust//rust/platform:darwin": ["@cargo_raze__iconv//:iconv"],
         "@rules_rust//rust/platform:linux": ["@cargo_raze__pcre//:pcre"],

--- a/third_party/libssh2/BUILD.libssh2.bazel
+++ b/third_party/libssh2/BUILD.libssh2.bazel
@@ -1,4 +1,4 @@
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 
 filegroup(
     name = "all",
@@ -17,14 +17,14 @@ _LINUX_CACHE_ENTRIES = dict(_CACHE_ENTRIES.items() + {
     "CMAKE_C_FLAGS": "-fPIC",
 }.items())
 
-cmake_external(
+cmake(
     name = "libssh2",
     cache_entries = select({
         "@rules_rust//rust/platform:linux": _LINUX_CACHE_ENTRIES,
         "//conditions:default": _CACHE_ENTRIES,
     }),
     lib_source = "//:all",
-    static_libraries = select({
+    out_static_libs = select({
         # TODO: I'm guessing at this name. Needs to be checked on windows.
         "@rules_rust//rust/platform:windows": ["ssh2.lib"],
         "//conditions:default": ["libssh2.a"],

--- a/third_party/openssl/BUILD.openssl.bazel
+++ b/third_party/openssl/BUILD.openssl.bazel
@@ -2,12 +2,12 @@
 https://github.com/bazelbuild/rules_foreign_cc/issues/337
 """
 
-load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
 
 # Read https://wiki.openssl.org/index.php/Compilation_and_Installation
 
 filegroup(
-    name = "all",
+    name = "all_srcs",
     srcs = glob(["**"]),
 )
 
@@ -36,14 +36,14 @@ configure_make(
             "no-shared",
         ] + CONFIGURE_OPTIONS,
     }),
-    lib_source = ":all",
-    make_commands = [
-        "make build_libs",
-        "make install_dev",
-    ],
-    static_libraries = [
+    lib_source = ":all_srcs",
+    out_static_libs = [
         "libcrypto.a",
         "libssl.a",
+    ],
+    targets = [
+        "build_libs",
+        "install_dev",
     ],
     visibility = ["//visibility:public"],
 )

--- a/third_party/pcre/BUILD.pcre.bazel
+++ b/third_party/pcre/BUILD.pcre.bazel
@@ -1,18 +1,18 @@
 """pcre is only expected to be used on Linux systems"""
 
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 
 filegroup(
     name = "all",
     srcs = glob(["**"]),
 )
 
-cmake_external(
+cmake(
     name = "pcre",
     cache_entries = {
         "CMAKE_C_FLAGS": "-fPIC",
     },
     lib_source = ":all",
-    static_libraries = ["libpcre.a"],
+    out_static_libs = ["libpcre.a"],
     visibility = ["//visibility:public"],
 )

--- a/transitive_deps.bzl
+++ b/transitive_deps.bzl
@@ -1,6 +1,6 @@
 """A module defining the transitive dependencies of cargo-raze"""
 
-load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 
 def cargo_raze_transitive_deps():


### PR DESCRIPTION
[rules_foreign_cc 0.2.0](https://github.com/bazelbuild/rules_foreign_cc/releases/tag/0.2.0) was just cut and contains some API changes. This PR updates the user of `rules_foreign_cc` rules to use the new API.