### PR TITLE
Update rules_rust and rules_foreign_cc to latest

### DIFF
--- a/examples/remote/binary_dependencies/BUILD.bazel
+++ b/examples/remote/binary_dependencies/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:rust.bzl", "rust_binary")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//remote/binary_dependencies/cargo:crates.bzl", "all_crate_deps")
 
 package(default_visibility = ["//visibility:public"])

--- a/examples/remote/build_dependencies/BUILD.bazel
+++ b/examples/remote/build_dependencies/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_rust//cargo:cargo_build_script.bzl", "cargo_build_script")
-load("@rules_rust//rust:rust.bzl", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_test")
 
 cargo_build_script(
     name = "build_script",

--- a/examples/remote/cargo_workspace/num_printer/BUILD.bazel
+++ b/examples/remote/cargo_workspace/num_printer/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:rust.bzl", "rust_binary")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//remote/cargo_workspace/cargo:crates.bzl", "all_crate_deps")
 
 package(default_visibility = ["//visibility:public"])

--- a/examples/remote/cargo_workspace/printer/BUILD.bazel
+++ b/examples/remote/cargo_workspace/printer/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:rust.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library")
 load("//remote/cargo_workspace/cargo:crates.bzl", "all_crate_deps")
 
 package(default_visibility = ["//visibility:public"])

--- a/examples/remote/cargo_workspace/rng/BUILD.bazel
+++ b/examples/remote/cargo_workspace/rng/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:rust.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library")
 load("//remote/cargo_workspace/cargo:crates.bzl", "crate_deps")
 
 package(default_visibility = ["//visibility:public"])

--- a/examples/remote/complicated_cargo_library/BUILD
+++ b/examples/remote/complicated_cargo_library/BUILD
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:rust.bzl", "rust_binary")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/examples/remote/dev_dependencies/BUILD.bazel
+++ b/examples/remote/dev_dependencies/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:rust.bzl", "rust_binary", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/examples/remote/no_deps/BUILD
+++ b/examples/remote/no_deps/BUILD
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:rust.bzl", "rust_binary")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/examples/remote/non_cratesio/BUILD
+++ b/examples/remote/non_cratesio/BUILD
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:rust.bzl", "rust_binary")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/examples/vendored/cargo_workspace/num_printer/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/num_printer/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:rust.bzl", "rust_binary")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//vendored/cargo_workspace/cargo:crates.bzl", "all_crate_deps")
 
 package(default_visibility = ["//visibility:public"])

--- a/examples/vendored/cargo_workspace/printer/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/printer/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:rust.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library")
 load("//vendored/cargo_workspace/cargo:crates.bzl", "all_crate_deps")
 
 package(default_visibility = ["//visibility:public"])

--- a/examples/vendored/cargo_workspace/rng/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/rng/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:rust.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library")
 load("//vendored/cargo_workspace/cargo:crates.bzl", "all_crate_deps")
 
 package(default_visibility = ["//visibility:public"])

--- a/examples/vendored/complicated_cargo_library/BUILD
+++ b/examples/vendored/complicated_cargo_library/BUILD
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:rust.bzl", "rust_binary")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/examples/vendored/hello_cargo_library/BUILD
+++ b/examples/vendored/hello_cargo_library/BUILD
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:rust.bzl", "rust_binary")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/examples/vendored/non_cratesio_library/BUILD
+++ b/examples/vendored/non_cratesio_library/BUILD
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:rust.bzl", "rust_binary")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/impl/BUILD.bazel
+++ b/impl/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:rust.bzl", "rust_binary", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 load("//third_party/cargo:crates.bzl", "all_crate_deps")
 
 package(default_visibility = ["//visibility:public"])

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -17,18 +17,18 @@ def cargo_raze_repositories():
     maybe(
         http_archive,
         name = "rules_rust",
-        sha256 = "cdc853460de2245b3b49a0a9b178d20d7768c94da4d78d0b2c6d7048df2d4f11",
-        strip_prefix = "rules_rust-a667ff9bdc3a800e3005e8f19b89283a6a1be5a4",
-        # Main branch as of 2021-04-02
-        url = "https://github.com/bazelbuild/rules_rust/archive/a667ff9bdc3a800e3005e8f19b89283a6a1be5a4.tar.gz",
+        sha256 = "69934a7953e5267ac18b751d6b109bc9e906d4a5d887f68cdd1940f172b64254",
+        strip_prefix = "rules_rust-e7b1e5ab9afcccc8d301c2b8922cae815d20c714",
+        # Main branch as of 2021-11-15
+        url = "https://github.com/bazelbuild/rules_rust/archive/e7b1e5ab9afcccc8d301c2b8922cae815d20c714.tar.gz",
     )
 
     maybe(
         http_archive,
         name = "rules_foreign_cc",
-        sha256 = "d54742ffbdc6924f222d2179f0e10e911c5c659c4ae74158e9fe827aad862ac6",
-        strip_prefix = "rules_foreign_cc-0.2.0",
-        url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.2.0.tar.gz",
+        sha256 = "69023642d5781c68911beda769f91fcbc8ca48711db935a75da7f6536b65047f",
+        strip_prefix = "rules_foreign_cc-0.6.0",
+        url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.6.0.tar.gz",
     )
 
     maybe(

--- a/third_party/curl/BUILD.curl.bazel
+++ b/third_party/curl/BUILD.curl.bazel
@@ -29,7 +29,7 @@ cmake(
         "@rules_rust//rust/platform:linux": _LINUX_CACHE_ENTRIES,
         "//conditions:default": _CACHE_ENTRIES,
     }),
-    cmake_options = select({
+    generate_args = select({
         "@platforms//os:windows": ["-GNinja"],
         "//conditions:default": [],
     }),

--- a/third_party/iconv/BUILD.iconv.bazel
+++ b/third_party/iconv/BUILD.iconv.bazel
@@ -9,16 +9,16 @@ filegroup(
 
 configure_make(
     name = "iconv",
-    env = select({
-        "@rules_rust//rust/platform:darwin": {"AR": ""},
-        "//conditions:default": {},
-    }),
     configure_in_place = True,
     configure_options = [
         "--enable-relocatable",
         "--enable-shared=no",
         "--enable-static=yes",
     ],
+    env = select({
+        "@rules_rust//rust/platform:darwin": {"AR": ""},
+        "//conditions:default": {},
+    }),
     lib_source = ":all",
     out_static_libs = ["libiconv.a"],
     targets = ["install-lib"],

--- a/third_party/iconv/BUILD.iconv.bazel
+++ b/third_party/iconv/BUILD.iconv.bazel
@@ -9,7 +9,7 @@ filegroup(
 
 configure_make(
     name = "iconv",
-    configure_env_vars = select({
+    env = select({
         "@rules_rust//rust/platform:darwin": {"AR": ""},
         "//conditions:default": {},
     }),

--- a/third_party/openssl/BUILD.openssl.bazel
+++ b/third_party/openssl/BUILD.openssl.bazel
@@ -20,10 +20,6 @@ CONFIGURE_OPTIONS = [
 configure_make(
     name = "openssl",
     configure_command = "config",
-    env = select({
-        "@rules_rust//rust/platform:darwin": {"AR": ""},
-        "//conditions:default": {},
-    }),
     configure_in_place = True,
     configure_options = select({
         "@rules_rust//rust/platform:darwin": [
@@ -35,6 +31,10 @@ configure_make(
         "//conditions:default": [
             "no-shared",
         ] + CONFIGURE_OPTIONS,
+    }),
+    env = select({
+        "@rules_rust//rust/platform:darwin": {"AR": ""},
+        "//conditions:default": {},
     }),
     lib_source = ":all_srcs",
     out_static_libs = [

--- a/third_party/openssl/BUILD.openssl.bazel
+++ b/third_party/openssl/BUILD.openssl.bazel
@@ -20,7 +20,7 @@ CONFIGURE_OPTIONS = [
 configure_make(
     name = "openssl",
     configure_command = "config",
-    configure_env_vars = select({
+    env = select({
         "@rules_rust//rust/platform:darwin": {"AR": ""},
         "//conditions:default": {},
     }),
@@ -38,8 +38,8 @@ configure_make(
     }),
     lib_source = ":all_srcs",
     out_static_libs = [
-        "libcrypto.a",
         "libssl.a",
+        "libcrypto.a",
     ],
     targets = [
         "build_libs",

--- a/third_party/pcre/pcre_repositories.bzl
+++ b/third_party/pcre/pcre_repositories.bzl
@@ -12,6 +12,6 @@ def pcre_repositories():
         strip_prefix = "pcre-8.44",
         urls = [
             "https://mirror.bazel.build/ftp.pcre.org/pub/pcre/pcre-8.44.tar.gz",
-            "https://ftp.pcre.org/pub/pcre/pcre-8.44.tar.gz",
+            "https://downloads.sourceforge.net/project/pcre/pcre/8.44/pcre-8.44.tar.gz",
         ],
     )


### PR DESCRIPTION
These two repos have breaking changes in latest. This means that importing this repo in a `WORKSPACE` fails if newer versions of rules_rust and/or rules_foreign_cc are already imported.