### PR TITLE
Bump rules_rust and rules_foreign_cc

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -17,19 +17,19 @@ def cargo_raze_repositories():
     maybe(
         http_archive,
         name = "rules_rust",
-        sha256 = "872b04538ca20dad94791c348623f079ba93daf274c1d57ae6bfe0930ec77f0d",
+        sha256 = "696b01deea96a5e549f1b5ae18589e1bbd5a1d71a36a243b5cf76a9433487cf2",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_rust/releases/download/0.6.0/rules_rust-v0.6.0.tar.gz",
-            "https://github.com/bazelbuild/rules_rust/releases/download/0.6.0/rules_rust-v0.6.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_rust/releases/download/0.11.0/rules_rust-v0.11.0.tar.gz",
+            "https://github.com/bazelbuild/rules_rust/releases/download/0.11.0/rules_rust-v0.11.0.tar.gz",
         ],
     )
 
     maybe(
         http_archive,
         name = "rules_foreign_cc",
-        sha256 = "69023642d5781c68911beda769f91fcbc8ca48711db935a75da7f6536b65047f",
-        strip_prefix = "rules_foreign_cc-0.6.0",
-        url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.6.0.tar.gz",
+        sha256 = "2a4d07cd64b0719b39a7c12218a3e507672b82a97b98c6a89d38565894cf7c51",
+        strip_prefix = "rules_foreign_cc-0.9.0",
+        url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.9.0.tar.gz",
     )
 
     maybe(
@@ -39,6 +39,16 @@ def cargo_raze_repositories():
         sha256 = "1bef6433ba1a4288b5853dc0ebd6cf436dc1c83cce6e16abf73e7ad1b785def4",
         strip_prefix = "rules_cc-c612c9581b9e740a49ed4c006edb93912c8ab205",
         type = "zip",
+    )
+
+    maybe(
+        http_archive,
+        name = "bazel_skylib",
+        urls = [
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz",
+        ],
+        sha256 = "af87959afe497dc8dfd4c6cb66e1279cb98ccc84284619ebfec27d9c09a903de",
     )
 
     curl_repositories()

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -44,22 +44,22 @@ sh_binary(
 alias(
     name = "cargo",
     actual = select({
-        "@rules_rust//rust/platform:aarch64-apple-darwin": "@rust_darwin_aarch64//:cargo",
-        "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": "@rust_linux_aarch64//:cargo",
-        "@rules_rust//rust/platform:x86_64-apple-darwin": "@rust_darwin_x86_64//:cargo",
-        "@rules_rust//rust/platform:x86_64-pc-windows-msvc": "@rust_windows_x86_64//:cargo",
-        "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": "@rust_linux_x86_64//:cargo",
+        "@rules_rust//rust/platform:aarch64-apple-darwin": "@rust_darwin_aarch64_tools//:cargo",
+        "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": "@rust_linux_aarch64_tools//:cargo",
+        "@rules_rust//rust/platform:x86_64-apple-darwin": "@rust_darwin_x86_64_tools//:cargo",
+        "@rules_rust//rust/platform:x86_64-pc-windows-msvc": "@rust_windows_x86_64_tools//:cargo",
+        "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": "@rust_linux_x86_64_tools//:cargo",
     }),
 )
 
 alias(
     name = "rustc",
     actual = select({
-        "@rules_rust//rust/platform:aarch64-apple-darwin": "@rust_darwin_aarch64//:rustc",
-        "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": "@rust_linux_aarch64//:rustc",
-        "@rules_rust//rust/platform:x86_64-apple-darwin": "@rust_darwin_x86_64//:rustc",
-        "@rules_rust//rust/platform:x86_64-pc-windows-msvc": "@rust_windows_x86_64//:rustc",
-        "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": "@rust_linux_x86_64//:rustc",
+        "@rules_rust//rust/platform:aarch64-apple-darwin": "@rust_darwin_aarch64_tools//:rustc",
+        "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": "@rust_linux_aarch64_tools//:rustc",
+        "@rules_rust//rust/platform:x86_64-apple-darwin": "@rust_darwin_x86_64_tools//:rustc",
+        "@rules_rust//rust/platform:x86_64-pc-windows-msvc": "@rust_windows_x86_64_tools//:rustc",
+        "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": "@rust_linux_x86_64_tools//:rustc",
     }),
 )
 

--- a/transitive_deps.bzl
+++ b/transitive_deps.bzl
@@ -1,9 +1,24 @@
 """A module defining the transitive dependencies of cargo-raze"""
 
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
-load("@rules_rust//rust:repositories.bzl", "rust_repositories")
+load("@rules_rust//rust:defs.bzl", "rust_common")
+load("@rules_rust//rust:repositories.bzl", "DEFAULT_TOOLCHAIN_TRIPLES", "rust_repositories", "rust_toolchain_tools_repository")
 
 def cargo_raze_transitive_deps():
     """Loads all dependnecies from repositories required for cargo-raze"""
+
+    bazel_skylib_workspace()
+
     rules_foreign_cc_dependencies()
-    rust_repositories(edition = "2018", include_rustc_srcs = True)
+    rust_repositories(edition = "2021", include_rustc_srcs = True)
+    for exec_triple, name in DEFAULT_TOOLCHAIN_TRIPLES.items():
+        maybe(
+            rust_toolchain_tools_repository,
+            name + "_tools",
+            edition = "2021",
+            exec_triple = exec_triple,
+            target_triple = exec_triple,
+            version = rust_common.default_version,
+        )


### PR DESCRIPTION
Bump rules_rust to version 0.11.0 and rules_foreign_cc to 0.9.0

**This MR breaks compatibility with rules_rust < 0.7.0**

Closes #522

Signed-off-by: Alan Diego dos Santos <alandiegosantos@gmail.com>