### PR TITLE
Set CMAKE_INSTALL_LIBDIR=lib for libgit2 and libssh2

### DIFF
--- a/third_party/libgit2/BUILD.libgit2.bazel
+++ b/third_party/libgit2/BUILD.libgit2.bazel
@@ -13,6 +13,7 @@ _CACHE_ENTRIES = {
     "BUILD_EXAMPLES": "off",
     "BUILD_FUZZERS": "off",
     "BUILD_SHARED_LIBS": "off",
+    "CMAKE_INSTALL_LIBDIR": "lib",
     "CMAKE_PREFIX_PATH": "$EXT_BUILD_DEPS/pcre;$EXT_BUILD_DEPS/openssl;$EXT_BUILD_DEPS/libssh2;$EXT_BUILD_DEPS/zlib",
     "EMBED_SSH_PATH": "$(execpath @cargo_raze__libssh2//:libssh2)",
     "USE_HTTPS": "on",

--- a/third_party/libssh2/BUILD.libssh2.bazel
+++ b/third_party/libssh2/BUILD.libssh2.bazel
@@ -10,6 +10,7 @@ _CACHE_ENTRIES = {
     "BUILD_SHARED_LIBS": "off",
     "BUILD_TESTING": "off",
     "CMAKE_FIND_DEBUG_MODE": "on",
+    "CMAKE_INSTALL_LIBDIR": "lib",
     "CMAKE_PREFIX_PATH": "$EXT_BUILD_DEPS/openssl",
 }
 


### PR DESCRIPTION
RHEL/Fedora uses lib64 as default GNU install dir for libraries, which means `cmake` generates a call for `libssh2.a` to installed in a `lib64` subfolder, which Bazel then doesn't find.

Setting `CMAKE_INSTALL_LIBDIR` to `lib` solves the issue and doesn't (AFAIK) have any side effects for this build.

Here's an excerpt for a failing build _without_ this patch:

```
ERROR: /home/gabriel/.cache/bazel/54e66689fc0b4c88d7bbceed87be1577/external/cargo_raze__libssh2/BUILD.bazel:20:6: output 'external/cargo_raze__libssh2/libssh2/lib/libssh2.a' was not created
ERROR: /home/gabriel/.cache/bazel/54e66689fc0b4c88d7bbceed87be1577/external/cargo_raze__libssh2/BUILD.bazel:20:6: Foreign Cc - CMake: Building libssh2 failed: not all outputs were created or valid
```