### PR TITLE
Specify CMAKE_INSTALL_LIBDIR for libssh2

### DIFF
--- a/third_party/libssh2/BUILD.libssh2.bazel
+++ b/third_party/libssh2/BUILD.libssh2.bazel
@@ -10,6 +10,7 @@ _CACHE_ENTRIES = {
     "BUILD_SHARED_LIBS": "off",
     "BUILD_TESTING": "off",
     "CMAKE_FIND_DEBUG_MODE": "on",
+    "CMAKE_INSTALL_LIBDIR": "lib",
     "CMAKE_PREFIX_PATH": "$EXT_BUILD_DEPS/openssl",
 }
 


### PR DESCRIPTION
RHEL/Fedora uses lib64 as default GNU install dir for libraries, which makes this build fail.