### PR TITLE
Print the error message when cargo tree fails

### DIFF
--- a/impl/src/features.rs
+++ b/impl/src/features.rs
@@ -22,6 +22,7 @@ use crate::util::cargo_bin_path;
 use anyhow::{Error, Result};
 use camino::Utf8PathBuf;
 use cargo_metadata::{Package, PackageId, Version};
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 type UnconsolidatedFeatures = BTreeMap<PackageId, BTreeMap<String, BTreeSet<String>>>;
@@ -135,7 +136,7 @@ fn clean_cargo_tree_output(cargo_tree_output: &str) -> Vec<String> {
 // to extract per-platform targets.
 fn run_cargo_tree(cargo_dir: &Path, triple: &str) -> Result<String> {
   let cargo_bin: Utf8PathBuf = cargo_bin_path();
-  let mut cargo_tree = Command::new(cargo_bin);
+  let mut cargo_tree = Command::new(&cargo_bin);
   cargo_tree.current_dir(cargo_dir);
   cargo_tree
     .arg("tree")
@@ -147,7 +148,19 @@ fn run_cargo_tree(cargo_dir: &Path, triple: &str) -> Result<String> {
   let tree_output = cargo_tree
     .output()
     .map_err(|_err| Error::new(RazeError::Generic("Failed to run cargo-tree.".into())))?;
-  assert!(tree_output.status.success());
+  if !tree_output.status.success() {
+    eprintln!(
+      "Running `{:?} {}` in {:?} failed, output follows:",
+      cargo_bin,
+      cargo_tree
+        .get_args()
+        .map(|os_str| os_str.to_str().unwrap_or("<unprintable>"))
+        .join(" "),
+      cargo_dir
+    );
+    eprintln!("{:?}", std::str::from_utf8(&tree_output.stderr));
+    panic!("cargo-tree ran and returned failure, see stderr for details");
+  }
 
   String::from_utf8(tree_output.stdout).map_err(|_err| {
     Error::new(RazeError::Generic(

--- a/impl/src/features.rs
+++ b/impl/src/features.rs
@@ -138,12 +138,14 @@ fn run_cargo_tree(cargo_dir: &Path, triple: &str) -> Result<String> {
   let cargo_bin: Utf8PathBuf = cargo_bin_path();
   let mut cargo_tree = Command::new(&cargo_bin);
   cargo_tree.current_dir(cargo_dir);
-  cargo_tree
-    .arg("tree")
-    .arg("--prefix=none")
-    .arg("--frozen")
-    .arg(format!("--target={}", triple))
-    .arg("--format={p}|{f}|"); // The format to print output with
+  let args = [
+    "tree".to_string(),
+    "--prefix=none".to_string(),
+    "--frozen".to_string(),
+    format!("--target={}", triple),
+    "--format={p}|{f}|".to_string(), // The format to print output with
+  ];
+  cargo_tree.args(args.iter());
 
   let tree_output = cargo_tree
     .output()
@@ -152,10 +154,7 @@ fn run_cargo_tree(cargo_dir: &Path, triple: &str) -> Result<String> {
     eprintln!(
       "Running `{:?} {}` in {:?} failed, output follows:",
       cargo_bin,
-      cargo_tree
-        .get_args()
-        .map(|os_str| os_str.to_str().unwrap_or("<unprintable>"))
-        .join(" "),
+      args.iter().join(" "),
       cargo_dir
     );
     eprintln!("{:?}", std::str::from_utf8(&tree_output.stderr));


### PR DESCRIPTION
I made a simple typo (spelled a platform wrong), and figure out what was wrong was next to impossible without this output. With this change, it's obvious what the problem is.