### PR TITLE
fix(panic): Fix panics caused by non-existent template paths

### DIFF
--- a/impl/src/rendering/bazel.rs
+++ b/impl/src/rendering/bazel.rs
@@ -74,8 +74,7 @@ fn bazel_package_name(render_details: &RenderDetails) -> String {
 
 impl BazelRenderer {
   pub fn new() -> Self {
-    // Configure tera with a bogus template dir: We don't want any runtime template support
-    let mut internal_renderer = Tera::new("/tmp/cargo-raze/doesnt/exist/*").unwrap();
+    let mut internal_renderer = Tera::default();
     internal_renderer
       .add_raw_templates(vec![
         (


### PR DESCRIPTION
As mentioned in Keats/tera#819, there was a regression in how non-existent glob paths are handled. Previously, invalid globs would be expanded to the empty set, but now they lead to an error.

Since this implementation just wants a bogus template directory, we just load the `Tera::default()` template.

This should address #545