### PR TITLE
Update to rules_rust 0.6.0

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,3 @@
-load("@rules_rust//rust:defs.bzl", "rust_analyzer")
-
 alias(
     name = "cargo_raze",
     actual = "//impl:cargo_raze",
@@ -36,12 +34,4 @@ test_suite(
         "@cargo_raze_examples//tests:examples_tests",
     ],
     visibility = ["//visibility:private"],
-)
-
-rust_analyzer(
-    name = "rust_analyzer",
-    targets = [
-        "//impl:cargo_raze_bin",
-        "//impl:cargo_raze",
-    ],
 )

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ http_archive(
 
 load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 
-rust_repositories()
+rust_repositories(edition="2018")
 ```
 
 ### Generate a Cargo.toml

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -13,7 +13,7 @@ http_archive(
 
 load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 
-rust_repositories(edition="2018")
+rust_repositories(edition = "2018")
 
 load("//:repositories.bzl", "repositories")
 

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -4,17 +4,16 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_rust",
-    sha256 = "accb5a89cbe63d55dcdae85938e56ff3aa56f21eb847ed826a28a83db8500ae6",
-    strip_prefix = "rules_rust-9aa49569b2b0dacecc51c05cee52708b7255bd98",
+    sha256 = "872b04538ca20dad94791c348623f079ba93daf274c1d57ae6bfe0930ec77f0d",
     urls = [
-        # Main branch as of 2021-02-19
-        "https://github.com/bazelbuild/rules_rust/archive/9aa49569b2b0dacecc51c05cee52708b7255bd98.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_rust/releases/download/0.6.0/rules_rust-v0.6.0.tar.gz",
+        "https://github.com/bazelbuild/rules_rust/releases/download/0.6.0/rules_rust-v0.6.0.tar.gz",
     ],
 )
 
 load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 
-rust_repositories()
+rust_repositories(edition="2018")
 
 load("//:repositories.bzl", "repositories")
 

--- a/impl/BUILD.bazel
+++ b/impl/BUILD.bazel
@@ -34,9 +34,9 @@ _TEST_DATA = glob(["src/**/*.template"]) + [
 ]
 
 _TEST_ENV = {
-    "CARGO": "$(execpath //tools:cargo)",
-    "CARGO_HOME": "$(execpath //tools:cargo).home",
-    "RUSTC": "$(execpath //tools:rustc)",
+    "CARGO": "cargo_raze/$(BINDIR)/$(rootpath //tools:cargo)",
+    "CARGO_HOME": "cargo_raze/$(BINDIR)/$(rootpath //tools:cargo).home",
+    "RUSTC": "cargo_raze/$(BINDIR)/$(rootpath //tools:rustc)",
 }
 
 rust_test(

--- a/impl/BUILD.bazel
+++ b/impl/BUILD.bazel
@@ -34,9 +34,9 @@ _TEST_DATA = glob(["src/**/*.template"]) + [
 ]
 
 _TEST_ENV = {
-    "CARGO": "cargo_raze/$(BINDIR)/$(rootpath //tools:cargo)",
-    "CARGO_HOME": "cargo_raze/$(BINDIR)/$(rootpath //tools:cargo).home",
-    "RUSTC": "cargo_raze/$(BINDIR)/$(rootpath //tools:rustc)",
+    "CARGO": "$(rootpath //tools:cargo)",
+    "CARGO_HOME": "$(rootpath //tools:cargo).home",
+    "RUSTC": "$(rootpath //tools:rustc)",
 }
 
 rust_test(

--- a/impl/Cargo.lock
+++ b/impl/Cargo.lock
@@ -407,6 +407,7 @@ dependencies = [
  "cargo_toml",
  "cfg-expr",
  "crates-index",
+ "ctor",
  "docopt",
  "flate2",
  "glob",
@@ -580,9 +581,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "ctor"
-version = "0.1.20"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
 dependencies = [
  "quote",
  "syn",
@@ -2234,9 +2235,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.68"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce15dd3ed8aa2f8eeac4716d6ef5ab58b6b9256db41d7e1a0224c2788e8fd87"
+checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -49,6 +49,7 @@ toml = "0.5.8"
 url = { version = "2.2.0", features = ["serde"] }
 
 [dev-dependencies]
+ctor = "0.1.22"
 flate2 = "1.0.19"
 hamcrest2 = "0.3.0"
 httpmock = "0.5.4"

--- a/impl/src/metadata.rs
+++ b/impl/src/metadata.rs
@@ -61,8 +61,6 @@ impl MetadataFetcher for CargoMetadataFetcher {
       command.no_deps();
     }
 
-    eprintln!("cargo bin path: {:?}", &self.cargo_bin_path);
-
     command
       .cargo_path(&self.cargo_bin_path)
       .current_dir(working_dir)

--- a/impl/src/metadata.rs
+++ b/impl/src/metadata.rs
@@ -61,6 +61,8 @@ impl MetadataFetcher for CargoMetadataFetcher {
       command.no_deps();
     }
 
+    eprintln!("cargo bin path: {:?}", &self.cargo_bin_path);
+
     command
       .cargo_path(&self.cargo_bin_path)
       .current_dir(working_dir)

--- a/impl/src/testing.rs
+++ b/impl/src/testing.rs
@@ -21,8 +21,6 @@ use tempfile::TempDir;
 
 use std::{
   collections::HashMap,
-  env,
-  env::{current_dir, set_var},
   fs::{create_dir_all, write, File},
   io::Write,
   path::Path,
@@ -40,11 +38,11 @@ use crate::{
 #[cfg(test)]
 #[ctor::ctor]
 fn init() {
-  let current_dir = current_dir().unwrap();
+  let current_dir = std::env::current_dir().unwrap();
   let env_vars_to_fix = ["CARGO", "CARGO_HOME", "RUSTC"];
   for var_name in env_vars_to_fix {
-    if let Ok(var_value) = env::var(var_name) {
-      set_var(var_name, current_dir.join(var_value));
+    if let Ok(var_value) = std::env::var(var_name) {
+      std::env::set_var(var_name, current_dir.join(var_value));
     }
   }
 }

--- a/impl/src/testing.rs
+++ b/impl/src/testing.rs
@@ -43,9 +43,8 @@ fn init() {
   let current_dir = current_dir().unwrap();
   let env_vars_to_fix = ["CARGO", "CARGO_HOME", "RUSTC"];
   for var_name in env_vars_to_fix {
-    match env::var(var_name) {
-      Ok(var_value) => set_var(var_name, current_dir.join(var_value)),
-      _ => {}
+    if let Ok(var_value) = env::var(var_name) {
+      set_var(var_name, current_dir.join(var_value));
     }
   }
 }

--- a/impl/src/testing.rs
+++ b/impl/src/testing.rs
@@ -43,7 +43,10 @@ fn init() {
   let current_dir = current_dir().unwrap();
   let env_vars_to_fix = ["CARGO", "CARGO_HOME", "RUSTC"];
   for var_name in env_vars_to_fix {
-    set_var(var_name, current_dir.join(env::var(var_name).unwrap()));
+    match env::var(var_name) {
+      Ok(var_value) => set_var(var_name, current_dir.join(var_value)),
+      _ => {}
+    }
   }
 }
 

--- a/impl/src/testing.rs
+++ b/impl/src/testing.rs
@@ -21,6 +21,8 @@ use tempfile::TempDir;
 
 use std::{
   collections::HashMap,
+  env,
+  env::{current_dir, set_var},
   fs::{create_dir_all, write, File},
   io::Write,
   path::Path,
@@ -38,13 +40,11 @@ use crate::{
 #[cfg(test)]
 #[ctor::ctor]
 fn init() {
-  let current_dir = std::env::current_dir().unwrap();
-  std::env::set_var("CARGO", current_dir.join(std::env::var("CARGO").unwrap()));
-  std::env::set_var(
-    "CARGO_HOME",
-    current_dir.join(std::env::var("CARGO_HOME").unwrap()),
-  );
-  std::env::set_var("RUSTC", current_dir.join(std::env::var("RUSTC").unwrap()));
+  let current_dir = current_dir().unwrap();
+  let env_vars_to_fix = ["CARGO", "CARGO_HOME", "RUSTC"];
+  for var_name in env_vars_to_fix {
+    set_var(var_name, current_dir.join(env::var(var_name).unwrap()));
+  }
 }
 
 /// A module containing constants for each metadata template

--- a/impl/src/testing.rs
+++ b/impl/src/testing.rs
@@ -34,6 +34,19 @@ use crate::{
   util::package_ident,
 };
 
+// Make these env variables absolute for testing.
+#[cfg(test)]
+#[ctor::ctor]
+fn init() {
+  let current_dir = std::env::current_dir().unwrap();
+  std::env::set_var("CARGO", current_dir.join(std::env::var("CARGO").unwrap()));
+  std::env::set_var(
+    "CARGO_HOME",
+    current_dir.join(std::env::var("CARGO_HOME").unwrap()),
+  );
+  std::env::set_var("RUSTC", current_dir.join(std::env::var("RUSTC").unwrap()));
+}
+
 /// A module containing constants for each metadata template
 pub mod templates {
   pub const BASIC_METADATA: &str = "basic_metadata.json.template";

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -17,10 +17,11 @@ def cargo_raze_repositories():
     maybe(
         http_archive,
         name = "rules_rust",
-        sha256 = "69934a7953e5267ac18b751d6b109bc9e906d4a5d887f68cdd1940f172b64254",
-        strip_prefix = "rules_rust-e7b1e5ab9afcccc8d301c2b8922cae815d20c714",
-        # Main branch as of 2021-11-15
-        url = "https://github.com/bazelbuild/rules_rust/archive/e7b1e5ab9afcccc8d301c2b8922cae815d20c714.tar.gz",
+        sha256 = "872b04538ca20dad94791c348623f079ba93daf274c1d57ae6bfe0930ec77f0d",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_rust/releases/download/0.6.0/rules_rust-v0.6.0.tar.gz",
+            "https://github.com/bazelbuild/rules_rust/releases/download/0.6.0/rules_rust-v0.6.0.tar.gz",
+        ],
     )
 
     maybe(

--- a/third_party/cargo/crates.bzl
+++ b/third_party/cargo/crates.bzl
@@ -60,6 +60,7 @@ _DEV_DEPENDENCIES = {
 # EXPERIMENTAL -- MAY CHANGE AT ANY TIME: A mapping of package names to a set of proc_macro dev dependencies for the Rust targets of that package.
 _DEV_PROC_MACRO_DEPENDENCIES = {
     "impl": {
+        "ctor": "@cargo_raze__ctor__0_1_22//:ctor",
         "indoc": "@cargo_raze__indoc__1_0_3//:indoc",
     },
 }
@@ -751,12 +752,12 @@ def cargo_raze_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "cargo_raze__ctor__0_1_20",
-        url = "https://crates.io/api/v1/crates/ctor/0.1.20/download",
+        name = "cargo_raze__ctor__0_1_22",
+        url = "https://crates.io/api/v1/crates/ctor/0.1.22/download",
         type = "tar.gz",
-        sha256 = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d",
-        strip_prefix = "ctor-0.1.20",
-        build_file = Label("//third_party/cargo/remote:BUILD.ctor-0.1.20.bazel"),
+        sha256 = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c",
+        strip_prefix = "ctor-0.1.22",
+        build_file = Label("//third_party/cargo/remote:BUILD.ctor-0.1.22.bazel"),
     )
 
     maybe(
@@ -2431,12 +2432,12 @@ def cargo_raze_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "cargo_raze__syn__1_0_68",
-        url = "https://crates.io/api/v1/crates/syn/1.0.68/download",
+        name = "cargo_raze__syn__1_0_80",
+        url = "https://crates.io/api/v1/crates/syn/1.0.80/download",
         type = "tar.gz",
-        sha256 = "3ce15dd3ed8aa2f8eeac4716d6ef5ab58b6b9256db41d7e1a0224c2788e8fd87",
-        strip_prefix = "syn-1.0.68",
-        build_file = Label("//third_party/cargo/remote:BUILD.syn-1.0.68.bazel"),
+        sha256 = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194",
+        strip_prefix = "syn-1.0.80",
+        build_file = Label("//third_party/cargo/remote:BUILD.syn-1.0.80.bazel"),
     )
 
     maybe(

--- a/third_party/cargo/remote/BUILD.async-trait-0.1.48.bazel
+++ b/third_party/cargo/remote/BUILD.async-trait-0.1.48.bazel
@@ -82,7 +82,7 @@ rust_proc_macro(
         ":async_trait_build_script",
         "@cargo_raze__proc_macro2__1_0_26//:proc_macro2",
         "@cargo_raze__quote__1_0_9//:quote",
-        "@cargo_raze__syn__1_0_68//:syn",
+        "@cargo_raze__syn__1_0_80//:syn",
     ],
 )
 

--- a/third_party/cargo/remote/BUILD.ctor-0.1.22.bazel
+++ b/third_party/cargo/remote/BUILD.ctor-0.1.22.bazel
@@ -49,10 +49,10 @@ rust_proc_macro(
         "crate-name=ctor",
         "manual",
     ],
-    version = "0.1.20",
+    version = "0.1.22",
     # buildifier: leave-alone
     deps = [
         "@cargo_raze__quote__1_0_9//:quote",
-        "@cargo_raze__syn__1_0_68//:syn",
+        "@cargo_raze__syn__1_0_80//:syn",
     ],
 )

--- a/third_party/cargo/remote/BUILD.futures-macro-0.3.13.bazel
+++ b/third_party/cargo/remote/BUILD.futures-macro-0.3.13.bazel
@@ -55,6 +55,6 @@ rust_proc_macro(
     deps = [
         "@cargo_raze__proc_macro2__1_0_26//:proc_macro2",
         "@cargo_raze__quote__1_0_9//:quote",
-        "@cargo_raze__syn__1_0_68//:syn",
+        "@cargo_raze__syn__1_0_80//:syn",
     ],
 )

--- a/third_party/cargo/remote/BUILD.openssl-macros-0.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.openssl-macros-0.1.0.bazel
@@ -52,6 +52,6 @@ rust_proc_macro(
     deps = [
         "@cargo_raze__proc_macro2__1_0_26//:proc_macro2",
         "@cargo_raze__quote__1_0_9//:quote",
-        "@cargo_raze__syn__1_0_68//:syn",
+        "@cargo_raze__syn__1_0_80//:syn",
     ],
 )

--- a/third_party/cargo/remote/BUILD.pest_generator-2.1.3.bazel
+++ b/third_party/cargo/remote/BUILD.pest_generator-2.1.3.bazel
@@ -54,6 +54,6 @@ rust_library(
         "@cargo_raze__pest_meta__2_1_3//:pest_meta",
         "@cargo_raze__proc_macro2__1_0_26//:proc_macro2",
         "@cargo_raze__quote__1_0_9//:quote",
-        "@cargo_raze__syn__1_0_68//:syn",
+        "@cargo_raze__syn__1_0_80//:syn",
     ],
 )

--- a/third_party/cargo/remote/BUILD.pin-project-internal-1.0.6.bazel
+++ b/third_party/cargo/remote/BUILD.pin-project-internal-1.0.6.bazel
@@ -52,6 +52,6 @@ rust_proc_macro(
     deps = [
         "@cargo_raze__proc_macro2__1_0_26//:proc_macro2",
         "@cargo_raze__quote__1_0_9//:quote",
-        "@cargo_raze__syn__1_0_68//:syn",
+        "@cargo_raze__syn__1_0_80//:syn",
     ],
 )

--- a/third_party/cargo/remote/BUILD.serde_derive-1.0.126.bazel
+++ b/third_party/cargo/remote/BUILD.serde_derive-1.0.126.bazel
@@ -84,6 +84,6 @@ rust_proc_macro(
         ":serde_derive_build_script",
         "@cargo_raze__proc_macro2__1_0_26//:proc_macro2",
         "@cargo_raze__quote__1_0_9//:quote",
-        "@cargo_raze__syn__1_0_68//:syn",
+        "@cargo_raze__syn__1_0_80//:syn",
     ],
 )

--- a/third_party/cargo/remote/BUILD.syn-1.0.80.bazel
+++ b/third_party/cargo/remote/BUILD.syn-1.0.80.bazel
@@ -65,7 +65,7 @@ cargo_build_script(
         "cargo-raze",
         "manual",
     ],
-    version = "1.0.68",
+    version = "1.0.80",
     visibility = ["//visibility:private"],
     deps = [
     ],
@@ -102,7 +102,7 @@ rust_library(
         "crate-name=syn",
         "manual",
     ],
-    version = "1.0.68",
+    version = "1.0.80",
     # buildifier: leave-alone
     deps = [
         ":syn_build_script",

--- a/third_party/cargo/remote/BUILD.tokio-macros-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.tokio-macros-1.1.0.bazel
@@ -52,6 +52,6 @@ rust_proc_macro(
     deps = [
         "@cargo_raze__proc_macro2__1_0_26//:proc_macro2",
         "@cargo_raze__quote__1_0_9//:quote",
-        "@cargo_raze__syn__1_0_68//:syn",
+        "@cargo_raze__syn__1_0_80//:syn",
     ],
 )

--- a/third_party/cargo/remote/BUILD.tracing-attributes-0.1.15.bazel
+++ b/third_party/cargo/remote/BUILD.tracing-attributes-0.1.15.bazel
@@ -52,7 +52,7 @@ rust_proc_macro(
     deps = [
         "@cargo_raze__proc_macro2__1_0_26//:proc_macro2",
         "@cargo_raze__quote__1_0_9//:quote",
-        "@cargo_raze__syn__1_0_68//:syn",
+        "@cargo_raze__syn__1_0_80//:syn",
     ],
 )
 

--- a/third_party/cargo/remote/BUILD.value-bag-1.0.0-alpha.6.bazel
+++ b/third_party/cargo/remote/BUILD.value-bag-1.0.0-alpha.6.bazel
@@ -69,7 +69,7 @@ rust_library(
     data = [],
     edition = "2018",
     proc_macro_deps = [
-        "@cargo_raze__ctor__0_1_20//:ctor",
+        "@cargo_raze__ctor__0_1_22//:ctor",
     ],
     rustc_flags = [
         "--cap-lints=allow",

--- a/third_party/cargo/remote/BUILD.wasm-bindgen-backend-0.2.73.bazel
+++ b/third_party/cargo/remote/BUILD.wasm-bindgen-backend-0.2.73.bazel
@@ -56,7 +56,7 @@ rust_library(
         "@cargo_raze__log__0_4_14//:log",
         "@cargo_raze__proc_macro2__1_0_26//:proc_macro2",
         "@cargo_raze__quote__1_0_9//:quote",
-        "@cargo_raze__syn__1_0_68//:syn",
+        "@cargo_raze__syn__1_0_80//:syn",
         "@cargo_raze__wasm_bindgen_shared__0_2_73//:wasm_bindgen_shared",
     ],
 )

--- a/third_party/cargo/remote/BUILD.wasm-bindgen-macro-support-0.2.73.bazel
+++ b/third_party/cargo/remote/BUILD.wasm-bindgen-macro-support-0.2.73.bazel
@@ -53,7 +53,7 @@ rust_library(
     deps = [
         "@cargo_raze__proc_macro2__1_0_26//:proc_macro2",
         "@cargo_raze__quote__1_0_9//:quote",
-        "@cargo_raze__syn__1_0_68//:syn",
+        "@cargo_raze__syn__1_0_80//:syn",
         "@cargo_raze__wasm_bindgen_backend__0_2_73//:wasm_bindgen_backend",
         "@cargo_raze__wasm_bindgen_shared__0_2_73//:wasm_bindgen_shared",
     ],

--- a/transitive_deps.bzl
+++ b/transitive_deps.bzl
@@ -6,4 +6,4 @@ load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 def cargo_raze_transitive_deps():
     """Loads all dependnecies from repositories required for cargo-raze"""
     rules_foreign_cc_dependencies()
-    rust_repositories(include_rustc_srcs = True)
+    rust_repositories(edition="2018", include_rustc_srcs = True)

--- a/transitive_deps.bzl
+++ b/transitive_deps.bzl
@@ -6,4 +6,4 @@ load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 def cargo_raze_transitive_deps():
     """Loads all dependnecies from repositories required for cargo-raze"""
     rules_foreign_cc_dependencies()
-    rust_repositories(edition="2018", include_rustc_srcs = True)
+    rust_repositories(edition = "2018", include_rustc_srcs = True)


### PR DESCRIPTION
This fixes the path problems in #485.

The `rust_analyzer` rule is no longer needed, but rust_analyzer still works as we have it here. See https://github.com/bazelbuild/rules_rust/pull/1405.