### PR TITLE
Allow skipping submodules

### DIFF
--- a/impl/src/rendering/templates/remote_crates.bzl.template
+++ b/impl/src/rendering/templates/remote_crates.bzl.template
@@ -17,7 +17,11 @@ def {{workspace.gen_workspace_prefix}}_fetch_remote_crates():
         remote = "{{crate.source_details.git_data.remote}}",
         commit = "{{crate.source_details.git_data.commit}}",
         build_file = Label("{{workspace.workspace_path}}/remote:BUILD.{{crate.pkg_name}}-{{crate.pkg_version}}.bazel"),
+{%- if crate.raze_settings.skip_submodules %}
+        init_submodules = False,
+{%- else %}
         init_submodules = True,
+{%- endif %}
         {%- include "templates/partials/remote_crates_patch.template" %}
     )
 {%- else %}

--- a/impl/src/settings.rs
+++ b/impl/src/settings.rs
@@ -248,6 +248,12 @@ pub struct CrateSettings {
   /// context, see https://doc.rust-lang.org/cargo/reference/workspaces.html#root-package
   #[serde(default)]
   pub additional_build_file: Option<PathBuf>,
+
+  /// Skip initializing submodules in the target repository.
+  ///
+  /// Some crates may not need their submodules initialized in order to build.
+  #[serde(default)]
+  pub skip_submodules: bool,
 }
 
 /// Describes how dependencies should be managed in tree.
@@ -285,6 +291,7 @@ impl Default for CrateSettings {
       patch_tool: None,
       patches: Vec::new(),
       additional_build_file: None,
+      skip_submodules: false,
     }
   }
 }


### PR DESCRIPTION
Some crates may not need their submodules in order to build.  Add a
`CrateSettings` parameter to allow skipping submodule initialization
on such crates.

Signed-off-by: Chris Frantz <cfrantz@google.com>