### PR TITLE
Fix upcoming macOS toolchain incompatibility

### DIFF
--- a/third_party/iconv/BUILD.iconv.bazel
+++ b/third_party/iconv/BUILD.iconv.bazel
@@ -19,6 +19,7 @@ configure_make(
         "@rules_rust//rust/platform:darwin": {"AR": ""},
         "//conditions:default": {},
     }),
+    features = ["-libtool"],
     lib_source = ":all",
     out_static_libs = ["libiconv.a"],
     targets = ["install-lib"],


### PR DESCRIPTION
Once https://github.com/bazelbuild/bazel/pull/16619 lands this target would fail to build because of ar vs libtool incompatibilities. This replaces the logic around setting AR to an empty string but I left that piece to continue supporting older versions of bazel as well.