### PR TITLE
Added a filegroup for all Bazel sources

### DIFF
--- a/examples/remote/binary_dependencies/cargo/BUILD.bazel
+++ b/examples/remote/binary_dependencies/cargo/BUILD.bazel
@@ -77,8 +77,18 @@ alias(
 
 # Export file for Stardoc support
 exports_files(
-    [
-        "crates.bzl",
-    ],
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
     visibility = ["//visibility:public"],
 )

--- a/examples/remote/binary_dependencies/cargo/remote/BUILD.bazel
+++ b/examples/remote/binary_dependencies/cargo/remote/BUILD.bazel
@@ -1,0 +1,17 @@
+# Export file for Stardoc support
+exports_files(
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/remote/build_dependencies/cargo/BUILD.bazel
+++ b/examples/remote/build_dependencies/cargo/BUILD.bazel
@@ -23,8 +23,18 @@ alias(
 
 # Export file for Stardoc support
 exports_files(
-    [
-        "crates.bzl",
-    ],
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
     visibility = ["//visibility:public"],
 )

--- a/examples/remote/build_dependencies/cargo/remote/BUILD.bazel
+++ b/examples/remote/build_dependencies/cargo/remote/BUILD.bazel
@@ -1,0 +1,17 @@
+# Export file for Stardoc support
+exports_files(
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/remote/cargo_workspace/cargo/BUILD.bazel
+++ b/examples/remote/cargo_workspace/cargo/BUILD.bazel
@@ -7,8 +7,18 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 
 # Export file for Stardoc support
 exports_files(
-    [
-        "crates.bzl",
-    ],
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
     visibility = ["//visibility:public"],
 )

--- a/examples/remote/cargo_workspace/cargo/remote/BUILD.bazel
+++ b/examples/remote/cargo_workspace/cargo/remote/BUILD.bazel
@@ -1,0 +1,17 @@
+# Export file for Stardoc support
+exports_files(
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/remote/complicated_cargo_library/cargo/BUILD.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/BUILD.bazel
@@ -50,8 +50,18 @@ alias(
 
 # Export file for Stardoc support
 exports_files(
-    [
-        "crates.bzl",
-    ],
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
     visibility = ["//visibility:public"],
 )

--- a/examples/remote/complicated_cargo_library/cargo/remote/BUILD.bazel
+++ b/examples/remote/complicated_cargo_library/cargo/remote/BUILD.bazel
@@ -1,0 +1,17 @@
+# Export file for Stardoc support
+exports_files(
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/remote/dev_dependencies/cargo/BUILD.bazel
+++ b/examples/remote/dev_dependencies/cargo/BUILD.bazel
@@ -32,8 +32,18 @@ alias(
 
 # Export file for Stardoc support
 exports_files(
-    [
-        "crates.bzl",
-    ],
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
     visibility = ["//visibility:public"],
 )

--- a/examples/remote/dev_dependencies/cargo/remote/BUILD.bazel
+++ b/examples/remote/dev_dependencies/cargo/remote/BUILD.bazel
@@ -1,0 +1,17 @@
+# Export file for Stardoc support
+exports_files(
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/remote/no_deps/cargo/BUILD.bazel
+++ b/examples/remote/no_deps/cargo/BUILD.bazel
@@ -15,8 +15,18 @@ licenses([
 
 # Export file for Stardoc support
 exports_files(
-    [
-        "crates.bzl",
-    ],
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
     visibility = ["//visibility:public"],
 )

--- a/examples/remote/no_deps/cargo/remote/BUILD.bazel
+++ b/examples/remote/no_deps/cargo/remote/BUILD.bazel
@@ -1,0 +1,17 @@
+# Export file for Stardoc support
+exports_files(
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/remote/non_cratesio/cargo/BUILD.bazel
+++ b/examples/remote/non_cratesio/cargo/BUILD.bazel
@@ -41,8 +41,18 @@ alias(
 
 # Export file for Stardoc support
 exports_files(
-    [
-        "crates.bzl",
-    ],
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
     visibility = ["//visibility:public"],
 )

--- a/examples/remote/non_cratesio/cargo/remote/BUILD.bazel
+++ b/examples/remote/non_cratesio/cargo/remote/BUILD.bazel
@@ -1,0 +1,17 @@
+# Export file for Stardoc support
+exports_files(
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/vendored/cargo_workspace/cargo/BUILD.bazel
+++ b/examples/vendored/cargo_workspace/cargo/BUILD.bazel
@@ -7,8 +7,18 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 
 # Export file for Stardoc support
 exports_files(
-    [
-        "crates.bzl",
-    ],
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This allows users to easily include these sources in other targets like those from `rules_pkg` as well as run `buildifier` using the new test rules.