### PR TITLE
Document the commands to regenerate checked-in outputs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,8 @@
+# Regenerating BUILD files
+
+raze-generated BUILD files are present in several places which must be manually
+regenerated to test changes. Commands to update these:
+```console
+$ bazel run //tools:examples_check
+$ bazel run //:raze -- --manifest-path $(readlink -f impl/Cargo.toml)
+```


### PR DESCRIPTION
Looking through the commit history, it looks like forgetting to re-generated some of the outputs that get checked has happened multiple times. Doing this often makes bugs in new changes obvious when things fail to build.

Ideally CI would verify this (there's a TODO for it in presubmit.yml), but as a starting point let's at least document it.