### PR TITLE
Add armv7-linux-androideabi tier 2 CPU

### DIFF
--- a/impl/src/util.rs
+++ b/impl/src/util.rs
@@ -41,6 +41,7 @@ static SUPPORTED_PLATFORM_TRIPLES: &[&str] = &[
   "aarch64-linux-android",
   "aarch64-unknown-linux-gnu",
   "arm-unknown-linux-gnueabi",
+  "armv7-linux-androideabi",
   "i686-linux-android",
   "i686-unknown-freebsd",
   "powerpc-unknown-linux-gnu",


### PR DESCRIPTION
This is required for some dependencies to correctly handle select
statements like non-windows.

Related: https://github.com/bazelbuild/rules_rust/pull/1362