### PR TITLE
Support additional registries

### DIFF
--- a/impl/Cargo.lock
+++ b/impl/Cargo.lock
@@ -2550,6 +2550,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -46,7 +46,7 @@ spdx = "0.3.4"
 tempfile = "3.2.0"
 tera = "1.6.1"
 toml = "0.5.8"
-url = "2.2.0"
+url = { version = "2.2.0", features = ["serde"] }
 
 [dev-dependencies]
 flate2 = "1.0.19"

--- a/impl/src/context.rs
+++ b/impl/src/context.rs
@@ -20,6 +20,7 @@ use std::{
 use crate::settings::CrateSettings;
 use semver::Version;
 use serde::Serialize;
+use url::Url;
 
 /// A struct containing information about a crate's dependency that's buildable in Bazel
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
@@ -82,6 +83,7 @@ pub struct GitRepo {
 #[derive(Debug, Clone, Serialize)]
 pub struct SourceDetails {
   pub git_data: Option<GitRepo>,
+  pub download_url: Option<Url>,
 }
 
 #[derive(Default, Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -167,7 +169,6 @@ pub struct CrateContext {
   pub links: Option<String>,
   pub source_details: SourceDetails,
   pub sha256: Option<String>,
-  pub registry_url: String,
 
   // TODO(acmcarther): This is used internally by renderer to know where to put the build file. It
   // probably should live somewhere else. Renderer params (separate from context) should live

--- a/impl/src/metadata.rs
+++ b/impl/src/metadata.rs
@@ -286,6 +286,15 @@ impl RazeMetadataFetcher {
       )?;
     }
 
+    let source_dotcargo = cargo_workspace_root.join(".cargo");
+    let source_dotcargo_config = source_dotcargo.join("config.toml");
+    if source_dotcargo_config.exists() {
+      let destination_dotcargo = temp_dir.path().join(".cargo");
+      fs::create_dir(&destination_dotcargo)?;
+      let destination_dotcargo_config = destination_dotcargo.join("config.toml");
+      fs::copy(&source_dotcargo_config, &destination_dotcargo_config)?;
+    }
+
     // Copy over the Cargo.toml files of each workspace member
     self.link_src_to_workspace(&no_deps_metadata, temp_dir.as_ref())?;
     Ok((temp_dir, no_deps_metadata.workspace_root.into()))

--- a/impl/src/rendering/bazel.rs
+++ b/impl/src/rendering/bazel.rs
@@ -544,9 +544,15 @@ mod tests {
       }],
       build_script_target: None,
       links: None,
-      source_details: SourceDetails { git_data: None },
+      source_details: SourceDetails {
+        git_data: None,
+        download_url: Some(
+          "https://crates.io/api/v1/crates/test-binary/1.1.1/download"
+            .parse()
+            .unwrap(),
+        ),
+      },
       sha256: None,
-      registry_url: "https://crates.io/api/v1/crates/test-binary/1.1.1/download".to_string(),
       lib_target_name: None,
     }
   }
@@ -582,9 +588,15 @@ mod tests {
       }],
       build_script_target: None,
       links: Some("ssh2".to_owned()),
-      source_details: SourceDetails { git_data: None },
+      source_details: SourceDetails {
+        git_data: None,
+        download_url: Some(
+          "https://crates.io/api/v1/crates/test-binary/1.1.1/download"
+            .parse()
+            .unwrap(),
+        ),
+      },
       sha256: None,
-      registry_url: "https://crates.io/api/v1/crates/test-binary/1.1.1/download".to_string(),
       lib_target_name: Some("test_library".to_owned()),
     }
   }
@@ -629,9 +641,15 @@ mod tests {
       }],
       build_script_target: None,
       links: Some("ssh2".to_owned()),
-      source_details: SourceDetails { git_data: None },
+      source_details: SourceDetails {
+        git_data: None,
+        download_url: Some(
+          "https://crates.io/api/v1/crates/test-proc-macro/1.1.1/download"
+            .parse()
+            .unwrap(),
+        ),
+      },
       sha256: None,
-      registry_url: "https://crates.io/api/v1/crates/test-proc-macro/1.1.1/download".to_string(),
       lib_target_name: Some("test_proc_macro".to_owned()),
     }
   }

--- a/impl/src/rendering/templates/remote_crates.bzl.template
+++ b/impl/src/rendering/templates/remote_crates.bzl.template
@@ -24,7 +24,7 @@ def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
     maybe(
         http_archive,
         name = "{{workspace.gen_workspace_prefix}}__{{crate.pkg_name | replace(from="-", to="_")}}__{{crate.pkg_version | slugify | replace(from="-", to="_")}}",
-        url = "{{ crate.registry_url }}",
+        url = "{{ crate.source_details.download_url }}",
         type = "tar.gz",
 {%- if crate.sha256 %}
         sha256 = "{{crate.sha256}}",

--- a/third_party/cargo/remote/BUILD.url-2.2.1.bazel
+++ b/third_party/cargo/remote/BUILD.url-2.2.1.bazel
@@ -37,6 +37,7 @@ rust_library(
     name = "url",
     srcs = glob(["**/*.rs"]),
     crate_features = [
+        "serde",
     ],
     crate_root = "src/lib.rs",
     data = [],
@@ -55,6 +56,7 @@ rust_library(
         "@cargo_raze__idna__0_2_2//:idna",
         "@cargo_raze__matches__0_1_8//:matches",
         "@cargo_raze__percent_encoding__2_1_0//:percent_encoding",
+        "@cargo_raze__serde__1_0_126//:serde",
     ],
 )
 


### PR DESCRIPTION
This relies on the registry information being in .cargo/config.toml (and
will proactively error if other keys are found in there).

The reason for this is that we need to run `cargo metadata` before we
even parse out config, and we can't run `cargo metadata` without having
this data active for that `cargo` invocation. It also simplifies
implementation a lot, by just copying around one file rather than
needing to generate config for `cargo` to use.

Fixes #24.