### PR TITLE
Preserve original crate name as a Bazel target tag

### DIFF
--- a/impl/src/rendering/templates/crate.BUILD.template
+++ b/impl/src/rendering/templates/crate.BUILD.template
@@ -35,6 +35,7 @@ licenses([
 {%      include "templates/partials/build_script.template" %}
 {%- endif -%}
 {%- for target in crate.targets -%}
+{%-     set target_name_original = target.name %}
 {%-     set target_name_sanitized = target.name | replace(from="-", to="_") %}
 {%-     if target.kind == "bin" %}
 

--- a/impl/src/rendering/templates/partials/common_attrs.template
+++ b/impl/src/rendering/templates/partials/common_attrs.template
@@ -53,5 +53,6 @@
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name={{ target_name_original }}"
     ],
     version = "{{ crate.pkg_version }}",


### PR DESCRIPTION
As `cargo raze` sanitizes target names (replacing `-` with `_` - could you shed some light on why that needs to be done?), it's impossible to retrieve the name of the original crate.

As a solution, we're including the original name of the crate into Bazel target's `tags`.