### PR TITLE
Add flags to build with a C11 compiler

### DIFF
--- a/third_party/libgit2/BUILD.libgit2.bazel
+++ b/third_party/libgit2/BUILD.libgit2.bazel
@@ -19,7 +19,7 @@ _CACHE_ENTRIES = {
 }
 
 _LINUX_CACHE_ENTRIES = dict(_CACHE_ENTRIES.items() + {
-    "CMAKE_C_FLAGS": "-fPIC",
+    "CMAKE_C_FLAGS": "-fPIC -D_GNU_SOURCE=1",
     "REGEX_BACKEND": "pcre",
 }.items())
 

--- a/third_party/openssl/BUILD.openssl.bazel
+++ b/third_party/openssl/BUILD.openssl.bazel
@@ -34,7 +34,7 @@ configure_make(
     }),
     env = select({
         "@rules_rust//rust/platform:darwin": {"AR": ""},
-        "//conditions:default": {},
+        "//conditions:default": {"CFLAGS": "-Dasm=__asm__ -D_GNU_SOURCE=1"},
     }),
     lib_source = ":all_srcs",
     out_static_libs = [

--- a/third_party/pcre/BUILD.pcre.bazel
+++ b/third_party/pcre/BUILD.pcre.bazel
@@ -10,7 +10,7 @@ filegroup(
 cmake(
     name = "pcre",
     cache_entries = {
-        "CMAKE_C_FLAGS": "-fPIC",
+        "CMAKE_C_FLAGS": "-fPIC -D_GNU_SOURCE=1",
     },
     lib_source = ":all",
     out_static_libs = ["libpcre.a"],


### PR DESCRIPTION
Add `CFLAGS` to build when `-std=c11`.

Signed-off-by: Chris Frantz <cfrantz@google.com>